### PR TITLE
fix: SWA page_size>1 page alignment and allocation rollback

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1034,14 +1034,22 @@ class ScheduleBatch:
         sliding_window_size = getattr(self.model_config, "sliding_window", None)
         if sliding_window_size is None or sliding_window_size <= 0:
             return
-        page_size = getattr(self.token_to_kv_pool_allocator, "_page_size",
-                           getattr(self.token_to_kv_pool_allocator, "page_size", 1))
+        page_size = getattr(
+            self.token_to_kv_pool_allocator,
+            "_page_size",
+            getattr(self.token_to_kv_pool_allocator, "page_size", 1),
+        )
         for req in self.reqs:
             pre_len = len(req.origin_input_ids) + len(req.output_ids) - 1
             self._evict_swa(req, pre_len, sliding_window_size, page_size)
 
     def _evict_swa(self, req, pre_len: int, sliding_window_size: int, page_size: int):
         """Free SWA pool slots for tokens outside the sliding window."""
+        if page_size > 1:
+            assert req.swa_evicted_seqlen % page_size == 0, (
+                f"swa_evicted_seqlen must be page-aligned, got {req.swa_evicted_seqlen} "
+                f"with page_size={page_size}"
+            )
         new_evicted = max(req.swa_evicted_seqlen, pre_len - sliding_window_size)
         # Page-align down
         if page_size > 1:

--- a/python/sgl_jax/srt/mem_cache/allocator.py
+++ b/python/sgl_jax/srt/mem_cache/allocator.py
@@ -428,6 +428,9 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         alloc_full_indices = self.full_attn_allocator.alloc(need_size)
         alloc_swa_indices = self.swa_attn_allocator.alloc(need_size)
+        if alloc_swa_indices is None:
+            self.full_attn_allocator.free(alloc_full_indices)
+            return None
         self.full_to_swa_index_mapping[alloc_full_indices] = alloc_swa_indices
         return alloc_full_indices
 
@@ -454,6 +457,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             prefix_lens, seq_lens, swa_last_loc, extend_num_tokens
         )
         if swa_indices is None:
+            self.full_attn_allocator.free(full_indices)
             return None
 
         # Update mapping for newly allocated indices
@@ -477,6 +481,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         # Allocate from SWA pool with translated last_loc
         swa_indices = self.swa_attn_allocator.alloc_decode(seq_lens, swa_last_loc)
         if swa_indices is None:
+            self.full_attn_allocator.free(full_indices)
             return None
 
         # Update mapping for newly allocated indices
@@ -495,8 +500,16 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert self.swa_attn_allocator.available_size() <= self.swa_attn_allocator.size
 
     def free_swa(self, free_index: np.array):
+        if len(free_index) == 0:
+            return
         map_vals = self.full_to_swa_index_mapping[free_index]
         swa_indices = map_vals[map_vals > 0]
+        if self.page_size > 1 and len(swa_indices) > 0:
+            assert len(swa_indices) % self.page_size == 0, (
+                f"free_swa: number of mapped SWA indices ({len(swa_indices)}) "
+                f"must be a multiple of page_size={self.page_size}. "
+                f"Callers must pass page-aligned ranges to avoid partial page release."
+            )
         self.swa_attn_allocator.free(swa_indices)
         self.full_to_swa_index_mapping[free_index] = 0
 

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -826,6 +826,12 @@ class SWARadixCache(BasePrefixCache):
             # the prefill prefix matching will stuck.
             if update_kv_after_len < total_prefix_length + prefix_len:
                 first_diff_idx = max(0, update_kv_after_len - total_prefix_length)
