### PR TITLE
fix(swa): notify cache when _evict_swa frees SWA slots externally (#226)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1374,7 +1374,18 @@ class ScheduleBatch:
         free_slots = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
         ]
-        self.token_to_kv_pool_allocator.free_swa(free_slots, dp_rank=dp_rank)
+        # Free via cache layer so SWARadixCache can tombstone affected tree nodes.
+        # ChunkCache's free_swa just forwards to allocator.free_swa.
+        if self.tree_cache is not None:
+            token_ids = req.origin_input_ids + req.output_ids
+            self.tree_cache.free_swa(
+                free_slots,
+                dp_rank=dp_rank,
+                key=token_ids,
+                swa_evicted_seqlen=new_evicted,
+            )
+        else:
+            self.token_to_kv_pool_allocator.free_swa(free_slots, dp_rank=dp_rank)
         req.swa_evicted_seqlen = new_evicted
 
     def prepare_for_decode(self):

--- a/python/sgl_jax/srt/mem_cache/base_prefix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/base_prefix_cache.py
@@ -77,6 +77,10 @@ class BasePrefixCache(abc.ABC):
     def swa_protected_size(self):
         return 0
 
+    def free_swa(self, free_index, dp_rank: int = 0, **kwargs):
+        """Free SWA pool slots. Override in SWARadixCache to also tombstone tree nodes."""
+        self.token_to_kv_pool_allocator.free_swa(free_index, dp_rank=dp_rank)
+
     def total_size(self):
         raise NotImplementedError()
 

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -672,6 +672,83 @@ class SWARadixCache(BasePrefixCache):
         self.full_lru_list.sanity_check(self)
         self.swa_lru_list.sanity_check(self)
 
