### PR TITLE
fix: checkout workflow ref for K8s templates

### DIFF
--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -63,10 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-    - name: Checkout
+    - name: Checkout (workflow repo for K8s templates)
       uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.branch }}
 
     - name: Authenticate to GCP
       uses: google-github-actions/auth@v2

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -79,10 +79,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-    - name: Checkout
+    - name: Checkout (workflow repo for K8s templates)
       uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.branch }}
 
     - name: Authenticate to GCP
       uses: google-github-actions/auth@v2

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -59,10 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
-    - name: Checkout
+    - name: Checkout (workflow repo for K8s templates)
       uses: actions/checkout@v4
-      with:
-        ref: ${{ inputs.branch }}
 
     - name: Authenticate to GCP
       uses: google-github-actions/auth@v2


### PR DESCRIPTION
## Summary
- Fix Deploy job failure: `.github/ci/sglang-4chip-job.yaml: No such file or directory`
- Checkout defaults to workflow's ref (main) instead of `inputs.branch`, so `envsubst` can find K8s templates
- The user's branch is only cloned inside the pod via `git clone --branch`

## Context
First run of #251 failed at Deploy step because checkout was pointing at `exp/scatter-optimization` which doesn't have `.github/ci/` files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations for improved clarity in step naming and standardized checkout behavior across accuracy, benchmark, and profiling pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->