+                if self.page_size > 1:
+                    # Round up to page boundary so that free() only receives
+                    # page-aligned indices for PagedTokenToKVPoolAllocator.
+                    first_diff_idx = (
+                        (first_diff_idx + self.page_size - 1) // self.page_size
+                    ) * self.page_size
                 if node.swa_tombstone:
                     assert (
                         node.swa_lock_ref == 0

--- a/python/sgl_jax/test/mem_cache/test_swa_paged.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_paged.py
@@ -1,0 +1,273 @@
+# cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_swa_paged.py -v
+
+import os
+
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import unittest
+
+import jax
+import numpy as np
+from jax.sharding import Mesh
+
+from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
+from sgl_jax.srt.mem_cache.memory_pool import (
+    MHATokenToKVPool,
+    ReqToTokenPool,
+    SWAKVPool,
+)
+from sgl_jax.srt.mem_cache.swa_radix_cache import SWARadixCache
+
+
+class TestSWAPaged(unittest.TestCase):
+    """Tests for SWA + page_size > 1 correctness.
+
+    These tests verify page alignment invariants required when using
+    PagedTokenToKVPoolAllocator with the SWA dual-pool architecture.
+    """
+
+    PAGE_SIZE = 4
+    FULL_SIZE = 512  # 128 pages
+    SWA_SIZE = 256  # 64 pages
+    SLIDING_WINDOW = 16
+
+    def setUp(self):
+        self.devices = jax.devices()
+        self.mesh = Mesh([self.devices[0]], axis_names=("tensor",))
+
+        self.kv_pool = SWAKVPool(
+            size=self.FULL_SIZE,
+            size_swa=self.SWA_SIZE,
+            page_size=self.PAGE_SIZE,
+            swa_attention_layer_ids=[0],
+            full_attention_layer_ids=[1],
+            full_pool_class=MHATokenToKVPool,
+            swa_pool_class=MHATokenToKVPool,
+            dtype=jax.numpy.bfloat16,
+            head_num=1,
+            head_dim=1,
+            mesh=self.mesh,
+        )
+
+        self.allocator = SWATokenToKVPoolAllocator(
+            size=self.FULL_SIZE,
+            size_swa=self.SWA_SIZE,
+            kvcache=self.kv_pool,
+            page_size=self.PAGE_SIZE,
+        )
+
+        self.req_pool = ReqToTokenPool(size=64, max_context_len=512)
+
+        self.cache = SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=self.SLIDING_WINDOW,
+            page_size=self.PAGE_SIZE,
+            disable=False,
+        )
+
+    def _alloc_paged(self, n: int) -> np.ndarray:
+        """Allocate n tokens (must be page-aligned) from the SWA allocator."""
+        assert n % self.PAGE_SIZE == 0, f"n={n} must be page-aligned"
+        idx = self.allocator.alloc(n)
+        self.assertIsNotNone(idx, f"Failed to allocate {n} tokens")
+        self.assertEqual(len(idx), n)
+        return idx
+
+    # ------------------------------------------------------------------
+    # Bug 1: alloc_extend does not rollback full allocation on SWA failure
+    # ------------------------------------------------------------------
+    def test_alloc_extend_rollback_on_swa_failure(self):
+        """When SWA pool is exhausted but full pool has space, alloc_extend
+        should return None AND rollback the full allocation so no pages leak."""
+
+        # Exhaust the SWA pool by allocating almost everything
+        # SWA pool has 256 tokens = 64 pages. Allocate 252 tokens = 63 pages.
+        # Leave only 1 page (4 tokens) free in SWA.
+        exhaust_size = (self.SWA_SIZE // self.PAGE_SIZE - 1) * self.PAGE_SIZE
+        _exhaust = self.allocator.alloc(exhaust_size)
+        self.assertIsNotNone(_exhaust)
+
+        full_before = self.allocator.full_available_size()
+
+        # Try to allocate more tokens than SWA has available.
+        # We need 2 pages (8 tokens) but SWA only has 1 page (4 tokens).
+        result = self.allocator.alloc_extend(
+            prefix_lens=[0],
+            seq_lens=[8],
+            last_loc=[-1],
+            extend_num_tokens=8,
+        )
+
+        # alloc_extend should fail
+        self.assertIsNone(result)
+
+        # Full pool should NOT have leaked pages
+        full_after = self.allocator.full_available_size()
+        self.assertEqual(
+            full_before, full_after, f"Full pool leaked: before={full_before}, after={full_after}"
+        )
+
+    # ------------------------------------------------------------------
+    # Bug 1b: alloc_decode does not rollback full allocation on SWA failure
+    # ------------------------------------------------------------------
+    def test_alloc_decode_rollback_on_swa_failure(self):
+        """When SWA pool is exhausted, alloc_decode should rollback full allocation."""
+
+        # First, allocate a sequence so we have valid last_loc
+        initial = self.allocator.alloc_extend(
+            prefix_lens=[0],
+            seq_lens=[4],
+            last_loc=[-1],
+            extend_num_tokens=4,
+        )
+        self.assertIsNotNone(initial)
+
+        # Exhaust the SWA pool
+        remaining_swa = self.allocator.swa_available_size()
+        remaining_pages = remaining_swa // self.PAGE_SIZE
+        exhaust_needed = remaining_pages * self.PAGE_SIZE
+        if exhaust_needed > 0:
+            _exhaust = self.allocator.alloc(exhaust_needed)
+            self.assertIsNotNone(_exhaust)
+
+        full_before = self.allocator.full_available_size()
+        swa_before = self.allocator.swa_available_size()
+        self.assertEqual(swa_before, 0, "SWA pool should be exhausted")
+
+        # Try alloc_decode -- the sequence needs a decode token at position 5
+        # which crosses a page boundary, requiring a new SWA page
+        result = self.allocator.alloc_decode(
+            seq_lens=[5],
+            last_loc=[int(initial[-1])],
+        )
+
+        # Should fail since SWA has no pages
+        self.assertIsNone(result)
+
+        # Full pool should not leak
+        full_after = self.allocator.full_available_size()
+        self.assertEqual(
+            full_before, full_after, f"Full pool leaked: before={full_before}, after={full_after}"
+        )
+
+    # ------------------------------------------------------------------
+    # Bug 2: free_swa with non-page-aligned indices releases entire pages
+    # ------------------------------------------------------------------
+    def test_free_swa_non_page_aligned_releases_whole_page(self):
+        """Calling free_swa with fewer than page_size indices should be
+        rejected because PagedTokenToKVPoolAllocator.free() releases
+        entire pages, which would corrupt still-in-use tokens."""
+
+        # Allocate 2 pages (8 tokens)
+        indices = self._alloc_paged(8)
+
+        # Free only the first 2 indices (not a complete page) -- should raise
+        partial_free = indices[:2]
+        with self.assertRaises(
+            AssertionError, msg="free_swa should reject non-page-aligned indices"
+        ):
+            self.allocator.free_swa(partial_free)
+
+    def test_free_swa_page_aligned_works(self):
+        """free_swa with a complete page of indices should succeed."""
+
+        # Allocate 2 pages (8 tokens)
+        indices = self._alloc_paged(8)
+        swa_before = self.allocator.swa_available_size()
+
+        # Free the first complete page (4 indices)
+        full_page_free = indices[: self.PAGE_SIZE]
+        self.allocator.free_swa(full_page_free)
+
+        swa_after = self.allocator.swa_available_size()
+        freed = swa_after - swa_before
+        self.assertEqual(freed, self.PAGE_SIZE)
+
+    # ------------------------------------------------------------------
+    # Bug 3: _insert_helper tombstone restore with non-page-aligned boundary
+    # ------------------------------------------------------------------
+    def test_insert_tombstone_restore_page_aligned(self):
+        """When tombstone nodes are restored during re-insertion, the free
+        boundary (first_diff_idx) must be page-aligned to avoid freeing
+        partial pages in PagedTokenToKVPoolAllocator."""
+
+        # Insert two sequences sharing a prefix to create internal nodes.
+        # key_a: [100..115] (4 pages), key_b: [100..107, 200..207] (shared 2 pages + 2 different)
+        # This creates: root -> [100..107] (internal) -> [108..115] (leaf A), [200..207] (leaf B)
+        key_a = list(range(100, 116))
+        key_b = list(range(100, 108)) + list(range(200, 208))
+
+        val_a = self._alloc_paged(16)
+        self.cache.insert(key_a, value=val_a, prev_prefix_len=0)
+
+        val_b = self._alloc_paged(16)
+        self.cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        total_before, swa_before = self.cache.total_size()
+        # 8 (shared) + 8 (A suffix) + 8 (B suffix) = 24
+        self.assertEqual(total_before, 24)
+
+        # SWA-evict: tombstone the shared internal node [100..107] (8 tokens = 2 pages)
+        # SWA eviction picks LRU non-leaf nodes first for tombstoning
+        self.cache.evict(full_num_tokens=0, swa_num_tokens=8)
+
+        total_after_evict, swa_after_evict = self.cache.total_size()
+        # Full tokens should still be 24 (tombstone only frees SWA)
+        self.assertEqual(total_after_evict, 24)
+        self.assertLess(swa_after_evict, swa_before)
+
+        # Now re-insert key_a with prev_prefix_len=6 (not page-aligned).
+        # This creates first_diff_idx = max(0, 6 - 0) = 6 in _insert_helper,
+        # which is NOT page-aligned. The tombstone restore path will call
+        # free(node.value[6:]) passing non-page-aligned indices to PagedAllocator.
+        val_c = self._alloc_paged(16)
+        self.cache.insert(key_a, value=val_c, prev_prefix_len=6)
+
+        # The cache should be in a consistent state
+        total_final, swa_final = self.cache.total_size()
+        self.assertGreater(total_final, 0)
+
+        # Verify the key can still be matched
+        match = self.cache.match_prefix(key_a)
+        self.assertEqual(len(match.device_indices), 16)
+
+    # ------------------------------------------------------------------
+    # Sanity: page-aligned operations should work correctly end-to-end
+    # ------------------------------------------------------------------
+    def test_paged_swa_insert_match_evict_cycle(self):
+        """End-to-end test: insert, match, SWA evict, re-match with page alignment."""
+
+        # Insert 2 sequences sharing a prefix
+        key_a = list(range(0, 16))  # 4 pages
+        key_b = list(range(0, 8)) + list(range(200, 208))  # shares first 2 pages
+
+        val_a = self._alloc_paged(16)
+        self.cache.insert(key_a, value=val_a, prev_prefix_len=0)
+
+        val_b = self._alloc_paged(16)
+        self.cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        # Both should match fully
+        match_a = self.cache.match_prefix(key_a)
+        self.assertEqual(len(match_a.device_indices), 16)
+        match_b = self.cache.match_prefix(key_b)
+        self.assertEqual(len(match_b.device_indices), 16)
+
+        # Shared prefix (first 8 tokens) should use the same indices
+        np.testing.assert_array_equal(
+            np.asarray(match_a.device_indices[:8]),
+            np.asarray(match_b.device_indices[:8]),
+        )
+
+        # Evict SWA tokens -- this tombstones internal nodes
+        self.cache.evict(full_num_tokens=0, swa_num_tokens=8)
+
+        # Sanity check should pass
+        self.cache.sanity_check()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add rollback in `alloc`/`alloc_extend`/`alloc_decode` when SWA allocation fails, preventing full-pool page leaks
- Add page-alignment assertion in `free_swa` to reject partial-page frees that would corrupt `PagedTokenToKVPoolAllocator` state
- Add `swa_evicted_seqlen` page-alignment assertion in `_evict_swa`
- Round up `first_diff_idx` to page boundary in `_insert_helper` tombstone restore path
- Add 6 unit tests in `test_swa_paged.py` verifying all fixes

## Test plan

- [x] `test_alloc_extend_rollback_on_swa_failure` — verifies full pool pages are freed when SWA alloc_extend fails
- [x] `test_alloc_decode_rollback_on_swa_failure` — verifies full pool pages are freed when SWA alloc_decode fails
- [x] `test_free_swa_non_page_aligned_releases_whole_page` — verifies assertion rejects non-page-aligned free_swa
- [x] `test_free_swa_page_aligned_works` — verifies page-aligned free_swa succeeds
- [x] `test_insert_tombstone_restore_page_aligned` — verifies tombstone restore with non-page-aligned prev_prefix_len
- [x] `test_paged_swa_insert_match_evict_cycle` — end-to-end insert/match/evict with page_size=4

```bash
cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_swa_paged.py -v
```

Relates to #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)