### PR TITLE
fix(swa): evict SWA every page_size decode steps instead of every sliding_window (#227)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1336,7 +1336,16 @@ class ScheduleBatch:
                 if not info.reqs:
                     continue
                 for req in info.reqs:
-                    if req.decode_batch_idx % sliding_window_size == 1:
+                    # Skip decode_batch_idx=0 when overlap is enabled:
+                    # the previous batch may still be reading SWA pages.
+                    if self.enable_overlap and req.decode_batch_idx == 0:
+                        continue
+                    # Evict every page_size steps (or every step if page_size=1)
+                    # to keep SWA pool compact. Previous condition
+                    # (decode_batch_idx % sliding_window_size == 1) was too
+                    # infrequent — with sliding_window=4096, only every 4096
+                    # steps, accumulating thousands of stale SWA slots.
+                    if page_size <= 1 or req.decode_batch_idx % page_size == 0:
                         self._evict_swa(
                             req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
                         )

--- a/python/sgl_jax/test/mem_cache/test_swa_allocator.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_allocator.py
@@ -13,9 +13,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.sharding import Mesh
 
-from sgl_jax.srt.mem_cache.allocator import (
-    SWATokenToKVPoolAllocator,
-)
+from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 from sgl_jax.srt.mem_cache.memory_pool import (
     MHATokenToKVPool,
     ReqToTokenPool,
@@ -595,6 +593,28 @@ class TestSWAOverlapSafety(unittest.TestCase):
             self.assertEqual(self.alloc.swa_available_size(), swa_before + expected_evicted)
         finally:
             global_server_args_dict["chunked_prefill_size"] = old_chunked_prefill_size
+
+    def test_decode_eviction_every_step(self):
+        """Decode eviction should happen at every decode step, not only every sliding_window steps."""
+        from sgl_jax.srt.model_executor.forward_batch_info import ForwardMode
+
+        # Use a long sequence so there's always something to evict
+        req = self._make_req(origin_len=200, output_len=1)
+        self._setup_req_tokens(req, req.seqlen)
+
+        # decode_batch_idx=2 — with old condition (% sliding_window == 1),
+        # this does NOT trigger eviction (2 % 64 != 1)
+        req.decode_batch_idx = 2
+        batch = self._make_batch(req, enable_overlap=False, forward_mode=ForwardMode.DECODE)
+        batch.maybe_evict_swa()
+
+        self.assertGreater(
+            req.swa_evicted_seqlen,
+            0,
+            f"Eviction at decode_batch_idx=2 should free tokens outside the window. "
+            f"seqlen={req.seqlen}, sliding_window={self.sliding_window}. "
+            f"The condition `decode_batch_idx % sliding_window_size == 1` skips this step.",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Change decode eviction from sliding_window_size to page_size frequency. Preserves overlap safety (skip decode_batch_idx=0).

## Test plan
- [x] Local CPU tests PASS
- [x] TPU pod validation PASS

Fixes primatrix/sglang-jax#227

🤖 Generated with [Claude Code](https://claude.com/claude-code)