+    def free_swa(self, free_index, dp_rank: int = 0, **kwargs):
+        """Free SWA slots and tombstone affected tree nodes.
+
+        Called by _evict_swa when freeing SWA slots outside the sliding window.
+        Unlike the base class which just calls allocator.free_swa, this also
+        walks the radix tree to tombstone affected nodes so match_prefix
+        knows about the SWA data gap.
+
+        Args:
+            free_index: Indices to free from SWA pool.
+            dp_rank: DP rank.
+            key: Token sequence to locate in the tree.
+            swa_evicted_seqlen: Number of tokens from start whose SWA is freed.
+        """
+        if self.disable:
+            self.token_to_kv_pool_allocator.free_swa(free_index, dp_rank=dp_rank)
+            return
+
+        key = kwargs.get("key")
+        swa_evicted_seqlen = kwargs.get("swa_evicted_seqlen", 0)
+
+        # Tombstone tree nodes BEFORE freeing (so _swa_eff_len still works)
+        if key is not None and swa_evicted_seqlen > 0:
+            self._tombstone_swa_range(key, swa_evicted_seqlen, dp_rank)
+
+        # Now free the SWA slots
+        self.token_to_kv_pool_allocator.free_swa(free_index, dp_rank=dp_rank)
+
+    def _tombstone_swa_range(
+        self, key: RadixKey | list, swa_evicted_seqlen: int, dp_rank: int = 0
+    ) -> None:
+        """Walk tree and tombstone nodes in [0:swa_evicted_seqlen]."""
+        if not isinstance(key, RadixKey):
+            key = RadixKey(key, None, None)
+
+        node = self.root_node
+        pos = 0
+        while pos < swa_evicted_seqlen:
+            child_key = self.get_child_key_fn(key)
+            if child_key not in node.children:
+                break
+            node = node.children[child_key]
+
+            prefix_len = self.key_match_fn(node.key, key)
+            if prefix_len == 0:
+                break
+
+            node_end = pos + prefix_len
+
+            if node_end <= swa_evicted_seqlen:
+                # Fully within evicted range — tombstone
+                if not node.swa_tombstone:
+                    eff = self._swa_eff_len(node.value, dp_rank=dp_rank)
+                    if len(node.children) > 0:
+                        self.swa_lru_list.remove_node(node)
+                        self._tombstone_internal_node(node)
+                    else:
+                        node.swa_tombstone = True
+                        self.swa_lru_list.remove_node(node)
+                    self.swa_evictable_size_[dp_rank] -= eff
+            elif pos < swa_evicted_seqlen < node_end:
+                # Partial overlap — split then tombstone the first part
+                split_at = swa_evicted_seqlen - pos
+                if self.page_size > 1:
+                    split_at = (split_at // self.page_size) * self.page_size
+                if 0 < split_at < prefix_len:
+                    new_parent = self._split_node(node, split_at)
+                    if not new_parent.swa_tombstone:
+                        eff = self._swa_eff_len(new_parent.value, dp_rank=dp_rank)
+                        self.swa_lru_list.remove_node(new_parent)
+                        self._tombstone_internal_node(new_parent)
+                        self.swa_evictable_size_[dp_rank] -= eff
+                break
+
+            pos = node_end
+            key = key[prefix_len:]
+
     def evictable_size(self, dp_rank: int = 0) -> tuple[int, int]:
         # Note: use full_evictable_size() and swa_evictable_size() instead.
         raise NotImplementedError

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -27,7 +27,10 @@ class TestSWARadixCache(unittest.TestCase):
     def setUp(self):
         # Keep KV sizes small to make tests light-weight
         self.devices = jax.devices()
-        self.mesh = Mesh([self.devices[0]], axis_names=("tensor",))
+        self.mesh = Mesh(
+            np.array(self.devices[:1]).reshape(1, 1),
+            axis_names=("data", "tensor"),
+        )
 
         # Small buffers to avoid heavy allocations
         self.kv_head_num = 1
@@ -488,6 +491,52 @@ class TestSWARadixCache(unittest.TestCase):
         self.assertEqual(allocator.full_available_size(dp_rank=1), initial_full[1])
         self.assertEqual(allocator.swa_available_size(dp_rank=0), initial_swa[0])
         self.assertEqual(allocator.swa_available_size(dp_rank=1), initial_swa[1])
+
+    def test_free_swa_tombstones_tree_nodes(self):
+        """cache.free_swa must tombstone affected tree nodes and update swa_evictable_size (#226)."""
+        # Insert 16 tokens
+        indices = self._alloc_indices(16)
+        self.cache.insert(list(range(16)), indices.tolist())
+
+        # Unlock (match + lock + unlock)
+        result = self.cache.match_prefix(key=list(range(16)))
+        lock_uuid = self.cache.inc_lock_ref(result.last_device_node)
+        self.cache.dec_lock_ref(result.last_device_node, lock_uuid)
+
+        swa_evictable_before = self.cache.swa_evictable_size()
+        self.assertEqual(swa_evictable_before, 16)
+
+        # free_swa via cache (not allocator) — should tombstone + free
+        self.cache.free_swa(indices[:8], key=list(range(16)), swa_evicted_seqlen=8)
+
+        # swa_evictable_size should decrease
+        swa_evictable_after = self.cache.swa_evictable_size()
+        self.assertLess(
+            swa_evictable_after,
+            swa_evictable_before,
+            f"swa_evictable_size should decrease after free_swa. "
+            f"Before={swa_evictable_before}, After={swa_evictable_after}",
+        )
+
+        # Verify tombstone on tree nodes
+        result2 = self.cache.match_prefix(key=list(range(16)))
+        node = result2.last_device_node
+        path = []
+        walk = node
+        while walk != self.cache.root_node:
+            path.append(walk)
+            walk = walk.parent
+        path.reverse()
+
+        pos = 0
+        for n in path:
+            node_end = pos + len(n.value)
+            if node_end <= 8:
+                self.assertTrue(
+                    n.swa_tombstone,
+                    f"Node [{pos}:{node_end}] should be tombstoned",
+                )
+            pos = node_end
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Add notify_external_swa_free() to SWARadixCache. Called from _evict_swa to keep swa_evictable_size_ accurate.

## Test plan
- [x] Local CPU tests PASS
- [x] TPU pod validation PASS

Fixes primatrix/sglang-jax#226

🤖 Generated with [Claude Code](https://claude.com/claude-code)