### PR TITLE
fix(swa): check is_hybrid before disable_radix_cache in scheduler cache init (#202)

### DIFF
--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -514,19 +514,19 @@ class Scheduler(
         server_args = self.server_args
         self.req_to_token_pool, self.token_to_kv_pool_allocator = self.tp_worker.get_memory_pool()
 
-        if server_args.chunked_prefill_size is not None and server_args.disable_radix_cache:
-            self.tree_cache = ChunkCache(
-                req_to_token_pool=self.req_to_token_pool,
-                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
-                page_size=self.page_size,
-            )
-        elif self.is_hybrid:
+        if self.is_hybrid:
             self.tree_cache = SWARadixCache(
                 req_to_token_pool=self.req_to_token_pool,
                 token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
                 sliding_window_size=self.sliding_window_size,
                 page_size=self.page_size,
                 disable=server_args.disable_radix_cache,
+            )
+        elif server_args.chunked_prefill_size is not None and server_args.disable_radix_cache:
+            self.tree_cache = ChunkCache(
+                req_to_token_pool=self.req_to_token_pool,
+                token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+                page_size=self.page_size,
             )
         else:
             self.tree_cache = RadixCache(
@@ -1754,9 +1754,7 @@ class Scheduler(
                 if self.dp_size > 1:
                     from jax.experimental.multihost_utils import process_allgather
 
-                    next_token_ids_device = process_allgather(
-                        next_token_ids_device, tiled=True
-                    )
+                    next_token_ids_device = process_allgather(next_token_ids_device, tiled=True)
                 next_token_ids = np.array(jax.device_get(next_token_ids_device))
                 self._extract_dp_output_ids(next_token_ids, model_worker_batch, batch)
         else:

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -490,5 +490,47 @@ class TestSWARadixCache(unittest.TestCase):
         self.assertEqual(allocator.swa_available_size(dp_rank=1), initial_swa[1])
 
 
+class TestSchedulerCacheInit(unittest.TestCase):
+    """Tests for scheduler cache type selection with hybrid models (#202)."""
+
+    def test_hybrid_with_disable_radix_cache_gets_swa_radix_cache(self):
+        """When is_hybrid=True and disable_radix_cache=True, must use SWARadixCache, not ChunkCache."""
+        # Replicate the condition logic from scheduler.py:517-542
+        chunked_prefill_size = 8192
+        disable_radix_cache = True
+        is_hybrid = True
+
+        # Current (wrong) logic: chunked_prefill + disable_radix_cache checked first
+        if chunked_prefill_size is not None and disable_radix_cache:
+            cache_type = "ChunkCache"
+        elif is_hybrid:
+            cache_type = "SWARadixCache"
+        else:
+            cache_type = "RadixCache"
+
+        self.assertEqual(
+            cache_type,
+            "SWARadixCache",
+            "Hybrid model with disable_radix_cache should use SWARadixCache(disable=True), "
+            "not ChunkCache. The is_hybrid check must come first in scheduler.py.",
+        )
+
+    def test_non_hybrid_with_disable_radix_cache_gets_chunk_cache(self):
+        """Non-hybrid with disable_radix_cache should still use ChunkCache."""
+        chunked_prefill_size = 8192
+        disable_radix_cache = True
+        is_hybrid = False
+
+        # After fix: is_hybrid first
+        if is_hybrid:
+            cache_type = "SWARadixCache"
+        elif chunked_prefill_size is not None and disable_radix_cache:
+            cache_type = "ChunkCache"
+        else:
+            cache_type = "RadixCache"
+
+        self.assertEqual(cache_type, "ChunkCache")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -493,43 +493,41 @@ class TestSWARadixCache(unittest.TestCase):
 class TestSchedulerCacheInit(unittest.TestCase):
     """Tests for scheduler cache type selection with hybrid models (#202)."""
 
+    def _select_cache_type(self, is_hybrid, chunked_prefill_size, disable_radix_cache):
+        """Mirror the condition logic in scheduler.py init_memory_pool_and_cache."""
+        if is_hybrid:
+            return "SWARadixCache"
+        elif chunked_prefill_size is not None and disable_radix_cache:
+            return "ChunkCache"
+        else:
+            return "RadixCache"
+
     def test_hybrid_with_disable_radix_cache_gets_swa_radix_cache(self):
         """When is_hybrid=True and disable_radix_cache=True, must use SWARadixCache, not ChunkCache."""
-        # Replicate the condition logic from scheduler.py:517-542
-        chunked_prefill_size = 8192
-        disable_radix_cache = True
-        is_hybrid = True
-
-        # Current (wrong) logic: chunked_prefill + disable_radix_cache checked first
-        if chunked_prefill_size is not None and disable_radix_cache:
-            cache_type = "ChunkCache"
-        elif is_hybrid:
-            cache_type = "SWARadixCache"
-        else:
-            cache_type = "RadixCache"
-
         self.assertEqual(
-            cache_type,
+            self._select_cache_type(
+                is_hybrid=True, chunked_prefill_size=8192, disable_radix_cache=True
+            ),
             "SWARadixCache",
-            "Hybrid model with disable_radix_cache should use SWARadixCache(disable=True), "
-            "not ChunkCache. The is_hybrid check must come first in scheduler.py.",
+        )
+
+    def test_hybrid_with_radix_cache_enabled_gets_swa_radix_cache(self):
+        """When is_hybrid=True and disable_radix_cache=False, must use SWARadixCache."""
+        self.assertEqual(
+            self._select_cache_type(
+                is_hybrid=True, chunked_prefill_size=8192, disable_radix_cache=False
+            ),
+            "SWARadixCache",
         )
 
     def test_non_hybrid_with_disable_radix_cache_gets_chunk_cache(self):
         """Non-hybrid with disable_radix_cache should still use ChunkCache."""
-        chunked_prefill_size = 8192
-        disable_radix_cache = True
-        is_hybrid = False
-
-        # After fix: is_hybrid first
-        if is_hybrid:
-            cache_type = "SWARadixCache"
-        elif chunked_prefill_size is not None and disable_radix_cache:
-            cache_type = "ChunkCache"
-        else:
-            cache_type = "RadixCache"
-
-        self.assertEqual(cache_type, "ChunkCache")
+        self.assertEqual(
+            self._select_cache_type(
+                is_hybrid=False, chunked_prefill_size=8192, disable_radix_cache=True
+            ),
+            "ChunkCache",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Swap condition order in init_memory_pool_and_cache so is_hybrid is checked first. Hybrid models now get SWARadixCache(disable=True) instead of ChunkCache.

## Test plan
- [x] Local CPU tests PASS
- [x] TPU pod validation PASS

Fixes primatrix/sglang-jax#202

🤖 Generated with [Claude Code](https://claude.com/claude-code)