### PR TITLE
fix: keep future token resolve data-sharded

### DIFF
--- a/python/sgl_jax/srt/managers/utils.py
+++ b/python/sgl_jax/srt/managers/utils.py
@@ -45,13 +45,12 @@ def validate_input_length(
 
 @jax.jit(static_argnames=("mesh"))
 def resolve_future_token_ids(input_ids, future_token_ids_map, mesh):
-    input_ids_global = jax.sharding.reshard(input_ids, NamedSharding(mesh, P()))
-    input_ids_global = jnp.where(
-        input_ids_global < 0,
-        future_token_ids_map[jnp.clip(-input_ids_global, a_min=0)],
-        input_ids_global,
+    out_sharding = NamedSharding(mesh, P("data"))
+    future_token_ids = future_token_ids_map.at[jnp.clip(-input_ids, min=0)].get(
+        out_sharding=out_sharding
     )
-    return jax.sharding.reshard(input_ids_global, NamedSharding(mesh, P("data")))
+    input_ids = jnp.where(input_ids < 0, future_token_ids, input_ids)
+    return jax.sharding.reshard(input_ids, out_sharding)
 
 
 @jax.jit(static_argnames=("mesh"))

--- a/python/sgl_jax/test/managers/test_resolve_future_token_ids.py
+++ b/python/sgl_jax/test/managers/test_resolve_future_token_ids.py
@@ -9,6 +9,7 @@ if os.environ.get("USE_DEVICE_TYPE") == "cpu":
 
 import jax
 import numpy as np
+from jax.experimental import multihost_utils
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
@@ -37,7 +38,7 @@ class TestResolveFutureTokenIds(unittest.TestCase):
             )
 
             resolved = resolve_future_token_ids(input_ids, future_token_ids_map, mesh)
-            resolved_np = np.array(resolved)
+            resolved_np = multihost_utils.process_allgather(resolved, tiled=True)
 
             expected = input_ids_np.copy()
             expected[::1024] = 101

--- a/python/sgl_jax/test/managers/test_resolve_future_token_ids.py
+++ b/python/sgl_jax/test/managers/test_resolve_future_token_ids.py
@@ -1,0 +1,60 @@
+# cd python && USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/managers/test_resolve_future_token_ids.py -q
+
+import os
+import unittest
+
+if os.environ.get("USE_DEVICE_TYPE") == "cpu":
+    os.environ["XLA_FLAGS"] = "--xla_force_host_platform_device_count=4"
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import jax
+import numpy as np
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.managers.utils import resolve_future_token_ids
+from sgl_jax.srt.utils.mesh_utils import create_device_mesh
+
+
+def _make_dp_mesh():
+    return create_device_mesh(ici_parallelism=[-1, 1], dcn_parallelism=[1, 1])
+
+
+class TestResolveFutureTokenIds(unittest.TestCase):
+    def test_resolve_future_keeps_input_ids_data_sharded(self):
+        mesh = _make_dp_mesh()
+        input_ids_np = np.arange(4096, dtype=np.int32)
+        input_ids_np[::1024] = -1
+        input_ids_np[1::1024] = -2
+        future_token_ids_map_np = np.zeros((16,), dtype=np.int32)
+        future_token_ids_map_np[1] = 101
+        future_token_ids_map_np[2] = 202
+
+        with mesh:
+            input_ids = jax.device_put(input_ids_np, NamedSharding(mesh, P("data")))
+            future_token_ids_map = jax.device_put(
+                future_token_ids_map_np, NamedSharding(mesh, P(None))
+            )
+
+            resolved = resolve_future_token_ids(input_ids, future_token_ids_map, mesh)
+            resolved_np = np.array(resolved)
+
+            expected = input_ids_np.copy()
+            expected[::1024] = 101
+            expected[1::1024] = 202
+            np.testing.assert_array_equal(resolved_np, expected)
+            self.assertEqual(resolved.sharding.spec, P("data"))
+
+            hlo = (
+                resolve_future_token_ids.lower(input_ids, future_token_ids_map, mesh)
+                .compiler_ir(dialect="hlo")
+                .as_hlo_text()
+            )
+
+        # DP input_ids should remain local. The future map is replicated, but
+        # resolve itself should not replicate the full input_ids vector.
+        self.assertLessEqual(hlo.count("sharding={replicated}"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #243.

`resolve_future_token_ids()` no longer reshards `input_ids` from `P("data")` to replicated `P()` before replacing negative future-token placeholders. It now gathers from the replicated `future_token_ids_map` with explicit `out_sharding=P("data")`, preserving DP locality for the full input_ids vector.

## TDD

Red test before fix:

```bash
USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/managers/test_resolve_future_token_ids.py -q
```

Failed because lowered HLO had 13 replicated sharding markers from the input_ids replication path.

Green tests after fix:

```bash
USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/managers/test_resolve_future_token_ids.py -q
USE_DEVICE_TYPE=cpu python -m pytest sgl_jax/test/mem_cache/test_swa_allocator.py -q
```

## Profiling Context

Existing TPU profile: `/Users/dengqiaoling/tpu-profiling/chips_16_dp_2_resolve_profiling`, chips=16, dp=2.

Before this fix, device-side `jit_resolve_future_token_ids` showed host stragglers:

| Host | Resolve wall sum | P50 cluster | Max cluster |
|---|---:|---:|---:|
| kkx-16-0 | 124.4 ms | 12.5 ms | 39.6 ms |
| kkx-16-1 | 9.2 ms | 0.25 ms | 3.9 ms |
| kkx-16-2 | 103.0 ms | 7.0 ms | 46.9 ms |
| kkx-16-3 | 5.1 ms | 0.06 ms | 1.9 ms |

Need TPU multi-host profile/e2e validation after merge candidate is deployed.
