### PR TITLE
fix: attention_sink TP sharding and MHA+bf16 q_packing alignment

### DIFF
--- a/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
+++ b/python/sgl_jax/srt/kernels/ragged_paged_attention/ragged_paged_attention_v3.py
@@ -889,23 +889,25 @@ def _ragged_paged_attention_kernel_loop(
 
         @pl.loop(0, num_bq, unroll=False)
         def compute_with_bq(bq_idx):
-            # Re-initialize l, m, acc to 0 before bkv loop.
-            l_ref[...] = jnp.full_like(l_ref, 0.0)
-            m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
             acc_ref[...] = jnp.full_like(acc_ref, 0.0)
 
-            # Attention sink: override m and l initialization.
+            # Initialize l, m before bkv loop.
             if attention_sink_ref is not None:
+                # Attention sink: m = sink logits, l = 1.0
+                # (pretend we've already seen a virtual token with logit = sink_value).
+                m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
+                l_ref[...] = jnp.full_like(l_ref, 1.0)
                 for kv_head_idx in range(actual_num_kv_heads):
                     sinks = attention_sink_ref[kv_head_idx]  # [num_q_heads_per_kv_head, 128]
                     lm_start = 0
                     lm_size = actual_bq_sz * num_q_heads_per_kv_head
-                    m_ref.at[kv_head_idx, pl.ds(lm_start, lm_size)][...] = jnp.concat(
-                        [sinks] * actual_bq_sz, axis=0
-                    ).astype(out_dtype)
-                    l_ref.at[kv_head_idx, pl.ds(lm_start, lm_size)][...] = jnp.full(
-                        (lm_size, 128), 1.0, dtype=out_dtype
+                    sink_tiled = jnp.tile(sinks, (actual_bq_sz, 1))
+                    m_ref.at[kv_head_idx, pl.ds(lm_start, lm_size)][...] = sink_tiled.astype(
+                        out_dtype
                     )
+            else:
+                l_ref[...] = jnp.full_like(l_ref, 0.0)
+                m_ref[...] = jnp.full_like(m_ref, -jnp.inf)
 
             bq_sem_idx = sem_ids_ref[0]
             next_seq_idx, next_bq_idx, next_bq_sem_idx = get_next_bq_ids(
@@ -1157,6 +1159,7 @@ def prepare_inputs(
     q: jax.Array,  # [max_num_tokens, actual_num_q_heads, actual_head_dim]
     k: jax.Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim]
     v: jax.Array,  # [max_num_tokens, actual_num_kv_heads, actual_head_dim]
+    attention_sink: jax.Array | float | None = None,  # f32[actual_num_q_heads]
 ):
     max_num_tokens, actual_num_q_heads, actual_head_dim = q.shape
     actual_num_kv_heads = k.shape[1]
@@ -1191,7 +1194,21 @@ def prepare_inputs(
         .swapaxes(0, 1)
     )
     kv = merge_kv(k, v)
-    return q, kv
+
+    if attention_sink is not None:
+        sink = jnp.asarray(attention_sink, dtype=jnp.float32)
+        if sink.ndim == 0:
+            sink = jnp.full((actual_num_q_heads,), sink, dtype=jnp.float32)
+        sink = sink[: actual_num_kv_heads * actual_num_q_heads_per_kv_head]
+        sink = sink.reshape(actual_num_kv_heads, actual_num_q_heads_per_kv_head)
+        if num_q_heads_per_kv_head > actual_num_q_heads_per_kv_head:
+            sink = jnp.pad(
+                sink, ((0, 0), (0, num_q_heads_per_kv_head - actual_num_q_heads_per_kv_head))
+            )
+        attention_sink = sink.reshape(actual_num_kv_heads, num_q_heads_per_kv_head, 1)
+        attention_sink = jnp.repeat(attention_sink, 128, axis=-1)
+
+    return q, kv, attention_sink
 
 
 def prepare_outputs(
@@ -1713,19 +1730,8 @@ def ragged_paged_attention(
     actual_num_kv_heads = k.shape[1]
     actual_num_q_heads_per_kv_head = actual_num_q_heads // actual_num_kv_heads
 
-    q, kv = prepare_inputs(q, k, v)
+    q, kv, attention_sink = prepare_inputs(q, k, v, attention_sink)
     kv_cache_fused_processed = prepare_kv_cache_fused(kv_cache_fused)
-
-    # Prepare attention_sink for VMEM.
-    if attention_sink is not None:
-        sink = jnp.asarray(attention_sink, dtype=jnp.float32)
-        if sink.ndim == 0:
-            sink = jnp.full((actual_num_q_heads,), sink, dtype=jnp.float32)
-        padded_heads = actual_num_kv_heads * actual_num_q_heads_per_kv_head
-        if sink.shape[0] < padded_heads:
-            sink = jnp.pad(sink, (0, padded_heads - sink.shape[0]))
-        attention_sink = sink.reshape(actual_num_kv_heads, actual_num_q_heads_per_kv_head, 1)
-        attention_sink = jnp.repeat(attention_sink, 128, axis=-1)
 
     (
         _,

--- a/python/sgl_jax/srt/layers/attention/flashattention_backend.py
+++ b/python/sgl_jax/srt/layers/attention/flashattention_backend.py
@@ -538,7 +538,9 @@ class FlashAttention(AttentionBackend):
             P(self.attention_data_partition_axis),  # cu_kv_lens
             P(self.attention_data_partition_axis),  # distribution
             P(),  # custom_mask
-            P(),  # attention sink
+            (
+                P(self.kv_partition_axis) if attention_sink is not None else P()
+            ),  # attention sink: (num_q_heads,), sharded by heads
         )
 
         out_specs = (

--- a/python/sgl_jax/test/test_flashattention.py
+++ b/python/sgl_jax/test/test_flashattention.py
@@ -927,6 +927,144 @@ class TestAttention(CustomTestCase):
             attention_sink=attention_sink,
         )
 
+    def test_mha_attention_sink_decode_accuracy(self):
+        """Test attention sink accuracy in decode mode with MHA (num_heads == num_kv_heads)"""
+        num_heads = 32
+        num_kv_heads = 32
+        head_dim = 128
+
+        lens = [
+            (1, 256),
+            (1, 512),
+            (1, 1024),
+        ]
+
+        rng = np.random.RandomState(789)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "decode",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            max_total_token_size=200000,
+            attention_sink=attention_sink,
+        )
+
+    def test_mha_attention_sink_prefill_accuracy(self):
+        """Test attention sink accuracy in prefill mode with MHA (num_heads == num_kv_heads)"""
+        num_heads = 32
+        num_kv_heads = 32
+        head_dim = 128
+
+        lens = [
+            (1, 128),
+            (64, 64),
+            (128, 256),
+        ]
+
+        rng = np.random.RandomState(101)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            max_total_token_size=200000,
+            attention_sink=attention_sink,
+        )
+
+    def test_gqa_4q1kv_attention_sink_decode_accuracy(self):
+        """Test attention sink with GQA (4 q_heads, 1 kv_head) in decode mode"""
+        num_heads = 4
+        num_kv_heads = 1
+        head_dim = 128
+
+        lens = [
+            (1, 256),
+            (1, 512),
+            (1, 1024),
+        ]
+
+        rng = np.random.RandomState(202)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "decode",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            max_total_token_size=200000,
+            attention_sink=attention_sink,
+        )
+
+    def test_gqa_4q1kv_attention_sink_prefill_accuracy(self):
+        """Test attention sink with GQA (4 q_heads, 1 kv_head) in prefill mode"""
+        num_heads = 4
+        num_kv_heads = 1
+        head_dim = 128
+
+        lens = [
+            (1, 128),
+            (64, 64),
+            (128, 256),
+        ]
+
+        rng = np.random.RandomState(303)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            max_total_token_size=200000,
+            attention_sink=attention_sink,
+        )
+
+    def test_single_head_attention_sink_decode_accuracy(self):
+        """Test attention sink with single head MHA (1 q_head, 1 kv_head) in decode mode"""
+        num_heads = 1
+        num_kv_heads = 1
+        head_dim = 128
+
+        lens = [
+            (1, 256),
+            (1, 512),
+            (1, 1024),
+        ]
+
+        rng = np.random.RandomState(404)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "decode",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            max_total_token_size=200000,
+            attention_sink=attention_sink,
+        )
+
+    def test_single_head_attention_sink_prefill_accuracy(self):
+        """Test attention sink with single head MHA (1 q_head, 1 kv_head) in prefill mode"""
+        num_heads = 1
+        num_kv_heads = 1
+        head_dim = 128
+
+        lens = [
+            (1, 128),
+            (64, 64),
+            (128, 256),
+        ]
+
+        rng = np.random.RandomState(505)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "prefill",
+            lens,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            max_total_token_size=200000,
+            attention_sink=attention_sink,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/sgl_jax/test/test_flashattention_dp.py
+++ b/python/sgl_jax/test/test_flashattention_dp.py
@@ -6,7 +6,7 @@ import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention import (
+from sgl_jax.srt.kernels.ragged_paged_attention.ragged_paged_attention_v3 import (
     ref_ragged_paged_attention,
 )
 from sgl_jax.srt.layers.attention.flashattention_backend import FlashAttention
@@ -332,6 +332,7 @@ class TestAttention(CustomTestCase):
         sliding_window=None,
         logit_cap=None,
         xai_temperature_len=None,
+        attention_sink=None,
     ):
         num_heads, head_dim, num_kv_heads, page_size, dtype = mode_args
         causal = True
