### PR TITLE
fix: pass SWA-specific kv head count to SWAKVPool

### DIFF
--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -9,12 +9,12 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_pytree_node_class
 
+from sgl_jax.srt.kernels.ragged_paged_attention.util import get_dtype_packing
 from sgl_jax.srt.kernels.update_kv_cache.update_kv_cache import (
     get_num_slices_per_block,
     get_slot_mapping,
     kv_cache_update,
 )
-from sgl_jax.srt.kernels.ragged_paged_attention.util import get_dtype_packing
 
 
 def merge_kv(k: jax.Array, v: jax.Array) -> jax.Array:
@@ -735,11 +735,11 @@ class SplitMHATokenToKVPool(MHATokenToKVPool):
             cache_v = jnp.pad(cache_v, ((0, 0), (0, 0), (0, self.v_head_dim - cache_v.shape[-1])))
         N = self.k_buffer[layer_idx].shape[0]
         safe_loc = jnp.where(loc >= 0, loc, jnp.int32(N))
-        updated_k = self.k_buffer[layer_idx].at[safe_loc].set(
-            self._align_kv_heads(cache_k), mode="drop"
+        updated_k = (
+            self.k_buffer[layer_idx].at[safe_loc].set(self._align_kv_heads(cache_k), mode="drop")
         )
-        updated_v = self.v_buffer[layer_idx].at[safe_loc].set(
-            self._align_kv_heads(cache_v), mode="drop"
+        updated_v = (
+            self.v_buffer[layer_idx].at[safe_loc].set(self._align_kv_heads(cache_v), mode="drop")
         )
         return updated_k, updated_v
 
@@ -759,6 +759,7 @@ class SWAKVPool(KVCache):
         swa_pool_class: KVCache = MHATokenToKVPool,
         swa_head_dim: int | None = None,
         swa_v_head_dim: int | None = None,
+        swa_head_num: int | None = None,
         **kwargs,
     ):
         self.size = size
@@ -778,6 +779,8 @@ class SWAKVPool(KVCache):
             kwargs_swa["head_dim"] = swa_head_dim
         if swa_v_head_dim is not None:
             kwargs_swa["v_head_dim"] = swa_v_head_dim
+        if swa_head_num is not None:
+            kwargs_swa["head_num"] = swa_head_num
 
         self.swa_kv_pool = swa_pool_class(
             size=size_swa,

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -382,7 +382,6 @@ class ModelRunner(BaseModelRunner):
         # KV pool, so profiling must use the same values to estimate correctly.
         head_dim = self.model_config.head_dim
         v_head_dim = getattr(self.model_config, "v_head_dim", head_dim)
-        dtype_bytes = jnp.dtype(self.kv_cache_dtype).itemsize
         num_layers = self.model_config.num_hidden_layers
 
         fa_cell_per_layer = self._compute_kv_cell_per_layer(head_dim, v_head_dim)
@@ -410,7 +409,10 @@ class ModelRunner(BaseModelRunner):
                     "TPU Memory profiling (hybrid): available=%.1fGB, "
                     "full_pool=%d tokens (%d FA layers), swa_pool=%d tokens (%d SWA layers)",
                     available_kv_cache_bytes / (1024**3),
-                    full_max_tokens, fa_layers, swa_max_tokens, swa_layers,
+                    full_max_tokens,
+                    fa_layers,
+                    swa_max_tokens,
+                    swa_layers,
                 )
             else:
                 cell_size = fa_cell_per_layer * num_layers
@@ -598,6 +600,15 @@ class ModelRunner(BaseModelRunner):
             pool_class = SplitMHATokenToKVPool if full_hd != full_vhd else MHATokenToKVPool
             head_num = self.model_config.get_total_num_kv_heads_with_replication(self.tp_size)
 
+            # SWA layers may have a different number of KV heads (e.g. MiMo-V2-Flash).
+            hf_cfg = self.model_config.hf_text_config
+            swa_kv_heads_raw = getattr(hf_cfg, "swa_num_key_value_heads", None)
+            if swa_kv_heads_raw is not None and swa_kv_heads_raw != head_num:
+                # Apply the same TP-aware replication logic used for the FA heads.
+                swa_head_num = self.tp_size if self.tp_size > swa_kv_heads_raw else swa_kv_heads_raw
+            else:
+                swa_head_num = None  # same as FA, no override needed
+
             fa_layers, swa_layers = self._get_hybrid_layer_counts()
             swa_layer_ids = getattr(self.model_config, "swa_attention_layer_ids", None)
             full_layer_ids = getattr(self.model_config, "full_attention_layer_ids", None)
@@ -617,7 +628,11 @@ class ModelRunner(BaseModelRunner):
                     full_layer_ids = list(range(n))
 
             full_max = getattr(self, "full_max_total_num_tokens", self.max_total_num_tokens)
-            swa_max = getattr(self, "swa_max_total_num_tokens", int(self.max_total_num_tokens * self.server_args.swa_full_tokens_ratio))
+            swa_max = getattr(
+                self,
+                "swa_max_total_num_tokens",
+                int(self.max_total_num_tokens * self.server_args.swa_full_tokens_ratio),
+            )
 
             self.token_to_kv_pool = SWAKVPool(
                 size=full_max,
@@ -632,6 +647,7 @@ class ModelRunner(BaseModelRunner):
                 head_dim=aligned_head_dim,
                 mesh=self.mesh,
                 v_head_dim=aligned_v_head_dim,
+                swa_head_num=swa_head_num,
             )
             # Keep is_hybrid = True so scheduler uses dual-pool path
         else:
@@ -657,7 +673,11 @@ class ModelRunner(BaseModelRunner):
         if self.token_to_kv_pool_allocator is None:
             if self.is_hybrid:
                 full_max = getattr(self, "full_max_total_num_tokens", self.max_total_num_tokens)
-                swa_max = getattr(self, "swa_max_total_num_tokens", int(self.max_total_num_tokens * self.server_args.swa_full_tokens_ratio))
+                swa_max = getattr(
+                    self,
+                    "swa_max_total_num_tokens",
+                    int(self.max_total_num_tokens * self.server_args.swa_full_tokens_ratio),
+                )
                 self.token_to_kv_pool_allocator = SWATokenToKVPoolAllocator(
                     full_max,
                     swa_max,
@@ -681,8 +701,16 @@ class ModelRunner(BaseModelRunner):
         # Use object.__setattr__ to bypass Flax NNX's Pytree __setattr__ check,
         # which rejects assigning data (numpy array) to a static attribute.
         # This attribute is only used on host in get_forward_metadata(), never in JIT.
-        if self.is_hybrid and hasattr(self, "attn_backend") and hasattr(self.token_to_kv_pool_allocator, "full_to_swa_index_mapping"):
-            object.__setattr__(self.attn_backend, "swa_index_mapping", self.token_to_kv_pool_allocator.full_to_swa_index_mapping)
+        if (
+            self.is_hybrid
+            and hasattr(self, "attn_backend")
+            and hasattr(self.token_to_kv_pool_allocator, "full_to_swa_index_mapping")
+        ):
+            object.__setattr__(
+                self.attn_backend,
+                "swa_index_mapping",
+                self.token_to_kv_pool_allocator.full_to_swa_index_mapping,
+            )
 
     def init_attention_backend(self):
         """Init attention kernel backend."""
@@ -893,11 +921,19 @@ class ModelRunner(BaseModelRunner):
         L_swa = len(swa_attention_layer_ids)
 
         full_max = getattr(self, "full_max_total_num_tokens", self.max_total_num_tokens)
-        swa_max = getattr(self, "swa_max_total_num_tokens", int(self.max_total_num_tokens * self.server_args.swa_full_tokens_ratio))
+        swa_max = getattr(
+            self,
+            "swa_max_total_num_tokens",
+            int(self.max_total_num_tokens * self.server_args.swa_full_tokens_ratio),
+        )
         logger.info(
             "Hybrid model: dual pool with %d FA layers + %d SWA layers "
             "(window=%d), full_pool=%d tokens, swa_pool=%d tokens",
-            L_fa, L_swa, self.sliding_window_size, full_max, swa_max,
+            L_fa,
+            L_swa,
+            self.sliding_window_size,
+            full_max,
+            swa_max,
         )
 
     def init_lora_manager(self):

--- a/python/sgl_jax/test/mem_cache/test_swa_head_num.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_head_num.py
@@ -1,0 +1,90 @@
+"""Tests for SWAKVPool swa_head_num parameter support."""
+
+import unittest
+
+import jax.numpy as jnp
+
+from sgl_jax.srt.mem_cache.memory_pool import MHATokenToKVPool, SWAKVPool
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+mesh = create_device_mesh(ici_parallelism=[1, -1], dcn_parallelism=[1, 1])
+
+
+class TestSWAKVPoolHeadNum(unittest.TestCase):
+    """Verify that SWAKVPool correctly applies swa_head_num to the SWA sub-pool."""
+
+    def test_swa_head_num_override(self):
+        """SWA sub-pool should use swa_head_num when provided."""
+        fa_head_num = 4
+        swa_head_num = 8
+
+        pool = SWAKVPool(
+            size=32,
+            size_swa=16,
+            page_size=1,
+            swa_attention_layer_ids=[1, 3],
+            full_attention_layer_ids=[0, 2],
+            full_pool_class=MHATokenToKVPool,
+            swa_pool_class=MHATokenToKVPool,
+            dtype=jnp.bfloat16,
+            head_num=fa_head_num,
+            head_dim=128,
+            mesh=mesh,
+            swa_head_num=swa_head_num,
+        )
+
+        self.assertEqual(pool.full_kv_pool.head_num, fa_head_num)
+        self.assertEqual(pool.swa_kv_pool.head_num, swa_head_num)
+
+    def test_swa_head_num_default(self):
+        """Without swa_head_num, SWA sub-pool should inherit head_num from FA."""
+        head_num = 4
+
+        pool = SWAKVPool(
+            size=32,
+            size_swa=16,
+            page_size=1,
+            swa_attention_layer_ids=[1, 3],
+            full_attention_layer_ids=[0, 2],
+            full_pool_class=MHATokenToKVPool,
+            swa_pool_class=MHATokenToKVPool,
+            dtype=jnp.bfloat16,
+            head_num=head_num,
+            head_dim=128,
+            mesh=mesh,
+        )
+
+        self.assertEqual(pool.full_kv_pool.head_num, head_num)
+        self.assertEqual(pool.swa_kv_pool.head_num, head_num)
+
+    def test_swa_head_num_buffer_shape(self):
+        """Verify the actual buffer shapes reflect the different head counts."""
+        fa_head_num = 4
+        swa_head_num = 8
+        head_dim = 128
+
+        pool = SWAKVPool(
+            size=32,
+            size_swa=16,
+            page_size=1,
+            swa_attention_layer_ids=[1],
+            full_attention_layer_ids=[0],
+            full_pool_class=MHATokenToKVPool,
+            swa_pool_class=MHATokenToKVPool,
+            dtype=jnp.bfloat16,
+            head_num=fa_head_num,
+            head_dim=head_dim,
+            mesh=mesh,
+            swa_head_num=swa_head_num,
+        )
+
+        # MHATokenToKVPool uses fused KV: shape = [size+page, head_num*2, head_dim]
+        fa_buf = pool.full_kv_pool.kv_buffer[0]
+        swa_buf = pool.swa_kv_pool.kv_buffer[0]
+
+        self.assertEqual(fa_buf.shape[1], fa_head_num * 2)
+        self.assertEqual(swa_buf.shape[1], swa_head_num * 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `swa_head_num` parameter to `SWAKVPool.__init__` so the SWA sub-pool can use a different number of KV heads than the FA sub-pool
- In `init_memory_pool()`, read `swa_num_key_value_heads` from the HF config and pass it to `SWAKVPool`, fixing incorrect buffer shapes for models like MiMo-V2-Flash where FA layers have 4 KV heads but SWA layers have 8
- Remove unused `dtype_bytes` variable flagged by ruff

Relates to #192

## Test plan
- [x] Added `test_swa_head_num.py` with 3 tests verifying head_num override, default fallback, and buffer shapes
- [x] All existing mem_cache tests still pass (pre-existing Pallas/CPU failures in `test_kv_cache.py` are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)