### PR TITLE
feat: add GKE CI workflows for benchmark, accuracy, and profiling

### DIFF
--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -1,0 +1,202 @@
+# CI sglang-jax Job (16 chips) - K8s Manifests
+# 4 pods x 4 TPU chips = 16 chips, topology 4x4
+# Rendered by envsubst with:
+#   $JOB_NAME $BRANCH $MODEL_PATH $TP_SIZE $SERVER_ARGS
+#   $TASK_COMMAND $GITHUB_ACTOR $ACTIVE_DEADLINE
+#   $TPU_COORDINATOR_ADDRESS
+---
+# Headless Service for TPU pod DNS resolution (required for JAX multi-host)
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${JOB_NAME}-headless-svc
+  namespace: default
+  labels:
+    app: ci-sglang
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: default
+  labels:
+    app: ci-sglang
+    ci-actor: ${GITHUB_ACTOR}
+    ci-task: ${TASK_TYPE}
+    job-name: ${JOB_NAME}
+spec:
+  backoffLimit: 0
+  completionMode: Indexed
+  completions: 4
+  parallelism: 4
+  podReplacementPolicy: TerminatingOrFailed
+  activeDeadlineSeconds: ${ACTIVE_DEADLINE}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      annotations:
+        gke-gcsfuse/volumes: "true"
+      labels:
+        app: ci-sglang
+        job-name: ${JOB_NAME}
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchLabels:
+                job-name: ${JOB_NAME}
+            topologyKey: cloud.google.com/gke-nodepool
+      containers:
+      - name: sglang-tpu
+        image: python:3.12
+        imagePullPolicy: IfNotPresent
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          # 1. Clone branch
+          set +x
+          git clone --depth=1 --branch="${BRANCH}" \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/primatrix/sglang-jax.git" \
+            /root/sglang-jax
+          set -x
+          cd /root/sglang-jax
+
+          # 2. Setup Python environment
+          mkdir -p /tmp/ramdisk/logs
+          export UV_CACHE_DIR="/tmp/ramdisk/uv_cache"
+          export TMPDIR="/tmp/ramdisk"
+          pip install uv
+          uv venv /tmp/ramdisk/venv
+          source /tmp/ramdisk/venv/bin/activate
+          uv pip install pip
+          uv pip install -e "python[tpu]"
+
+          # 3. Install extra deps if specified
+          if [ -n "${EXTRA_DEPS}" ]; then
+            uv pip install ${EXTRA_DEPS}
+          fi
+
+          # 4. Determine node rank from JOB_COMPLETION_INDEX
+          NODE_RANK=${JOB_COMPLETION_INDEX}
+          NNODES=4
+          COORDINATOR_ADDR="${TPU_COORDINATOR_ADDRESS}"
+
+          echo "Node rank: ${NODE_RANK}, Coordinator: ${COORDINATOR_ADDR}"
+
+          # 5. Start sglang server
+          #    - Node 0 runs full stack (HTTP + scheduler)
+          #    - Nodes 1-3 run scheduler only
+          python3 -m sgl_jax.launch_server \
+            --model-path "${MODEL_PATH}" \
+            --host 0.0.0.0 \
+            --port 30271 \
+            --tp-size ${TP_SIZE} \
+            --device tpu \
+            --trust-remote-code \
+            --dist-init-addr "${COORDINATOR_ADDR}" \
+            --nnodes ${NNODES} \
+            --node-rank ${NODE_RANK} \
+            ${SERVER_ARGS} &
+          SERVER_PID=$!
+
+          if [ "${NODE_RANK}" -eq 0 ]; then
+            # 6. Coordinator: wait for server ready, run task
+            echo "Waiting for server to be ready..."
+            for i in $(seq 1 120); do
+              if curl -sf http://127.0.0.1:30271/health > /dev/null 2>&1; then
+                echo "Server is ready after ${i}0 seconds"
+                break
+              fi
+              if ! kill -0 $SERVER_PID 2>/dev/null; then
+                echo "ERROR: Server process died"
+                exit 1
+              fi
+              sleep 10
+            done
+
+            if ! curl -sf http://127.0.0.1:30271/health > /dev/null 2>&1; then
+              echo "ERROR: Server failed to start within 1200s"
+              kill $SERVER_PID 2>/dev/null || true
+              exit 1
+            fi
+
+            # Run the task command
+            eval "${TASK_COMMAND}"
+            TASK_EXIT=$?
+
+            # Shutdown server
+            kill $SERVER_PID 2>/dev/null || true
+            wait $SERVER_PID 2>/dev/null || true
+            exit $TASK_EXIT
+          else
+            # 7. Worker: just wait for server process to finish
+            wait $SERVER_PID
+          fi
+        env:
+        - name: MODEL_PATH
+          value: "${MODEL_PATH}"
+        - name: TP_SIZE
+          value: "${TP_SIZE}"
+        - name: SERVER_ARGS
+          value: "${SERVER_ARGS}"
+        - name: EXTRA_DEPS
+          value: "${EXTRA_DEPS}"
+        - name: TASK_COMMAND
+          value: "${TASK_COMMAND}"
+        - name: TPU_COORDINATOR_ADDRESS
+          value: "${TPU_COORDINATOR_ADDRESS}"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${JOB_NAME}-token
+              key: token
+        - name: PIP_CACHE_DIR
+          value: /tmp/ramdisk/.cache/pip
+        - name: JAX_COMPILATION_CACHE_DIR
+          value: /tmp/jit_cache
+        - name: HF_HOME
+          value: /models/huggingface
+        resources:
+          limits:
+            google.com/tpu: "4"
+          requests:
+            ephemeral-storage: 20Gi
+            google.com/tpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /models
+          name: gcs-fuse-csi-ephemeral
+        - mountPath: /tmp/ramdisk
+          name: tmpfs
+        - mountPath: /dev/shm
+          name: dshm
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+        cloud.google.com/gke-tpu-topology: "4x4"
+      restartPolicy: Never
+      serviceAccountName: gcs-account
+      subdomain: ${JOB_NAME}-headless-svc
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 200Gi
+        name: tmpfs
+      - emptyDir:
+          medium: Memory
+        name: gke-gcsfuse-cache
+      - name: gcs-fuse-csi-ephemeral
+        persistentVolumeClaim:
+          claimName: inference-model-storage-poc-tpu-hns-pvc
+      - name: dshm
+        emptyDir:
+          medium: Memory

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -1,0 +1,178 @@
+# CI sglang-jax Job (4 chips) - K8s Manifests
+# 1 pod x 4 TPU chips = 4 chips, topology 2x2
+# Rendered by envsubst with:
+#   $JOB_NAME $BRANCH $MODEL_PATH $TP_SIZE $SERVER_ARGS
+#   $TASK_COMMAND $GITHUB_ACTOR $ACTIVE_DEADLINE
+---
+# Headless Service for DNS resolution
+apiVersion: v1
+kind: Service
+metadata:
+  name: ${JOB_NAME}-headless-svc
+  namespace: default
+  labels:
+    app: ci-sglang
+spec:
+  clusterIP: None
+  selector:
+    job-name: ${JOB_NAME}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ${JOB_NAME}
+  namespace: default
+  labels:
+    app: ci-sglang
+    ci-actor: ${GITHUB_ACTOR}
+    ci-task: ${TASK_TYPE}
+    job-name: ${JOB_NAME}
+spec:
+  backoffLimit: 0
+  completionMode: Indexed
+  completions: 1
+  parallelism: 1
+  activeDeadlineSeconds: ${ACTIVE_DEADLINE}
+  ttlSecondsAfterFinished: 600
+  template:
+    metadata:
+      annotations:
+        gke-gcsfuse/volumes: "true"
+      labels:
+        app: ci-sglang
+        job-name: ${JOB_NAME}
+    spec:
+      containers:
+      - name: sglang-tpu
+        image: python:3.12
+        imagePullPolicy: IfNotPresent
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+
+          # 1. Clone branch
+          set +x
+          git clone --depth=1 --branch="${BRANCH}" \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/primatrix/sglang-jax.git" \
+            /root/sglang-jax
+          set -x
+          cd /root/sglang-jax
+
+          # 2. Setup Python environment
+          mkdir -p /tmp/ramdisk/logs
+          export UV_CACHE_DIR="/tmp/ramdisk/uv_cache"
+          export TMPDIR="/tmp/ramdisk"
+          pip install uv
+          uv venv /tmp/ramdisk/venv
+          source /tmp/ramdisk/venv/bin/activate
+          uv pip install pip
+          uv pip install -e "python[tpu]"
+
+          # 3. Install extra deps if specified
+          if [ -n "${EXTRA_DEPS}" ]; then
+            uv pip install ${EXTRA_DEPS}
+          fi
+
+          # 4. Start sglang server in background
+          python3 -m sgl_jax.launch_server \
+            --model-path "${MODEL_PATH}" \
+            --host 0.0.0.0 \
+            --port 30271 \
+            --tp-size ${TP_SIZE} \
+            --device tpu \
+            --trust-remote-code \
+            --dist-init-addr 0.0.0.0:10011 \
+            --nnodes 1 \
+            --node-rank 0 \
+            ${SERVER_ARGS} &
+          SERVER_PID=$!
+
+          # 5. Wait for server to be ready
+          echo "Waiting for server to be ready..."
+          for i in $(seq 1 120); do
+            if curl -sf http://127.0.0.1:30271/health > /dev/null 2>&1; then
+              echo "Server is ready after ${i}0 seconds"
+              break
+            fi
+            if ! kill -0 $SERVER_PID 2>/dev/null; then
+              echo "ERROR: Server process died"
+              exit 1
+            fi
+            sleep 10
+          done
+
+          if ! curl -sf http://127.0.0.1:30271/health > /dev/null 2>&1; then
+            echo "ERROR: Server failed to start within 1200s"
+            kill $SERVER_PID 2>/dev/null || true
+            exit 1
+          fi
+
+          # 6. Run the task command (benchmark / eval / profiling)
+          eval "${TASK_COMMAND}"
+          TASK_EXIT=$?
+
+          # 7. Shutdown server
+          kill $SERVER_PID 2>/dev/null || true
+          wait $SERVER_PID 2>/dev/null || true
+
+          exit $TASK_EXIT
+        env:
+        - name: MODEL_PATH
+          value: "${MODEL_PATH}"
+        - name: TP_SIZE
+          value: "${TP_SIZE}"
+        - name: SERVER_ARGS
+          value: "${SERVER_ARGS}"
+        - name: EXTRA_DEPS
+          value: "${EXTRA_DEPS}"
+        - name: TASK_COMMAND
+          value: "${TASK_COMMAND}"
+        - name: GITHUB_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: ${JOB_NAME}-token
+              key: token
+        - name: PIP_CACHE_DIR
+          value: /tmp/ramdisk/.cache/pip
+        - name: JAX_COMPILATION_CACHE_DIR
+          value: /tmp/jit_cache
+        - name: HF_HOME
+          value: /models/huggingface
+        resources:
+          limits:
+            google.com/tpu: "4"
+          requests:
+            ephemeral-storage: 20Gi
+            google.com/tpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - mountPath: /models
+          name: gcs-fuse-csi-ephemeral
+        - mountPath: /tmp/ramdisk
+          name: tmpfs
+        - mountPath: /dev/shm
+          name: dshm
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+        cloud.google.com/gke-tpu-topology: "2x2"
+      restartPolicy: Never
+      serviceAccountName: gcs-account
+      subdomain: ${JOB_NAME}-headless-svc
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - emptyDir:
+          medium: Memory
+          sizeLimit: 200Gi
+        name: tmpfs
+      - emptyDir:
+          medium: Memory
+        name: gke-gcsfuse-cache
+      - name: gcs-fuse-csi-ephemeral
+        persistentVolumeClaim:
+          claimName: inference-model-storage-poc-tpu-hns-pvc
+      - name: dshm
+        emptyDir:
+          medium: Memory

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -1,0 +1,273 @@
+name: Accuracy (GKE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to test"
+        required: true
+        default: "epic/mimo-v2-flash"
+      model_path:
+        description: "Model path (HuggingFace ID or /models/...)"
+        required: true
+        default: "XiaomiMiMo/MiMo-V2-Flash"
+      topology:
+        description: "TPU topology"
+        required: true
+        type: choice
+        options:
+          - "4chip"
+          - "16chip"
+        default: "4chip"
+      tp_size:
+        description: "Tensor parallel size"
+        required: true
+        default: "4"
+      datasets:
+        description: "Evaluation datasets (comma-separated)"
+        required: true
+        default: "gsm8k"
+      eval_batch_size:
+        description: "Evaluation batch size"
+        required: true
+        default: "32"
+      temperature:
+        description: "Generation temperature"
+        required: true
+        default: "0.8"
+      top_p:
+        description: "Generation top_p"
+        required: true
+        default: "0.95"
+      max_tokens:
+        description: "Max generation tokens (0 = use default)"
+        required: false
+        default: "0"
+      server_args:
+        description: "Extra sglang server args (e.g. --max-seq-len 32768)"
+        required: false
+        default: ""
+      extra_eval_args:
+        description: "Extra evalscope args (e.g. --limit 100)"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  accuracy:
+    name: "Accuracy (${{ inputs.topology }}, ${{ inputs.datasets }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Get GKE credentials
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Cleanup stale resources
+      run: |
+        for job in $(kubectl get jobs -l app=ci-sglang,ci-task=accuracy \
+          -o jsonpath='{.items[?(@.status.conditions[*].type)].metadata.name}' 2>/dev/null); do
+          echo "Deleting finished job: $job"
+          kubectl delete job "$job" --ignore-not-found
+          kubectl delete service "${job}-headless-svc" --ignore-not-found
+          kubectl delete secret "${job}-token" --ignore-not-found
+        done
+
+    - name: Configure job
+      id: config
+      run: |
+        TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+        JOB_NAME="acc-${TIMESTAMP}-${GITHUB_RUN_NUMBER}"
+        echo "job_name=${JOB_NAME}" >> "$GITHUB_OUTPUT"
+
+        # Sanitize actor name for K8s labels
+        ACTOR_SAFE=$(echo "${{ github.actor }}" | tr '[:upper:]' '[:lower:]' \
+          | sed 's/[^a-z0-9._-]/-/g' | sed 's/^[^a-z0-9]*//' | sed 's/[^a-z0-9]*$//' | head -c 63)
+        ACTOR_SAFE="${ACTOR_SAFE:-unknown}"
+        echo "actor_safe=${ACTOR_SAFE}" >> "$GITHUB_OUTPUT"
+
+        # Build generation config JSON
+        GEN_CONFIG="{\"temperature\": ${{ inputs.temperature }},\"top_p\":${{ inputs.top_p }}"
+        if [ "${{ inputs.max_tokens }}" != "0" ]; then
+          GEN_CONFIG+=",\"max_tokens\":${{ inputs.max_tokens }}"
+        fi
+        GEN_CONFIG+="}"
+
+        # Build task command
+        TASK_CMD="evalscope eval"
+        TASK_CMD+=" --model ${{ inputs.model_path }}"
+        TASK_CMD+=" --api-url http://127.0.0.1:30271/v1/chat/completions"
+        TASK_CMD+=" --api-key EMPTY"
+        TASK_CMD+=" --eval-type service"
+        TASK_CMD+=" --datasets ${{ inputs.datasets }}"
+        TASK_CMD+=" --eval-batch-size ${{ inputs.eval_batch_size }}"
+        TASK_CMD+=" --generation-config '${GEN_CONFIG}'"
+        TASK_CMD+=" ${{ inputs.extra_eval_args }}"
+        echo "task_command=${TASK_CMD}" >> "$GITHUB_OUTPUT"
+
+        # TPU coordinator address for 16chip
+        if [ "${{ inputs.topology }}" = "16chip" ]; then
+          COORD="${JOB_NAME}-0.${JOB_NAME}-headless-svc:10011"
+          echo "coordinator=${COORD}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Wait for TPU queue slot
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        MAX_CONCURRENT=4
+        MAX_PER_ACTOR=2
+        MAX_QUEUE_DEPTH=6
+        MY_RUN=${{ github.run_number }}
+        ACTOR="${{ github.actor }}"
+        ACTOR_SAFE="${{ steps.config.outputs.actor_safe }}"
+        REPO="${{ github.repository }}"
+        WORKFLOW="accuracy_gke.yml"
+        TASK_LABEL="accuracy"
+
+        WAITING=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?status=in_progress" \
+          --jq '.total_count' 2>/dev/null || echo 0)
+        if [ "$WAITING" -gt "$MAX_QUEUE_DEPTH" ]; then
+          echo "::error::Queue depth exceeded ($WAITING > $MAX_QUEUE_DEPTH). Please retry later."
+          exit 1
+        fi
+
+        echo "Run #${MY_RUN} by ${ACTOR}: waiting for queue slot (max $MAX_CONCURRENT concurrent, $MAX_PER_ACTOR per actor)..."
+
+        while true; do
+          ACTIVE=$(kubectl get jobs -l "app=ci-sglang,ci-task=$TASK_LABEL" -o json | \
+            jq '[.items[] | select(
+              (.status.conditions // [] | map(select(.type == "Complete" or .type == "Failed")) | length) == 0
+            )] | length')
+          MY_ACTIVE=$(kubectl get jobs -l "app=ci-sglang,ci-task=$TASK_LABEL,ci-actor=$ACTOR_SAFE" -o json | \
+            jq '[.items[] | select(
+              (.status.conditions // [] | map(select(.type == "Complete" or .type == "Failed")) | length) == 0
+            )] | length')
+
+          echo "--- Queue status ($(date -u +%H:%M:%S)) ---"
+          echo "  K8s active jobs: $ACTIVE/$MAX_CONCURRENT"
+          echo "  Your active jobs: $MY_ACTIVE/$MAX_PER_ACTOR ($ACTOR)"
+          echo "---"
+
+          if [ "$ACTIVE" -lt "$MAX_CONCURRENT" ] && [ "$MY_ACTIVE" -lt "$MAX_PER_ACTOR" ]; then
+            echo "Queue slot available. Proceeding!"
+            break
+          fi
+
+          if [ "$MY_ACTIVE" -ge "$MAX_PER_ACTOR" ]; then
+            echo "Waiting: you ($ACTOR) already have $MY_ACTIVE/$MAX_PER_ACTOR job(s) running."
+          else
+            echo "Waiting: queue full ($ACTIVE/$MAX_CONCURRENT active)."
+          fi
+          sleep 30
+        done
+
+    - name: Create K8s secret
+      run: |
+        kubectl create secret generic "${{ steps.config.outputs.job_name }}-token" \
+          --from-literal=token="${{ github.token }}" \
+          --dry-run=client -o yaml | kubectl apply -f -
+        kubectl label secret "${{ steps.config.outputs.job_name }}-token" \
+          app=ci-sglang ci-task=accuracy --overwrite
+
+    - name: Deploy job
+      run: |
+        export JOB_NAME="${{ steps.config.outputs.job_name }}"
+        export BRANCH="${{ inputs.branch }}"
+        export MODEL_PATH="${{ inputs.model_path }}"
+        export TP_SIZE="${{ inputs.tp_size }}"
+        export SERVER_ARGS="${{ inputs.server_args }}"
+        export TASK_COMMAND="${{ steps.config.outputs.task_command }}"
+        export TASK_TYPE="accuracy"
+        export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
+        export ACTIVE_DEADLINE="10800"
+        export EXTRA_DEPS="evalscope==0.17.1"
+
+        if [ "${{ inputs.topology }}" = "16chip" ]; then
+          export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
+          envsubst < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
+        else
+          envsubst < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
+        fi
+
+    - name: Wait for pods
+      run: |
+        echo "Waiting for pods to start..."
+        for i in $(seq 1 60); do
+          RUNNING=$(kubectl get pods -l job-name=${{ steps.config.outputs.job_name }} \
+            --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+          EXPECTED=1
+          if [ "${{ inputs.topology }}" = "16chip" ]; then
+            EXPECTED=4
+          fi
+          if [ "$RUNNING" -ge "$EXPECTED" ]; then
+            echo "All $EXPECTED pods are running"
+            break
+          fi
+          echo "  Running: $RUNNING / $EXPECTED"
+          sleep 10
+        done
+
+    - name: Re-authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Re-get GKE credentials
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Stream logs
+      run: |
+        kubectl logs -f "job/${{ steps.config.outputs.job_name }}" \
+          -c sglang-tpu --tail=1000 || true
+
+    - name: Re-authenticate to GCP (post-logs)
+      if: always()
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Re-get GKE credentials (post-logs)
+      if: always()
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Wait for completion
+      run: |
+        kubectl wait --for=condition=complete "job/${{ steps.config.outputs.job_name }}" \
+          --timeout=600s 2>/dev/null && echo "JOB SUCCEEDED" || {
+          kubectl wait --for=condition=failed "job/${{ steps.config.outputs.job_name }}" \
+            --timeout=10s 2>/dev/null && echo "JOB FAILED" && exit 1
+          echo "JOB TIMED OUT" && exit 1
+        }
+
+    - name: Cleanup
+      if: always()
+      run: |
+        kubectl delete job "${{ steps.config.outputs.job_name }}" --ignore-not-found
+        kubectl delete service "${{ steps.config.outputs.job_name }}-headless-svc" --ignore-not-found
+        kubectl delete secret "${{ steps.config.outputs.job_name }}-token" --ignore-not-found

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -1,0 +1,289 @@
+name: Benchmark (GKE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to benchmark"
+        required: true
+        default: "epic/mimo-v2-flash"
+      model_path:
+        description: "Model path (HuggingFace ID or /models/...)"
+        required: true
+        default: "XiaomiMiMo/MiMo-V2-Flash"
+      topology:
+        description: "TPU topology"
+        required: true
+        type: choice
+        options:
+          - "4chip"
+          - "16chip"
+        default: "4chip"
+      tp_size:
+        description: "Tensor parallel size"
+        required: true
+        default: "4"
+      backend:
+        description: "Benchmark backend"
+        required: true
+        default: "sgl-jax"
+      dataset_name:
+        description: "Dataset name"
+        required: true
+        default: "random"
+      random_input_len:
+        description: "Random input length"
+        required: true
+        default: "16384"
+      random_output_len:
+        description: "Random output length"
+        required: true
+        default: "1024"
+      random_range_ratio:
+        description: "Random range ratio"
+        required: true
+        default: "1.0"
+      request_rate:
+        description: "Request rate"
+        required: true
+        default: "100"
+      num_prompts:
+        description: "Number of prompts"
+        required: true
+        default: "256"
+      max_concurrency:
+        description: "Max concurrency"
+        required: true
+        default: "64"
+      seed:
+        description: "Random seed"
+        required: true
+        default: "12345"
+      server_args:
+        description: "Extra sglang server args (e.g. --max-seq-len 32768)"
+        required: false
+        default: ""
+      extra_bench_args:
+        description: "Extra bench_serving args (e.g. --warmup-requests 10)"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  benchmark:
+    name: "Benchmark (${{ inputs.topology }}, tp=${{ inputs.tp_size }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Get GKE credentials
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Cleanup stale resources
+      run: |
+        echo "Cleaning up completed/failed jobs..."
+        for job in $(kubectl get jobs -l app=ci-sglang,ci-task=benchmark \
+          -o jsonpath='{.items[?(@.status.conditions[*].type)].metadata.name}' 2>/dev/null); do
+          echo "Deleting finished job: $job"
+          kubectl delete job "$job" --ignore-not-found
+          kubectl delete service "${job}-headless-svc" --ignore-not-found
+          kubectl delete secret "${job}-token" --ignore-not-found
+        done
+
+    - name: Configure job
+      id: config
+      run: |
+        TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+        JOB_NAME="bench-${TIMESTAMP}-${GITHUB_RUN_NUMBER}"
+        echo "job_name=${JOB_NAME}" >> "$GITHUB_OUTPUT"
+
+        # Sanitize actor name for K8s labels
+        ACTOR_SAFE=$(echo "${{ github.actor }}" | tr '[:upper:]' '[:lower:]' \
+          | sed 's/[^a-z0-9._-]/-/g' | sed 's/^[^a-z0-9]*//' | sed 's/[^a-z0-9]*$//' | head -c 63)
+        ACTOR_SAFE="${ACTOR_SAFE:-unknown}"
+        echo "actor_safe=${ACTOR_SAFE}" >> "$GITHUB_OUTPUT"
+
+        # Build task command
+        TASK_CMD="python3 -m sgl_jax.bench_serving"
+        TASK_CMD+=" --backend ${{ inputs.backend }}"
+        TASK_CMD+=" --host 127.0.0.1 --port 30271"
+        TASK_CMD+=" --dataset-name ${{ inputs.dataset_name }}"
+        TASK_CMD+=" --random-input-len ${{ inputs.random_input_len }}"
+        TASK_CMD+=" --random-output-len ${{ inputs.random_output_len }}"
+        TASK_CMD+=" --random-range-ratio ${{ inputs.random_range_ratio }}"
+        TASK_CMD+=" --flush-cache --seed ${{ inputs.seed }}"
+        TASK_CMD+=" --request-rate ${{ inputs.request_rate }}"
+        TASK_CMD+=" --num-prompts ${{ inputs.num_prompts }}"
+        TASK_CMD+=" --max-concurrency ${{ inputs.max_concurrency }}"
+        TASK_CMD+=" ${{ inputs.extra_bench_args }}"
+        echo "task_command=${TASK_CMD}" >> "$GITHUB_OUTPUT"
+
+        # TPU coordinator address for 16chip
+        if [ "${{ inputs.topology }}" = "16chip" ]; then
+          COORD="${JOB_NAME}-0.${JOB_NAME}-headless-svc:10011"
+          echo "coordinator=${COORD}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Wait for TPU queue slot
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        MAX_CONCURRENT=4
+        MAX_PER_ACTOR=2
+        MAX_QUEUE_DEPTH=6
+        MY_RUN=${{ github.run_number }}
+        ACTOR="${{ github.actor }}"
+        ACTOR_SAFE="${{ steps.config.outputs.actor_safe }}"
+        REPO="${{ github.repository }}"
+        WORKFLOW="benchmark_gke.yml"
+        TASK_LABEL="benchmark"
+
+        WAITING=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?status=in_progress" \
+          --jq '.total_count' 2>/dev/null || echo 0)
+        if [ "$WAITING" -gt "$MAX_QUEUE_DEPTH" ]; then
+          echo "::error::Queue depth exceeded ($WAITING > $MAX_QUEUE_DEPTH). Please retry later."
+          exit 1
+        fi
+
+        echo "Run #${MY_RUN} by ${ACTOR}: waiting for queue slot (max $MAX_CONCURRENT concurrent, $MAX_PER_ACTOR per actor)..."
+
+        while true; do
+          ACTIVE=$(kubectl get jobs -l "app=ci-sglang,ci-task=$TASK_LABEL" -o json | \
+            jq '[.items[] | select(
+              (.status.conditions // [] | map(select(.type == "Complete" or .type == "Failed")) | length) == 0
+            )] | length')
+          MY_ACTIVE=$(kubectl get jobs -l "app=ci-sglang,ci-task=$TASK_LABEL,ci-actor=$ACTOR_SAFE" -o json | \
+            jq '[.items[] | select(
+              (.status.conditions // [] | map(select(.type == "Complete" or .type == "Failed")) | length) == 0
+            )] | length')
+
+          echo "--- Queue status ($(date -u +%H:%M:%S)) ---"
+          echo "  K8s active jobs: $ACTIVE/$MAX_CONCURRENT"
+          echo "  Your active jobs: $MY_ACTIVE/$MAX_PER_ACTOR ($ACTOR)"
+          echo "---"
+
+          if [ "$ACTIVE" -lt "$MAX_CONCURRENT" ] && [ "$MY_ACTIVE" -lt "$MAX_PER_ACTOR" ]; then
+            echo "Queue slot available. Proceeding!"
+            break
+          fi
+
+          if [ "$MY_ACTIVE" -ge "$MAX_PER_ACTOR" ]; then
+            echo "Waiting: you ($ACTOR) already have $MY_ACTIVE/$MAX_PER_ACTOR job(s) running."
+          else
+            echo "Waiting: queue full ($ACTIVE/$MAX_CONCURRENT active)."
+          fi
+          sleep 30
+        done
+
+    - name: Create K8s secret
+      run: |
+        kubectl create secret generic "${{ steps.config.outputs.job_name }}-token" \
+          --from-literal=token="${{ github.token }}" \
+          --dry-run=client -o yaml | kubectl apply -f -
+        kubectl label secret "${{ steps.config.outputs.job_name }}-token" \
+          app=ci-sglang ci-task=benchmark --overwrite
+
+    - name: Deploy job
+      run: |
+        export JOB_NAME="${{ steps.config.outputs.job_name }}"
+        export BRANCH="${{ inputs.branch }}"
+        export MODEL_PATH="${{ inputs.model_path }}"
+        export TP_SIZE="${{ inputs.tp_size }}"
+        export SERVER_ARGS="${{ inputs.server_args }}"
+        export TASK_COMMAND="${{ steps.config.outputs.task_command }}"
+        export TASK_TYPE="benchmark"
+        export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
+        export ACTIVE_DEADLINE="7200"
+        export EXTRA_DEPS=""
+
+        if [ "${{ inputs.topology }}" = "16chip" ]; then
+          export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
+          envsubst < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
+        else
+          envsubst < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
+        fi
+
+    - name: Wait for pods
+      run: |
+        echo "Waiting for pods to start..."
+        for i in $(seq 1 60); do
+          RUNNING=$(kubectl get pods -l job-name=${{ steps.config.outputs.job_name }} \
+            --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+          EXPECTED=1
+          if [ "${{ inputs.topology }}" = "16chip" ]; then
+            EXPECTED=4
+          fi
+          if [ "$RUNNING" -ge "$EXPECTED" ]; then
+            echo "All $EXPECTED pods are running"
+            break
+          fi
+          echo "  Running: $RUNNING / $EXPECTED"
+          sleep 10
+        done
+
+    # Re-authenticate before long-running log stream
+    - name: Re-authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Re-get GKE credentials
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Stream logs
+      run: |
+        # Stream from coordinator pod (index 0)
+        kubectl logs -f "job/${{ steps.config.outputs.job_name }}" \
+          -c sglang-tpu --tail=1000 || true
+
+    # Re-authenticate after log stream
+    - name: Re-authenticate to GCP (post-logs)
+      if: always()
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Re-get GKE credentials (post-logs)
+      if: always()
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Wait for completion
+      run: |
+        kubectl wait --for=condition=complete "job/${{ steps.config.outputs.job_name }}" \
+          --timeout=600s 2>/dev/null && echo "JOB SUCCEEDED" || {
+          kubectl wait --for=condition=failed "job/${{ steps.config.outputs.job_name }}" \
+            --timeout=10s 2>/dev/null && echo "JOB FAILED" && exit 1
+          echo "JOB TIMED OUT" && exit 1
+        }
+
+    - name: Cleanup
+      if: always()
+      run: |
+        kubectl delete job "${{ steps.config.outputs.job_name }}" --ignore-not-found
+        kubectl delete service "${{ steps.config.outputs.job_name }}-headless-svc" --ignore-not-found
+        kubectl delete secret "${{ steps.config.outputs.job_name }}-token" --ignore-not-found

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -1,0 +1,286 @@
+name: Profiling (GKE)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Branch to profile"
+        required: true
+        default: "epic/mimo-v2-flash"
+      model_path:
+        description: "Model path (HuggingFace ID or /models/...)"
+        required: true
+        default: "XiaomiMiMo/MiMo-V2-Flash"
+      topology:
+        description: "TPU topology"
+        required: true
+        type: choice
+        options:
+          - "4chip"
+          - "16chip"
+        default: "4chip"
+      tp_size:
+        description: "Tensor parallel size"
+        required: true
+        default: "4"
+      num_steps:
+        description: "Number of steps to profile"
+        required: true
+        default: "5"
+      profile_output_dir:
+        description: "GCS output dir for profile traces"
+        required: true
+        default: "gs://inference-model-storage-poc-tpu/profiling/sglang-jax"
+      num_prompts:
+        description: "Number of prompts for traffic generation"
+        required: true
+        default: "32"
+      random_input_len:
+        description: "Input length for traffic generation"
+        required: true
+        default: "512"
+      random_output_len:
+        description: "Output length for traffic generation"
+        required: true
+        default: "128"
+      server_args:
+        description: "Extra sglang server args"
+        required: false
+        default: ""
+
+permissions:
+  actions: read
+  contents: read
+  id-token: write
+
+jobs:
+  profiling:
+    name: "Profiling (${{ inputs.topology }}, tp=${{ inputs.tp_size }})"
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.branch }}
+
+    - name: Authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Get GKE credentials
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Cleanup stale resources
+      run: |
+        for job in $(kubectl get jobs -l app=ci-sglang,ci-task=profiling \
+          -o jsonpath='{.items[?(@.status.conditions[*].type)].metadata.name}' 2>/dev/null); do
+          echo "Deleting finished job: $job"
+          kubectl delete job "$job" --ignore-not-found
+          kubectl delete service "${job}-headless-svc" --ignore-not-found
+          kubectl delete secret "${job}-token" --ignore-not-found
+        done
+
+    - name: Configure job
+      id: config
+      run: |
+        TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+        JOB_NAME="prof-${TIMESTAMP}-${GITHUB_RUN_NUMBER}"
+        echo "job_name=${JOB_NAME}" >> "$GITHUB_OUTPUT"
+
+        # Sanitize actor name for K8s labels
+        ACTOR_SAFE=$(echo "${{ github.actor }}" | tr '[:upper:]' '[:lower:]' \
+          | sed 's/[^a-z0-9._-]/-/g' | sed 's/^[^a-z0-9]*//' | sed 's/[^a-z0-9]*$//' | head -c 63)
+        ACTOR_SAFE="${ACTOR_SAFE:-unknown}"
+        echo "actor_safe=${ACTOR_SAFE}" >> "$GITHUB_OUTPUT"
+
+        PROFILE_DIR="${{ inputs.profile_output_dir }}/${JOB_NAME}"
+        echo "profile_dir=${PROFILE_DIR}" >> "$GITHUB_OUTPUT"
+
+        # Build task command:
+        # 1. Trigger profiling (async, waits for num_steps forward passes)
+        # 2. Simultaneously send traffic to generate those forward passes
+        # 3. Print the output path
+        TASK_CMD='echo "=== Starting profiling ===" '
+        TASK_CMD+="&& curl -sf -X POST 'http://127.0.0.1:30271/start_profile'"
+        TASK_CMD+=" -H 'Content-Type: application/json'"
+        TASK_CMD+=" -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${{ inputs.num_steps }}}' &"
+        TASK_CMD+=" PROFILE_PID=\$!"
+        TASK_CMD+=" && sleep 5"
+        TASK_CMD+=" && python3 -m sgl_jax.bench_serving"
+        TASK_CMD+=" --backend sgl-jax --host 127.0.0.1 --port 30271"
+        TASK_CMD+=" --dataset-name random"
+        TASK_CMD+=" --random-input-len ${{ inputs.random_input_len }}"
+        TASK_CMD+=" --random-output-len ${{ inputs.random_output_len }}"
+        TASK_CMD+=" --random-range-ratio 1.0"
+        TASK_CMD+=" --num-prompts ${{ inputs.num_prompts }}"
+        TASK_CMD+=" --warmup-requests 0"
+        TASK_CMD+=" && wait \$PROFILE_PID"
+        TASK_CMD+=" && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
+        echo "task_command=${TASK_CMD}" >> "$GITHUB_OUTPUT"
+
+        if [ "${{ inputs.topology }}" = "16chip" ]; then
+          COORD="${JOB_NAME}-0.${JOB_NAME}-headless-svc:10011"
+          echo "coordinator=${COORD}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Wait for TPU queue slot
+      env:
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        MAX_CONCURRENT=4
+        MAX_PER_ACTOR=2
+        MAX_QUEUE_DEPTH=6
+        MY_RUN=${{ github.run_number }}
+        ACTOR="${{ github.actor }}"
+        ACTOR_SAFE="${{ steps.config.outputs.actor_safe }}"
+        REPO="${{ github.repository }}"
+        WORKFLOW="profiling_gke.yml"
+        TASK_LABEL="profiling"
+
+        WAITING=$(gh api "repos/${REPO}/actions/workflows/${WORKFLOW}/runs?status=in_progress" \
+          --jq '.total_count' 2>/dev/null || echo 0)
+        if [ "$WAITING" -gt "$MAX_QUEUE_DEPTH" ]; then
+          echo "::error::Queue depth exceeded ($WAITING > $MAX_QUEUE_DEPTH). Please retry later."
+          exit 1
+        fi
+
+        echo "Run #${MY_RUN} by ${ACTOR}: waiting for queue slot (max $MAX_CONCURRENT concurrent, $MAX_PER_ACTOR per actor)..."
+
+        while true; do
+          ACTIVE=$(kubectl get jobs -l "app=ci-sglang,ci-task=$TASK_LABEL" -o json | \
+            jq '[.items[] | select(
+              (.status.conditions // [] | map(select(.type == "Complete" or .type == "Failed")) | length) == 0
+            )] | length')
+          MY_ACTIVE=$(kubectl get jobs -l "app=ci-sglang,ci-task=$TASK_LABEL,ci-actor=$ACTOR_SAFE" -o json | \
+            jq '[.items[] | select(
+              (.status.conditions // [] | map(select(.type == "Complete" or .type == "Failed")) | length) == 0
+            )] | length')
+
+          echo "--- Queue status ($(date -u +%H:%M:%S)) ---"
+          echo "  K8s active jobs: $ACTIVE/$MAX_CONCURRENT"
+          echo "  Your active jobs: $MY_ACTIVE/$MAX_PER_ACTOR ($ACTOR)"
+          echo "---"
+
+          if [ "$ACTIVE" -lt "$MAX_CONCURRENT" ] && [ "$MY_ACTIVE" -lt "$MAX_PER_ACTOR" ]; then
+            echo "Queue slot available. Proceeding!"
+            break
+          fi
+
+          if [ "$MY_ACTIVE" -ge "$MAX_PER_ACTOR" ]; then
+            echo "Waiting: you ($ACTOR) already have $MY_ACTIVE/$MAX_PER_ACTOR job(s) running."
+          else
+            echo "Waiting: queue full ($ACTIVE/$MAX_CONCURRENT active)."
+          fi
+          sleep 30
+        done
+
+    - name: Create K8s secret
+      run: |
+        kubectl create secret generic "${{ steps.config.outputs.job_name }}-token" \
+          --from-literal=token="${{ github.token }}" \
+          --dry-run=client -o yaml | kubectl apply -f -
+        kubectl label secret "${{ steps.config.outputs.job_name }}-token" \
+          app=ci-sglang ci-task=profiling --overwrite
+
+    - name: Deploy job
+      run: |
+        export JOB_NAME="${{ steps.config.outputs.job_name }}"
+        export BRANCH="${{ inputs.branch }}"
+        export MODEL_PATH="${{ inputs.model_path }}"
+        export TP_SIZE="${{ inputs.tp_size }}"
+        export SERVER_ARGS="${{ inputs.server_args }}"
+        export TASK_COMMAND="${{ steps.config.outputs.task_command }}"
+        export TASK_TYPE="profiling"
+        export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
+        export ACTIVE_DEADLINE="7200"
+        export EXTRA_DEPS=""
+
+        if [ "${{ inputs.topology }}" = "16chip" ]; then
+          export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
+          envsubst < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
+        else
+          envsubst < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
+        fi
+
+    - name: Wait for pods
+      run: |
+        echo "Waiting for pods to start..."
+        for i in $(seq 1 60); do
+          RUNNING=$(kubectl get pods -l job-name=${{ steps.config.outputs.job_name }} \
+            --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l)
+          EXPECTED=1
+          if [ "${{ inputs.topology }}" = "16chip" ]; then
+            EXPECTED=4
+          fi
+          if [ "$RUNNING" -ge "$EXPECTED" ]; then
+            echo "All $EXPECTED pods are running"
+            break
+          fi
+          echo "  Running: $RUNNING / $EXPECTED"
+          sleep 10
+        done
+
+    - name: Re-authenticate to GCP
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Re-get GKE credentials
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Stream logs
+      run: |
+        kubectl logs -f "job/${{ steps.config.outputs.job_name }}" \
+          -c sglang-tpu --tail=1000 || true
+
+    - name: Re-authenticate to GCP (post-logs)
+      if: always()
+      uses: google-github-actions/auth@v2
+      with:
+        workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+        service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+    - name: Re-get GKE credentials (post-logs)
+      if: always()
+      uses: google-github-actions/get-gke-credentials@v2
+      with:
+        cluster_name: ${{ secrets.GKE_CLUSTER }}
+        location: ${{ secrets.GKE_LOCATION }}
+
+    - name: Wait for completion
+      run: |
+        kubectl wait --for=condition=complete "job/${{ steps.config.outputs.job_name }}" \
+          --timeout=600s 2>/dev/null && echo "JOB SUCCEEDED" || {
+          kubectl wait --for=condition=failed "job/${{ steps.config.outputs.job_name }}" \
+            --timeout=10s 2>/dev/null && echo "JOB FAILED" && exit 1
+          echo "JOB TIMED OUT" && exit 1
+        }
+
+    - name: Print profile location
+      if: success()
+      run: |
+        echo "============================================"
+        echo "Profile traces saved to:"
+        echo "  ${{ steps.config.outputs.profile_dir }}"
+        echo ""
+        echo "View with:"
+        echo "  tensorboard --logdir=${{ steps.config.outputs.profile_dir }}"
+        echo "  # or upload to https://ui.perfetto.dev/"
+        echo "============================================"
+
+    - name: Cleanup
+      if: always()
+      run: |
+        kubectl delete job "${{ steps.config.outputs.job_name }}" --ignore-not-found
+        kubectl delete service "${{ steps.config.outputs.job_name }}-headless-svc" --ignore-not-found
+        kubectl delete secret "${{ steps.config.outputs.job_name }}-token" --ignore-not-found


### PR DESCRIPTION
## Summary
- Add three `workflow_dispatch` workflows for running sglang-jax on GKE (`poc-tpu-partner / tpuv6e-256-node`)
  - **benchmark_gke.yml**: `bench_serving` with fully configurable params
  - **accuracy_gke.yml**: `evalscope eval` (pinned 0.17.1) with configurable model/datasets/generation
  - **profiling_gke.yml**: `/start_profile` HTTP API + traffic gen, traces to GCS
- Add K8s job templates supporting 4-chip (2x2) and 16-chip (4x4) topologies
- Per-workflow TPU queue management (max 4 concurrent, 2 per actor)
- WIF authentication with credential refresh for long-running jobs

## Test plan
- [ ] Merge to main so `workflow_dispatch` becomes available
- [ ] Trigger benchmark workflow with minimal config to validate full pipeline
- [ ] Verify WIF auth → GKE → K8s Job → Pod → sglang server → benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Kubernetes Job templates to support running workloads on 4-chip and 16-chip TPU clusters with distributed coordination
  * Added GitHub Actions workflow for automated accuracy evaluation on Google Cloud infrastructure
  * Added GitHub Actions workflow for automated benchmarking and performance testing on Google Cloud infrastructure
  * Added GitHub Actions workflow for automated profiling and performance analysis on Google Cloud infrastructure

<!-- end of auto-generated comment: release notes by coderabbit.ai -->