@@ -380,6 +381,7 @@ class TestAttention(CustomTestCase):
             sliding_window=sliding_window,
             logit_cap=logit_cap,
             xai_temperature_len=xai_temperature_len,
+            attention_sink=attention_sink,
         )
 
         sharding = NamedSharding(mesh, P("data", "tensor"))
@@ -403,7 +405,7 @@ class TestAttention(CustomTestCase):
 
         @jax.jit
         def jit_attn(q, k, v, forward_batch, token_to_kv_pool):
-            out = attn(q, k, v, forward_batch, token_to_kv_pool)
+            out = attn(q, k, v, forward_batch, token_to_kv_pool, attention_sink=attention_sink)
             return out
 
         # run
@@ -638,6 +640,90 @@ class TestAttention(CustomTestCase):
             xai_temperature_len=temp_len,
         )
 
+    def test_attention_sink_decode_dp_4(self):
+        """
+        Feature Test: Attention Sink with MHA and DP in decode mode.
+        Validates q_packing alignment fix for MHA (num_q_heads_per_kv_head=1).
+        """
+        mesh = set_mesh(tp_size=1, dp_size=4)
+        num_heads = 8
+        num_kv_heads = 8
+        head_dim = 128
+
+        lens_dict = {
+            0: [(1, 128)],
+            1: [(1, 256)],
+            2: [(1, 512)],
+            3: [(1, 1024)],
+        }
+
+        rng = np.random.RandomState(123)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "decode",
+            lens_dict,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            mesh,
+            4,
+            attention_sink=attention_sink,
+        )
+
+    def test_attention_sink_prefill_dp_4(self):
+        """
+        Feature Test: Attention Sink with MHA and DP in prefill mode.
+        """
+        mesh = set_mesh(tp_size=1, dp_size=4)
+        num_heads = 8
+        num_kv_heads = 8
+        head_dim = 128
+
+        lens_dict = {
+            0: [(64, 64)],
+            1: [(128, 128)],
+            2: [(32, 64)],
+            3: [(256, 256)],
+        }
+
+        rng = np.random.RandomState(456)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "prefill",
+            lens_dict,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            mesh,
+            4,
+            attention_sink=attention_sink,
+        )
+
+    def test_attention_sink_gqa_dp_2_tp_2(self):
+        """
+        Feature Test: Attention Sink with GQA and DP+TP.
+        Validates attention_sink TP sharding (P("tensor")).
+        """
+        mesh = set_mesh(tp_size=2, dp_size=2)
+        num_heads = 32
+        num_kv_heads = 8
+        head_dim = 128
+
+        lens_dict = {
+            0: [(1, 256), (1, 512)],
+            1: [(1, 128), (1, 1024)],
+        }
+
+        rng = np.random.RandomState(789)
+        attention_sink = jnp.array(rng.randn(num_heads).astype(np.float32))
+
+        self.run_test(
+            "decode",
+            lens_dict,
+            (num_heads, head_dim, num_kv_heads, 1, jnp.bfloat16),
+            mesh,
+            2,
+            attention_sink=attention_sink,
+        )
+
 
 def compute_dp_reference_attention(
     mode,
@@ -653,6 +739,7 @@ def compute_dp_reference_attention(
     sliding_window=None,
     logit_cap=None,
     xai_temperature_len=None,
+    attention_sink=None,
 ):
     """
     Computes reference attention results using ref_ragged_paged_attention.
@@ -748,6 +835,7 @@ def compute_dp_reference_attention(
             sliding_window=sliding_window,
             soft_cap=logit_cap,
             xai_temperature_len=xai_temperature_len,
+            attention_sink=attention_sink,
         )
         rank_out = jax.block_until_ready(rank_out)
         # Ensure numpy array


### PR DESCRIPTION
- Shard attention_sink by tensor axis for TP compatibility
- Move attention_sink preparation into prepare_inputs, pad per kv_head then pad q_heads_per_kv dimension to match kernel's padded layout
- Restructure l/m initialization to avoid redundant writes
- Add MHA attention_sink tests for decode and prefill

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Benchmarking and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Please use English, otherwise it will be closed.
- [ ] The purpose of the PR, or link existing issues this PR will resolve.
- [ ] The test plan, such as providing test command.
- [ ] (Optional) The necessary documentation update.
