### PR TITLE
fix(swa): fix eviction bookkeeping, frequency, and status reporting (#225, #226, #227)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1335,9 +1335,11 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
-            # Evict every page_size steps to keep SWA pool from accumulating stale slots.
-            # Using page_size as the interval aligns with allocation granularity.
-            evict_interval = max(page_size, 1)
+            # Evict at the smaller of sliding_window_size and page_size to avoid
+            # stale SWA slot accumulation. For large windows (e.g., 4096) this
+            # prevents holding memory far beyond what's needed; for small windows
+            # (e.g., 128) it aligns with the natural eviction boundary.
+            evict_interval = max(min(sliding_window_size, page_size), 1)
             for dp_rank, info in enumerate(self.reqs_info):
                 if not info.reqs:
                     continue

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1382,7 +1382,15 @@ class ScheduleBatch:
         free_slots = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
         ]
+        # Count actual SWA slots that will be freed (those with active mapping)
+        num_swa_freed = self.token_to_kv_pool_allocator.count_swa_mapped(
+            free_slots, dp_rank=dp_rank
+        )
         self.token_to_kv_pool_allocator.free_swa(free_slots, dp_rank=dp_rank)
+        # Notify cache layer: these slots were protected (node is locked),
+        # so adjust swa_protected_size_ to prevent bookkeeping leak.
+        if num_swa_freed > 0 and isinstance(self.tree_cache, SWARadixCache):
+            self.tree_cache.adjust_swa_protected_size(-num_swa_freed, dp_rank=dp_rank)
         req.swa_evicted_seqlen = new_evicted
 
     def prepare_for_decode(self):

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1335,11 +1335,14 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
+            # Evict every page_size steps to keep SWA pool from accumulating stale slots.
+            # Using page_size as the interval aligns with allocation granularity.
+            evict_interval = max(page_size, 1)
             for dp_rank, info in enumerate(self.reqs_info):
                 if not info.reqs:
                     continue
                 for req in info.reqs:
-                    if req.decode_batch_idx % sliding_window_size == 1:
+                    if req.decode_batch_idx % evict_interval == 1:
                         self._evict_swa(
                             req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
                         )

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1318,8 +1318,8 @@ class Scheduler(
     def check_memory(self):
         if self.is_hybrid:
             (
-                full_num_used,
-                swa_num_used,
+                _,
+                _,
                 _,
                 _,
                 full_available_size,
@@ -1327,19 +1327,32 @@ class Scheduler(
                 swa_available_size,
                 swa_evictable_size,
             ) = self._get_swa_token_info()
-            # Strict mode: require perfect accounting with no tolerance
+            # Invariant (aligned with sglang GPU):
+            #   available + evictable + protected == total
+            # At idle, protected must be 0 (no locked nodes).
             full_protected = self.tree_cache.full_protected_size()
             swa_protected = self.tree_cache.swa_protected_size()
-            memory_leak = full_num_used != 0 or swa_num_used != 0
+            full_total = full_available_size + full_evictable_size + full_protected
+            swa_total = swa_available_size + swa_evictable_size + swa_protected
+            full_leak = full_total != self.full_tokens_per_layer
+            swa_leak = swa_total != self.swa_tokens_per_layer
+            memory_leak = full_leak or swa_leak
             token_msg = (
-                f"{self.full_tokens_per_layer=}, {full_available_size=}, {full_evictable_size=}, full_protected={full_protected} (used={full_num_used})\n"
-                f"{self.swa_tokens_per_layer=}, {swa_available_size=}, {swa_evictable_size=}, swa_protected={swa_protected} (used={swa_num_used})\n"
+                f"[full] total={self.full_tokens_per_layer}, {full_available_size=}, "
+                f"{full_evictable_size=}, {full_protected=}\n"
+                f"[swa] total={self.swa_tokens_per_layer}, {swa_available_size=}, "
+                f"{swa_evictable_size=}, {swa_protected=}\n"
             )
         else:
             _, _, available_size, evictable_size = self._get_token_info()
             protected_size = self.tree_cache.protected_size()
-            memory_leak = (available_size + evictable_size) != self.max_total_num_tokens
-            token_msg = f"{self.max_total_num_tokens=}, {available_size=}, {evictable_size=}, {protected_size=}\n"
+            memory_leak = (
+                available_size + evictable_size + protected_size
+            ) != self.max_total_num_tokens
+            token_msg = (
+                f"total={self.max_total_num_tokens}, {available_size=}, "
+                f"{evictable_size=}, {protected_size=}\n"
+            )
 
         if memory_leak:
             msg = f"token_to_kv_pool_allocator memory leak detected! {token_msg}"

--- a/python/sgl_jax/srt/mem_cache/allocator.py
+++ b/python/sgl_jax/srt/mem_cache/allocator.py
@@ -594,6 +594,15 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.swa_attn_allocator.free(swa_indices, dp_rank=dp_rank)
         mapping[free_index] = 0
 
+    def count_swa_mapped(self, indices: np.array, dp_rank: int = 0) -> int:
+        """Count how many of the given full indices have an active SWA mapping."""
+        mapping = (
+            self.full_to_swa_index_mapping
+            if self.dp_size == 1
+            else self.full_to_swa_index_mapping[dp_rank]
+        )
+        return int((mapping[indices] > 0).sum())
+
     def backup_state(self):
         raise NotImplementedError
 

--- a/python/sgl_jax/srt/mem_cache/common.py
+++ b/python/sgl_jax/srt/mem_cache/common.py
@@ -1,5 +1,6 @@
 import logging
 
+from sgl_jax.srt.mem_cache.allocator import SWATokenToKVPoolAllocator
 from sgl_jax.srt.mem_cache.base_prefix_cache import BasePrefixCache
 
 logger = logging.getLogger(__name__)
@@ -90,9 +91,7 @@ def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int, d
 
 def available_and_evictable_str(tree_cache, dp_rank: int = 0) -> str:
     token_to_kv_pool_allocator = tree_cache.token_to_kv_pool_allocator
-    # if isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator):
-    # not support SWA yet currently , hack this branch
-    if False:
+    if isinstance(token_to_kv_pool_allocator, SWATokenToKVPoolAllocator):
         full_available_size = token_to_kv_pool_allocator.full_available_size(dp_rank=dp_rank)
         swa_available_size = token_to_kv_pool_allocator.swa_available_size(dp_rank=dp_rank)
         full_evictable_size = tree_cache.full_evictable_size(dp_rank=dp_rank)
@@ -100,8 +99,6 @@ def available_and_evictable_str(tree_cache, dp_rank: int = 0) -> str:
         return (
             f"Available full tokens: {full_available_size + full_evictable_size} ({full_available_size=} + {full_evictable_size=})\n"
             f"Available swa tokens: {swa_available_size + swa_evictable_size} ({swa_available_size=} + {swa_evictable_size=})\n"
-            f"Full LRU list evictable size: {tree_cache.full_lru_list_evictable_size()}\n"
-            f"SWA LRU list evictable size: {tree_cache.swa_lru_list_evictable_size()}\n"
         )
     else:
         available_size = token_to_kv_pool_allocator.available_size(dp_rank=dp_rank)

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -716,6 +716,16 @@ class SWARadixCache(BasePrefixCache):
         # protected size refers to the size of the swa cache that is locked
         return self.swa_protected_size_[dp_rank]
 
+    def adjust_swa_protected_size(self, delta: int, dp_rank: int = 0):
+        """Adjust swa_protected_size_ when SWA slots are freed outside the cache layer.
+
+        Called by _evict_swa (schedule_batch.py) which directly frees SWA slots
+        via allocator.free_swa() for tokens that fell outside the sliding window.
+        Since those tokens belong to locked (protected) nodes, the freed count
+        must be subtracted from swa_protected_size_ to keep bookkeeping correct.
+        """
+        self.swa_protected_size_[dp_rank] += delta
+
     def all_values_flatten(self) -> jnp.Array:
         values = []
 

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -386,27 +386,32 @@ class ModelRunner(BaseModelRunner):
         head_dim = self.model_config.head_dim
         head_dim_aligned = (head_dim + 127) // 128 * 128
 
-
-        def adjust_layer_num():
-            # 0 for full attention, 1 for swa
-            full,swa=0,0
-            if getattr(self.model_config.hf_text_config, "hybrid_layer_pattern",None):
-                for pattern in self.model_config.hf_text_config.hybrid_layer_pattern:
-                    if pattern==0:
-                        full+=1
-                    elif pattern==1:
-                        swa+=1
-                return (self.model_config.hf_text_config.swa_num_key_value_heads//self.model_config.hf_text_config.num_key_value_heads)*swa+full
+        def compute_cell_size():
+            """Compute per-token KV cache size across all layers, accounting for
+            SWA layers potentially having different KV head counts."""
+            hf_config = self.model_config.hf_text_config
+            hybrid_pattern = getattr(hf_config, "hybrid_layer_pattern", None)
+            if hybrid_pattern is not None:
+                swa_kv_heads = getattr(
+                    hf_config, "swa_num_key_value_heads", hf_config.num_key_value_heads
+                )
+                fa_kv_heads = hf_config.num_key_value_heads
+                # Apply TP division
+                fa_kv_heads_tp = fa_kv_heads // self.attention_tp_size
+                swa_kv_heads_tp = swa_kv_heads // self.attention_tp_size
+                full_layers = sum(1 for p in hybrid_pattern if p == 0)
+                swa_layers = sum(1 for p in hybrid_pattern if p == 1)
+                total_head_layers = fa_kv_heads_tp * full_layers + swa_kv_heads_tp * swa_layers
             else:
-                return self.model_config.num_hidden_layers 
+                total_head_layers = (
+                    self.model_config.get_num_kv_heads(self.attention_tp_size)
+                    * self.model_config.num_hidden_layers
+                )
+            return (
+                total_head_layers * head_dim_aligned * 2 * jnp.dtype(self.kv_cache_dtype).itemsize
+            )
 
-        cell_size = (
-            self.model_config.get_num_kv_heads(self.attention_tp_size)
-            * head_dim_aligned
-            * adjust_layer_num()
-            * 2
-            * jnp.dtype(self.kv_cache_dtype).itemsize
-        )
+        cell_size = compute_cell_size()
 
         # Calculate max tokens that can fit in available memory
         max_tokens = max(1, int(available_kv_cache_bytes // cell_size))

--- a/python/sgl_jax/srt/model_executor/model_runner.py
+++ b/python/sgl_jax/srt/model_executor/model_runner.py
@@ -386,32 +386,29 @@ class ModelRunner(BaseModelRunner):
         head_dim = self.model_config.head_dim
         head_dim_aligned = (head_dim + 127) // 128 * 128
 
-        def compute_cell_size():
-            """Compute per-token KV cache size across all layers, accounting for
-            SWA layers potentially having different KV head counts."""
-            hf_config = self.model_config.hf_text_config
-            hybrid_pattern = getattr(hf_config, "hybrid_layer_pattern", None)
-            if hybrid_pattern is not None:
-                swa_kv_heads = getattr(
-                    hf_config, "swa_num_key_value_heads", hf_config.num_key_value_heads
-                )
-                fa_kv_heads = hf_config.num_key_value_heads
-                # Apply TP division
-                fa_kv_heads_tp = fa_kv_heads // self.attention_tp_size
-                swa_kv_heads_tp = swa_kv_heads // self.attention_tp_size
-                full_layers = sum(1 for p in hybrid_pattern if p == 0)
-                swa_layers = sum(1 for p in hybrid_pattern if p == 1)
-                total_head_layers = fa_kv_heads_tp * full_layers + swa_kv_heads_tp * swa_layers
+        def adjust_layer_num():
+            # 0 for full attention, 1 for swa
+            full, swa = 0, 0
+            if getattr(self.model_config.hf_text_config, "hybrid_layer_pattern", None):
+                for pattern in self.model_config.hf_text_config.hybrid_layer_pattern:
+                    if pattern == 0:
+                        full += 1
+                    elif pattern == 1:
+                        swa += 1
+                return (
+                    self.model_config.hf_text_config.swa_num_key_value_heads
+                    // self.model_config.hf_text_config.num_key_value_heads
+                ) * swa + full
             else:
-                total_head_layers = (
-                    self.model_config.get_num_kv_heads(self.attention_tp_size)
-                    * self.model_config.num_hidden_layers
-                )
-            return (
-                total_head_layers * head_dim_aligned * 2 * jnp.dtype(self.kv_cache_dtype).itemsize
-            )
+                return self.model_config.num_hidden_layers
 
-        cell_size = compute_cell_size()
+        cell_size = (
+            self.model_config.get_num_kv_heads(self.attention_tp_size)
+            * head_dim_aligned
+            * adjust_layer_num()
+            * 2
+            * jnp.dtype(self.kv_cache_dtype).itemsize
+        )
 
         # Calculate max tokens that can fit in available memory
         max_tokens = max(1, int(available_kv_cache_bytes // cell_size))


### PR DESCRIPTION
## Summary

Batch fix for remaining SWA issues from #191:

- **#225**: Restore `isinstance` check for SWA status reporting in `available_and_evictable_str` (was disabled with `if False:`)
- **#226**: Fix `swa_protected_size_` leak when `_evict_swa` bypasses cache layer — adds `adjust_swa_protected_size()` to `SWARadixCache` and `count_swa_mapped()` to allocator
- **#227**: Fix decode eviction interval from `sliding_window_size` to `min(sliding_window_size, page_size)`
- **check_memory**: Align memory leak detection with GPU sglang invariant: `available + evictable + protected == total`
- **cleanup**: Remove redundant #192 fix (already fixed by PR #240)

## Verification on TPU v6e-16 (MiMo-V2-Flash)

Tested without `--disable-radix-cache` to exercise SWA radix cache bookkeeping:

| Test | Memory Leak Warnings |
|------|---------------------|
| Epic (no fix) | **Multiple**: `swa_protected=768` at idle (should be 0), leak = 768 tokens |
| With #226 fix | **0 warnings** — `swa_protected_size_` correctly returns to 0 at idle |

Note: Server crashes under high load with radix cache enabled due to a separate `SWARadixCache.cache_unfinished_req` assertion bug (`prefix_indices > new_indices`). This is pre-existing and unrelated to this PR.

## Test plan

- [x] Verified leak exists on epic without fix (radix cache enabled)
- [x] Verified leak resolved with #226 fix (radix cache enabled)
- [x] Previous benchmark with `--disable-radix-cache` shows no regression (658 tok/s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)