### PR TITLE
fix: remove conservative //2 divisor in page_indices SMEM budget

### DIFF
--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -548,7 +548,7 @@ class FlashAttention(AttentionBackend):
     @staticmethod
     def get_max_running_reqests(max_context_len: int, page_size: int) -> int:
         num_page_per_req = cdiv(max_context_len, page_size)
-        res = 1024 * 1024 // 2 // num_page_per_req // 4
+        res = 1024 * 1024 // num_page_per_req // 4
         assert (
             res > 0
         ), f"max running requests: {res} must larger than 0, please increase page size or decrease max context length"


### PR DESCRIPTION
## Summary

- Remove the conservative `// 2` divisor in `get_max_running_reqests` that reserved 512KB of SMEM for other scalar prefetch data which only uses ~1KB
- Doubles the max batch size (e.g., 64 → 128 for MiMo-V2-Flash with context_len=262144, page_size=128)

Closes #208

## Analysis

The `page_indices` scalar prefetch dominates SMEM usage. Other scalar prefetch arrays (`kv_lens`, `cu_q_lens`, `distribution`, etc.) total <1KB at any batch size, so the 512KB reservation is unnecessary.

| Config | Before (//2) | After |
|--------|-------------|-------|
| ctx=262144, ps=128 | BS=64 | **BS=128** |
| ctx=262144, ps=256 | BS=128 | **BS=256** |
| ctx=131072, ps=128 | BS=128 | **BS=256** |

## Test plan

- [ ] Verify kernel runs correctly at the higher batch sizes on TPU
- [ ] Confirm no SMEM overflow errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)