### PR TITLE
feat: GKE CI workflows for benchmark, accuracy, profiling

### DIFF
--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -1,9 +1,9 @@
 # CI sglang-jax Job (16 chips) - K8s Manifests
 # 4 pods x 4 TPU chips = 16 chips, topology 4x4
 # Rendered by envsubst with:
-#   $JOB_NAME $BRANCH $MODEL_PATH $TP_SIZE $SERVER_ARGS
-#   $TASK_COMMAND $GITHUB_ACTOR $ACTIVE_DEADLINE
-#   $TPU_COORDINATOR_ADDRESS
+#   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND
+#   $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE
+#   $TPU_COORDINATOR_ADDRESS $EXTRA_DEPS
 ---
 # Headless Service for TPU pod DNS resolution (required for JAX multi-host)
 apiVersion: v1
@@ -70,12 +70,9 @@ spec:
           cd /root/sglang-jax
 
           # 2. Setup Python environment
-          mkdir -p /tmp/ramdisk/logs
-          export UV_CACHE_DIR="/tmp/ramdisk/uv_cache"
-          export TMPDIR="/tmp/ramdisk"
           pip install uv
-          uv venv /tmp/ramdisk/venv
-          source /tmp/ramdisk/venv/bin/activate
+          uv venv /tmp/venv
+          source /tmp/venv/bin/activate
           uv pip install pip
           uv pip install -e "python[tpu]"
 
@@ -150,12 +147,8 @@ spec:
             secretKeyRef:
               name: ${JOB_NAME}-token
               key: token
-        - name: PIP_CACHE_DIR
-          value: /tmp/ramdisk/.cache/pip
         - name: JAX_COMPILATION_CACHE_DIR
           value: /tmp/jit_cache
-        - name: HF_HOME
-          value: /tmp/ramdisk/huggingface
         resources:
           limits:
             google.com/tpu: "4"
@@ -165,12 +158,10 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /models
-          name: gcs-fuse-csi-ephemeral
-        - mountPath: /tmp/ramdisk
-          name: tmpfs
+        - mountPath: /inference-models
+          name: model-storage
         - mountPath: /dev/shm
-          name: dshm
+          name: dev-shm
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
         cloud.google.com/gke-tpu-topology: "4x4"
@@ -181,14 +172,10 @@ spec:
       volumes:
       - emptyDir:
           medium: Memory
-          sizeLimit: 200Gi
-        name: tmpfs
-      - emptyDir:
-          medium: Memory
         name: gke-gcsfuse-cache
-      - name: gcs-fuse-csi-ephemeral
+      - name: model-storage
         persistentVolumeClaim:
           claimName: inference-model-storage-poc-tpu-hns-pvc
-      - name: dshm
+      - name: dev-shm
         emptyDir:
           medium: Memory

--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -94,16 +94,12 @@ spec:
           # 5. Start sglang server
           #    - Node 0 runs full stack (HTTP + scheduler)
           #    - Nodes 1-3 run scheduler only
-          python3 -m sgl_jax.launch_server \
-            --model-path "${MODEL_PATH}" \
+          python -u -m sgl_jax.launch_server \
             --host 0.0.0.0 \
             --port 30271 \
-            --tp-size ${TP_SIZE} \
-            --device tpu \
-            --trust-remote-code \
-            --dist-init-addr "${COORDINATOR_ADDR}" \
             --nnodes ${NNODES} \
             --node-rank ${NODE_RANK} \
+            --dist-init-addr "${COORDINATOR_ADDR}" \
             ${SERVER_ARGS} &
           SERVER_PID=$!
 
@@ -141,10 +137,6 @@ spec:
             wait $SERVER_PID
           fi
         env:
-        - name: MODEL_PATH
-          value: "${MODEL_PATH}"
-        - name: TP_SIZE
-          value: "${TP_SIZE}"
         - name: SERVER_ARGS
           value: "${SERVER_ARGS}"
         - name: EXTRA_DEPS

--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -1,7 +1,7 @@
 # CI sglang-jax Job (16 chips) - K8s Manifests
 # 4 pods x 4 TPU chips = 16 chips, topology 4x4
 # Rendered by envsubst with:
-#   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND
+#   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64
 #   $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE
 #   $TPU_COORDINATOR_ADDRESS $EXTRA_DEPS
 #   $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY
@@ -69,7 +69,7 @@ spec:
             '    "branch": os.environ.get("BRANCH", ""),' \
             '    "topology": os.environ.get("TOPOLOGY", ""),' \
             '    "server_args": os.environ.get("SERVER_ARGS", ""),' \
-            '    "task_command": os.environ.get("TASK_COMMAND", ""),' \
+            '    "task_command": os.environ.get("TASK_COMMAND_B64", ""),' \
             '    "task_type": os.environ.get("TASK_TYPE", ""),' \
             '    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",' \
             '    "exit_code": int(os.environ.get("TASK_EXIT_VAL", "-1"))' \
@@ -139,9 +139,11 @@ spec:
               exit 1
             fi
 
-            # Run the task command and capture output
+            # Decode and run the task command
+            TASK_CMD=$(echo "$TASK_COMMAND_B64" | base64 -d)
+            echo "Running: $TASK_CMD"
             set +e
-            eval "${TASK_COMMAND}" 2>&1 | tee /tmp/task_output.txt
+            eval "$TASK_CMD" 2>&1 | tee /tmp/task_output.txt
             TASK_EXIT=${PIPESTATUS[0]}
             set -e
 
@@ -168,8 +170,8 @@ spec:
           value: "${SERVER_ARGS}"
         - name: EXTRA_DEPS
           value: "${EXTRA_DEPS}"
-        - name: TASK_COMMAND
-          value: "${TASK_COMMAND}"
+        - name: TASK_COMMAND_B64
+          value: "${TASK_COMMAND_B64}"
         - name: TASK_TYPE
           value: "${TASK_TYPE}"
         - name: BRANCH

--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -62,6 +62,23 @@ spec:
         - |
           set -ex
 
+          # 0. Write metadata save script
+          printf '%s\n' 'import json, os, datetime' \
+            'meta = {' \
+            '    "run_number": os.environ.get("GITHUB_RUN_NUMBER", ""),' \
+            '    "branch": os.environ.get("BRANCH", ""),' \
+            '    "topology": os.environ.get("TOPOLOGY", ""),' \
+            '    "server_args": os.environ.get("SERVER_ARGS", ""),' \
+            '    "task_command": os.environ.get("TASK_COMMAND", ""),' \
+            '    "task_type": os.environ.get("TASK_TYPE", ""),' \
+            '    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",' \
+            '    "exit_code": int(os.environ.get("TASK_EXIT_VAL", "-1"))' \
+            '}' \
+            'with open(os.environ["RESULTS_PATH"] + "/metadata.json", "w") as f:' \
+            '    json.dump(meta, f, indent=2)' \
+            'print("Results saved to: " + os.environ["RESULTS_PATH"])' \
+            > /tmp/save_metadata.py
+
           # 1. Clone branch
           set +x
           git clone --depth=1 --branch="${BRANCH}" \
@@ -132,22 +149,8 @@ spec:
             if [ -n "${RESULTS_PATH}" ]; then
               mkdir -p "${RESULTS_PATH}"
               cp /tmp/task_output.txt "${RESULTS_PATH}/output.txt"
-              TASK_EXIT_VAL=$TASK_EXIT python3 -c "
-            import json, os, datetime
-            meta = {
-                'run_number': os.environ.get('GITHUB_RUN_NUMBER', ''),
-                'branch': os.environ.get('BRANCH', ''),
-                'topology': os.environ.get('TOPOLOGY', ''),
-                'server_args': os.environ.get('SERVER_ARGS', ''),
-                'task_command': os.environ.get('TASK_COMMAND', ''),
-                'task_type': os.environ.get('TASK_TYPE', ''),
-                'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
-                'exit_code': int(os.environ.get('TASK_EXIT_VAL', '-1'))
-            }
-            with open(os.environ['RESULTS_PATH'] + '/metadata.json', 'w') as f:
-                json.dump(meta, f, indent=2)
-            print('Results saved to: ' + os.environ['RESULTS_PATH'])
-            "
+              export TASK_EXIT_VAL=$TASK_EXIT
+              python3 /tmp/save_metadata.py
             fi
 
             # Shutdown server

--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -4,6 +4,7 @@
 #   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND
 #   $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE
 #   $TPU_COORDINATOR_ADDRESS $EXTRA_DEPS
+#   $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY
 ---
 # Headless Service for TPU pod DNS resolution (required for JAX multi-host)
 apiVersion: v1
@@ -121,17 +122,43 @@ spec:
               exit 1
             fi
 
-            # Run the task command
-            eval "${TASK_COMMAND}"
-            TASK_EXIT=$?
+            # Run the task command and capture output
+            set +e
+            eval "${TASK_COMMAND}" 2>&1 | tee /tmp/task_output.txt
+            TASK_EXIT=${PIPESTATUS[0]}
+            set -e
+
+            # Save results to GCS if RESULTS_PATH is set
+            if [ -n "${RESULTS_PATH}" ]; then
+              mkdir -p "${RESULTS_PATH}"
+              cp /tmp/task_output.txt "${RESULTS_PATH}/output.txt"
+              TASK_EXIT_VAL=$TASK_EXIT python3 -c "
+            import json, os, datetime
+            meta = {
+                'run_number': os.environ.get('GITHUB_RUN_NUMBER', ''),
+                'branch': os.environ.get('BRANCH', ''),
+                'topology': os.environ.get('TOPOLOGY', ''),
+                'server_args': os.environ.get('SERVER_ARGS', ''),
+                'task_command': os.environ.get('TASK_COMMAND', ''),
+                'task_type': os.environ.get('TASK_TYPE', ''),
+                'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+                'exit_code': int(os.environ.get('TASK_EXIT_VAL', '-1'))
+            }
+            with open(os.environ['RESULTS_PATH'] + '/metadata.json', 'w') as f:
+                json.dump(meta, f, indent=2)
+            print('Results saved to: ' + os.environ['RESULTS_PATH'])
+            "
+            fi
 
             # Shutdown server
             kill $SERVER_PID 2>/dev/null || true
             wait $SERVER_PID 2>/dev/null || true
             exit $TASK_EXIT
           else
-            # 7. Worker: just wait for server process to finish
+            # 7. Worker: wait for server, force-exit if hung
+            set +e
             wait $SERVER_PID
+            exit 0
           fi
         env:
         - name: SERVER_ARGS
@@ -140,6 +167,16 @@ spec:
           value: "${EXTRA_DEPS}"
         - name: TASK_COMMAND
           value: "${TASK_COMMAND}"
+        - name: TASK_TYPE
+          value: "${TASK_TYPE}"
+        - name: BRANCH
+          value: "${BRANCH}"
+        - name: RESULTS_PATH
+          value: "${RESULTS_PATH}"
+        - name: GITHUB_RUN_NUMBER
+          value: "${GITHUB_RUN_NUMBER}"
+        - name: TOPOLOGY
+          value: "${TOPOLOGY}"
         - name: TPU_COORDINATOR_ADDRESS
           value: "${TPU_COORDINATOR_ADDRESS}"
         - name: GITHUB_TOKEN

--- a/.github/ci/sglang-16chip-job.yaml
+++ b/.github/ci/sglang-16chip-job.yaml
@@ -155,7 +155,7 @@ spec:
         - name: JAX_COMPILATION_CACHE_DIR
           value: /tmp/jit_cache
         - name: HF_HOME
-          value: /models/huggingface
+          value: /tmp/ramdisk/huggingface
         resources:
           limits:
             google.com/tpu: "4"

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -1,8 +1,8 @@
 # CI sglang-jax Job (4 chips) - K8s Manifests
 # 1 pod x 4 TPU chips = 4 chips, topology 2x2
 # Rendered by envsubst with:
-#   $JOB_NAME $BRANCH $MODEL_PATH $TP_SIZE $SERVER_ARGS
-#   $TASK_COMMAND $GITHUB_ACTOR $ACTIVE_DEADLINE
+#   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND
+#   $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS
 ---
 # Headless Service for DNS resolution
 apiVersion: v1
@@ -61,12 +61,9 @@ spec:
           cd /root/sglang-jax
 
           # 2. Setup Python environment
-          mkdir -p /tmp/ramdisk/logs
-          export UV_CACHE_DIR="/tmp/ramdisk/uv_cache"
-          export TMPDIR="/tmp/ramdisk"
           pip install uv
-          uv venv /tmp/ramdisk/venv
-          source /tmp/ramdisk/venv/bin/activate
+          uv venv /tmp/venv
+          source /tmp/venv/bin/activate
           uv pip install pip
           uv pip install -e "python[tpu]"
 
@@ -126,12 +123,8 @@ spec:
             secretKeyRef:
               name: ${JOB_NAME}-token
               key: token
-        - name: PIP_CACHE_DIR
-          value: /tmp/ramdisk/.cache/pip
         - name: JAX_COMPILATION_CACHE_DIR
           value: /tmp/jit_cache
-        - name: HF_HOME
-          value: /tmp/ramdisk/huggingface
         resources:
           limits:
             google.com/tpu: "4"
@@ -141,12 +134,10 @@ spec:
         securityContext:
           privileged: true
         volumeMounts:
-        - mountPath: /models
-          name: gcs-fuse-csi-ephemeral
-        - mountPath: /tmp/ramdisk
-          name: tmpfs
+        - mountPath: /inference-models
+          name: model-storage
         - mountPath: /dev/shm
-          name: dshm
+          name: dev-shm
       nodeSelector:
         cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
         cloud.google.com/gke-tpu-topology: "2x2"
@@ -157,14 +148,10 @@ spec:
       volumes:
       - emptyDir:
           medium: Memory
-          sizeLimit: 200Gi
-        name: tmpfs
-      - emptyDir:
-          medium: Memory
         name: gke-gcsfuse-cache
-      - name: gcs-fuse-csi-ephemeral
+      - name: model-storage
         persistentVolumeClaim:
           claimName: inference-model-storage-poc-tpu-hns-pvc
-      - name: dshm
+      - name: dev-shm
         emptyDir:
           medium: Memory

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -1,7 +1,7 @@
 # CI sglang-jax Job (4 chips) - K8s Manifests
 # 1 pod x 4 TPU chips = 4 chips, topology 2x2
 # Rendered by envsubst with:
-#   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND
+#   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64
 #   $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS
 #   $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY
 ---
@@ -60,7 +60,7 @@ spec:
             '    "branch": os.environ.get("BRANCH", ""),' \
             '    "topology": os.environ.get("TOPOLOGY", ""),' \
             '    "server_args": os.environ.get("SERVER_ARGS", ""),' \
-            '    "task_command": os.environ.get("TASK_COMMAND", ""),' \
+            '    "task_command": os.environ.get("TASK_COMMAND_B64", ""),' \
             '    "task_type": os.environ.get("TASK_TYPE", ""),' \
             '    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",' \
             '    "exit_code": int(os.environ.get("TASK_EXIT_VAL", "-1"))' \
@@ -120,9 +120,11 @@ spec:
             exit 1
           fi
 
-          # 6. Run the task command and capture output
+          # 6. Decode and run the task command
+          TASK_CMD=$(echo "$TASK_COMMAND_B64" | base64 -d)
+          echo "Running: $TASK_CMD"
           set +e
-          eval "${TASK_COMMAND}" 2>&1 | tee /tmp/task_output.txt
+          eval "$TASK_CMD" 2>&1 | tee /tmp/task_output.txt
           TASK_EXIT=${PIPESTATUS[0]}
           set -e
 
@@ -143,8 +145,8 @@ spec:
           value: "${SERVER_ARGS}"
         - name: EXTRA_DEPS
           value: "${EXTRA_DEPS}"
-        - name: TASK_COMMAND
-          value: "${TASK_COMMAND}"
+        - name: TASK_COMMAND_B64
+          value: "${TASK_COMMAND_B64}"
         - name: TASK_TYPE
           value: "${TASK_TYPE}"
         - name: BRANCH

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -76,16 +76,12 @@ spec:
           fi
 
           # 4. Start sglang server in background
-          python3 -m sgl_jax.launch_server \
-            --model-path "${MODEL_PATH}" \
+          python -u -m sgl_jax.launch_server \
             --host 0.0.0.0 \
             --port 30271 \
-            --tp-size ${TP_SIZE} \
-            --device tpu \
-            --trust-remote-code \
-            --dist-init-addr 0.0.0.0:10011 \
             --nnodes 1 \
             --node-rank 0 \
+            --dist-init-addr 0.0.0.0:10011 \
             ${SERVER_ARGS} &
           SERVER_PID=$!
 
@@ -119,10 +115,6 @@ spec:
 
           exit $TASK_EXIT
         env:
-        - name: MODEL_PATH
-          value: "${MODEL_PATH}"
-        - name: TP_SIZE
-          value: "${TP_SIZE}"
         - name: SERVER_ARGS
           value: "${SERVER_ARGS}"
         - name: EXTRA_DEPS

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -131,7 +131,7 @@ spec:
         - name: JAX_COMPILATION_CACHE_DIR
           value: /tmp/jit_cache
         - name: HF_HOME
-          value: /models/huggingface
+          value: /tmp/ramdisk/huggingface
         resources:
           limits:
             google.com/tpu: "4"

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -53,6 +53,23 @@ spec:
         - |
           set -ex
 
+          # 0. Write metadata save script
+          printf '%s\n' 'import json, os, datetime' \
+            'meta = {' \
+            '    "run_number": os.environ.get("GITHUB_RUN_NUMBER", ""),' \
+            '    "branch": os.environ.get("BRANCH", ""),' \
+            '    "topology": os.environ.get("TOPOLOGY", ""),' \
+            '    "server_args": os.environ.get("SERVER_ARGS", ""),' \
+            '    "task_command": os.environ.get("TASK_COMMAND", ""),' \
+            '    "task_type": os.environ.get("TASK_TYPE", ""),' \
+            '    "timestamp": datetime.datetime.utcnow().isoformat() + "Z",' \
+            '    "exit_code": int(os.environ.get("TASK_EXIT_VAL", "-1"))' \
+            '}' \
+            'with open(os.environ["RESULTS_PATH"] + "/metadata.json", "w") as f:' \
+            '    json.dump(meta, f, indent=2)' \
+            'print("Results saved to: " + os.environ["RESULTS_PATH"])' \
+            > /tmp/save_metadata.py
+
           # 1. Clone branch
           set +x
           git clone --depth=1 --branch="${BRANCH}" \
@@ -113,22 +130,7 @@ spec:
           if [ -n "${RESULTS_PATH}" ]; then
             mkdir -p "${RESULTS_PATH}"
             cp /tmp/task_output.txt "${RESULTS_PATH}/output.txt"
-            TASK_EXIT_VAL=$TASK_EXIT python3 -c "
-          import json, os, datetime
-          meta = {
-              'run_number': os.environ.get('GITHUB_RUN_NUMBER', ''),
-              'branch': os.environ.get('BRANCH', ''),
-              'topology': os.environ.get('TOPOLOGY', ''),
-              'server_args': os.environ.get('SERVER_ARGS', ''),
-              'task_command': os.environ.get('TASK_COMMAND', ''),
-              'task_type': os.environ.get('TASK_TYPE', ''),
-              'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
-              'exit_code': int(os.environ.get('TASK_EXIT_VAL', '-1'))
-          }
-          with open(os.environ['RESULTS_PATH'] + '/metadata.json', 'w') as f:
-              json.dump(meta, f, indent=2)
-          print('Results saved to: ' + os.environ['RESULTS_PATH'])
-          "
+            TASK_EXIT_VAL=$TASK_EXIT python3 /tmp/save_metadata.py
           fi
 
           # 8. Shutdown server

--- a/.github/ci/sglang-4chip-job.yaml
+++ b/.github/ci/sglang-4chip-job.yaml
@@ -3,6 +3,7 @@
 # Rendered by envsubst with:
 #   $JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND
 #   $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS
+#   $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY
 ---
 # Headless Service for DNS resolution
 apiVersion: v1
@@ -102,11 +103,35 @@ spec:
             exit 1
           fi
 
-          # 6. Run the task command (benchmark / eval / profiling)
-          eval "${TASK_COMMAND}"
-          TASK_EXIT=$?
+          # 6. Run the task command and capture output
+          set +e
+          eval "${TASK_COMMAND}" 2>&1 | tee /tmp/task_output.txt
+          TASK_EXIT=${PIPESTATUS[0]}
+          set -e
 
-          # 7. Shutdown server
+          # 7. Save results to GCS if RESULTS_PATH is set
+          if [ -n "${RESULTS_PATH}" ]; then
+            mkdir -p "${RESULTS_PATH}"
+            cp /tmp/task_output.txt "${RESULTS_PATH}/output.txt"
+            TASK_EXIT_VAL=$TASK_EXIT python3 -c "
+          import json, os, datetime
+          meta = {
+              'run_number': os.environ.get('GITHUB_RUN_NUMBER', ''),
+              'branch': os.environ.get('BRANCH', ''),
+              'topology': os.environ.get('TOPOLOGY', ''),
+              'server_args': os.environ.get('SERVER_ARGS', ''),
+              'task_command': os.environ.get('TASK_COMMAND', ''),
+              'task_type': os.environ.get('TASK_TYPE', ''),
+              'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
+              'exit_code': int(os.environ.get('TASK_EXIT_VAL', '-1'))
+          }
+          with open(os.environ['RESULTS_PATH'] + '/metadata.json', 'w') as f:
+              json.dump(meta, f, indent=2)
+          print('Results saved to: ' + os.environ['RESULTS_PATH'])
+          "
+          fi
+
+          # 8. Shutdown server
           kill $SERVER_PID 2>/dev/null || true
           wait $SERVER_PID 2>/dev/null || true
 
@@ -118,6 +143,16 @@ spec:
           value: "${EXTRA_DEPS}"
         - name: TASK_COMMAND
           value: "${TASK_COMMAND}"
+        - name: TASK_TYPE
+          value: "${TASK_TYPE}"
+        - name: BRANCH
+          value: "${BRANCH}"
+        - name: RESULTS_PATH
+          value: "${RESULTS_PATH}"
+        - name: GITHUB_RUN_NUMBER
+          value: "${GITHUB_RUN_NUMBER}"
+        - name: TOPOLOGY
+          value: "${TOPOLOGY}"
         - name: GITHUB_TOKEN
           valueFrom:
             secretKeyRef:

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -160,11 +160,13 @@ jobs:
           app=ci-sglang ci-task=accuracy --overwrite
 
     - name: Deploy job
+      env:
+        EVAL_ARGS: ${{ inputs.eval_args }}
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
         export SERVER_ARGS="${{ inputs.server_args }}"
-        export TASK_COMMAND="evalscope eval ${{ inputs.eval_args }}"
+        export TASK_COMMAND_B64=$(printf '%s' "evalscope eval ${EVAL_ARGS}" | base64 -w0)
         export TASK_TYPE="accuracy"
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="10800"
@@ -173,7 +175,7 @@ jobs:
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 
-        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
           envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -6,51 +6,44 @@ on:
       branch:
         description: "Branch to test"
         required: true
-        default: "epic/mimo-v2-flash"
-      model_path:
-        description: "Model path (HuggingFace ID or /models/...)"
-        required: true
-        default: "XiaomiMiMo/MiMo-V2-Flash"
+        default: "exp/scatter-optimization"
       topology:
         description: "TPU topology"
         required: true
         type: choice
         options:
-          - "4chip"
           - "16chip"
-        default: "4chip"
-      tp_size:
-        description: "Tensor parallel size"
-        required: true
-        default: "4"
-      datasets:
-        description: "Evaluation datasets (comma-separated)"
-        required: true
-        default: "gsm8k"
-      eval_batch_size:
-        description: "Evaluation batch size"
-        required: true
-        default: "32"
-      temperature:
-        description: "Generation temperature"
-        required: true
-        default: "0.8"
-      top_p:
-        description: "Generation top_p"
-        required: true
-        default: "0.95"
-      max_tokens:
-        description: "Max generation tokens (0 = use default)"
-        required: false
-        default: "0"
+          - "4chip"
+        default: "16chip"
       server_args:
-        description: "Extra sglang server args (e.g. --max-seq-len 32768)"
-        required: false
-        default: ""
-      extra_eval_args:
-        description: "Extra evalscope args (e.g. --limit 100)"
-        required: false
-        default: ""
+        description: "sglang server launch args (all flags except --host/--port/--nnodes/--node-rank/--dist-init-addr)"
+        required: true
+        default: >-
+          --model-path /models/MiMo-V2-Flash
+          --trust-remote-code
+          --tp-size 16 --dp-size 4 --ep-size 16
+          --moe-backend fused
+          --page-size 256
+          --context-length 262144
+          --disable-radix-cache
+          --chunked-prefill-size 2048
+          --dtype bfloat16
+          --mem-fraction-static 0.95
+          --swa-full-tokens-ratio 0.2
+          --skip-server-warmup
+          --log-level info
+          --max-running-requests 128
+      eval_args:
+        description: "evalscope eval args (all flags)"
+        required: true
+        default: >-
+          --model XiaomiMiMo/MiMo-V2-Flash
+          --api-url http://127.0.0.1:30271/v1/chat/completions
+          --api-key EMPTY
+          --eval-type service
+          --datasets gsm8k
+          --eval-batch-size 32
+          --generation-config '{"temperature":0.8,"top_p":0.95}'
 
 permissions:
   actions: read
@@ -59,7 +52,7 @@ permissions:
 
 jobs:
   accuracy:
-    name: "Accuracy (${{ inputs.topology }}, ${{ inputs.datasets }})"
+    name: "Accuracy (${{ inputs.topology }})"
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
@@ -100,25 +93,6 @@ jobs:
           | sed 's/[^a-z0-9._-]/-/g' | sed 's/^[^a-z0-9]*//' | sed 's/[^a-z0-9]*$//' | head -c 63)
         ACTOR_SAFE="${ACTOR_SAFE:-unknown}"
         echo "actor_safe=${ACTOR_SAFE}" >> "$GITHUB_OUTPUT"
-
-        # Build generation config JSON
-        GEN_CONFIG="{\"temperature\": ${{ inputs.temperature }},\"top_p\":${{ inputs.top_p }}"
-        if [ "${{ inputs.max_tokens }}" != "0" ]; then
-          GEN_CONFIG+=",\"max_tokens\":${{ inputs.max_tokens }}"
-        fi
-        GEN_CONFIG+="}"
-
-        # Build task command
-        TASK_CMD="evalscope eval"
-        TASK_CMD+=" --model ${{ inputs.model_path }}"
-        TASK_CMD+=" --api-url http://127.0.0.1:30271/v1/chat/completions"
-        TASK_CMD+=" --api-key EMPTY"
-        TASK_CMD+=" --eval-type service"
-        TASK_CMD+=" --datasets ${{ inputs.datasets }}"
-        TASK_CMD+=" --eval-batch-size ${{ inputs.eval_batch_size }}"
-        TASK_CMD+=" --generation-config '${GEN_CONFIG}'"
-        TASK_CMD+=" ${{ inputs.extra_eval_args }}"
-        echo "task_command=${TASK_CMD}" >> "$GITHUB_OUTPUT"
 
         # TPU coordinator address for 16chip
         if [ "${{ inputs.topology }}" = "16chip" ]; then
@@ -189,10 +163,8 @@ jobs:
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
-        export MODEL_PATH="${{ inputs.model_path }}"
-        export TP_SIZE="${{ inputs.tp_size }}"
         export SERVER_ARGS="${{ inputs.server_args }}"
-        export TASK_COMMAND="${{ steps.config.outputs.task_command }}"
+        export TASK_COMMAND="evalscope eval ${{ inputs.eval_args }}"
         export TASK_TYPE="accuracy"
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="10800"

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -170,11 +170,12 @@ jobs:
         export ACTIVE_DEADLINE="10800"
         export EXTRA_DEPS="evalscope==0.17.1"
 
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
-          envsubst < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
+          envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
         else
-          envsubst < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
+          envsubst "$VARS" < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
         fi
 
     - name: Wait for pods

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -19,7 +19,7 @@ on:
         description: "sglang server launch args (all flags except --host/--port/--nnodes/--node-rank/--dist-init-addr)"
         required: true
         default: >-
-          --model-path /models/MiMo-V2-Flash
+          --model-path /inference-models/MiMo-V2-Flash
           --trust-remote-code
           --tp-size 16 --dp-size 4 --ep-size 16
           --moe-backend fused

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -169,8 +169,11 @@ jobs:
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="10800"
         export EXTRA_DEPS="evalscope==0.17.1"
+        export RESULTS_PATH=""
+        export GITHUB_RUN_NUMBER="${{ github.run_number }}"
+        export TOPOLOGY="${{ inputs.topology }}"
 
-        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS'
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
           envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
@@ -210,7 +213,9 @@ jobs:
 
     - name: Stream logs
       run: |
-        kubectl logs -f "job/${{ steps.config.outputs.job_name }}" \
+        # Stream from coordinator pod (index 0) only
+        kubectl logs -f \
+          -l job-name=${{ steps.config.outputs.job_name }},batch.kubernetes.io/job-completion-index=0 \
           -c sglang-tpu --tail=1000 || true
 
     - name: Re-authenticate to GCP (post-logs)
@@ -229,12 +234,29 @@ jobs:
 
     - name: Wait for completion
       run: |
-        kubectl wait --for=condition=complete "job/${{ steps.config.outputs.job_name }}" \
-          --timeout=600s 2>/dev/null && echo "JOB SUCCEEDED" || {
-          kubectl wait --for=condition=failed "job/${{ steps.config.outputs.job_name }}" \
-            --timeout=10s 2>/dev/null && echo "JOB FAILED" && exit 1
-          echo "JOB TIMED OUT" && exit 1
-        }
+        JOB_NAME="${{ steps.config.outputs.job_name }}"
+        TIMEOUT=600
+        ELAPSED=0
+        echo "Waiting for coordinator pod to complete (timeout ${TIMEOUT}s)..."
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+          PHASE=$(kubectl get pod \
+            -l job-name=${JOB_NAME},batch.kubernetes.io/job-completion-index=0 \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null)
+          if [ "$PHASE" = "Succeeded" ]; then
+            echo "JOB SUCCEEDED"
+            break
+          fi
+          if [ "$PHASE" = "Failed" ]; then
+            echo "JOB FAILED"
+            exit 1
+          fi
+          sleep 10
+          ELAPSED=$((ELAPSED + 10))
+        done
+        if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "JOB TIMED OUT"
+          exit 1
+        fi
 
     - name: Cleanup
       if: always()

--- a/.github/workflows/accuracy_gke.yml
+++ b/.github/workflows/accuracy_gke.yml
@@ -171,7 +171,7 @@ jobs:
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="10800"
         export EXTRA_DEPS="evalscope==0.17.1"
-        export RESULTS_PATH=""
+        export RESULTS_PATH="/inference-models/workflow/MiMo-V2-Flash/accuracy/workflow-${{ github.run_number }}"
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -174,11 +174,12 @@ jobs:
         export ACTIVE_DEADLINE="7200"
         export EXTRA_DEPS=""
 
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
-          envsubst < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
+          envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
         else
-          envsubst < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
+          envsubst "$VARS" < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
         fi
 
     - name: Wait for pods

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -6,67 +6,47 @@ on:
       branch:
         description: "Branch to benchmark"
         required: true
-        default: "epic/mimo-v2-flash"
-      model_path:
-        description: "Model path (HuggingFace ID or /models/...)"
-        required: true
-        default: "XiaomiMiMo/MiMo-V2-Flash"
+        default: "exp/scatter-optimization"
       topology:
         description: "TPU topology"
         required: true
         type: choice
         options:
-          - "4chip"
           - "16chip"
-        default: "4chip"
-      tp_size:
-        description: "Tensor parallel size"
-        required: true
-        default: "4"
-      backend:
-        description: "Benchmark backend"
-        required: true
-        default: "sgl-jax"
-      dataset_name:
-        description: "Dataset name"
-        required: true
-        default: "random"
-      random_input_len:
-        description: "Random input length"
-        required: true
-        default: "16384"
-      random_output_len:
-        description: "Random output length"
-        required: true
-        default: "1024"
-      random_range_ratio:
-        description: "Random range ratio"
-        required: true
-        default: "1.0"
-      request_rate:
-        description: "Request rate"
-        required: true
-        default: "100"
-      num_prompts:
-        description: "Number of prompts"
-        required: true
-        default: "256"
-      max_concurrency:
-        description: "Max concurrency"
-        required: true
-        default: "64"
-      seed:
-        description: "Random seed"
-        required: true
-        default: "12345"
+          - "4chip"
+        default: "16chip"
       server_args:
-        description: "Extra sglang server args (e.g. --max-seq-len 32768)"
-        required: false
-        default: ""
-      extra_bench_args:
-        description: "Extra bench_serving args (e.g. --warmup-requests 10)"
-        required: false
-        default: ""
+        description: "sglang server launch args (all flags except --host/--port/--nnodes/--node-rank/--dist-init-addr)"
+        required: true
+        default: >-
+          --model-path /models/MiMo-V2-Flash
+          --trust-remote-code
+          --tp-size 16 --dp-size 4 --ep-size 16
+          --moe-backend fused
+          --page-size 256
+          --context-length 262144
+          --disable-radix-cache
+          --chunked-prefill-size 2048
+          --dtype bfloat16
+          --mem-fraction-static 0.95
+          --swa-full-tokens-ratio 0.2
+          --skip-server-warmup
+          --log-level info
+          --max-running-requests 128
+      bench_args:
+        description: "bench_serving args (all flags)"
+        required: true
+        default: >-
+          --backend sgl-jax
+          --host 127.0.0.1 --port 30271
+          --dataset-name random
+          --random-input-len 16384
+          --random-output-len 1024
+          --random-range-ratio 1.0
+          --flush-cache --seed 12345
+          --request-rate 100
+          --num-prompts 256
+          --max-concurrency 64
 
 permissions:
   actions: read
@@ -75,7 +55,7 @@ permissions:
 
 jobs:
   benchmark:
-    name: "Benchmark (${{ inputs.topology }}, tp=${{ inputs.tp_size }})"
+    name: "Benchmark (${{ inputs.topology }})"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -117,21 +97,6 @@ jobs:
           | sed 's/[^a-z0-9._-]/-/g' | sed 's/^[^a-z0-9]*//' | sed 's/[^a-z0-9]*$//' | head -c 63)
         ACTOR_SAFE="${ACTOR_SAFE:-unknown}"
         echo "actor_safe=${ACTOR_SAFE}" >> "$GITHUB_OUTPUT"
-
-        # Build task command
-        TASK_CMD="python3 -m sgl_jax.bench_serving"
-        TASK_CMD+=" --backend ${{ inputs.backend }}"
-        TASK_CMD+=" --host 127.0.0.1 --port 30271"
-        TASK_CMD+=" --dataset-name ${{ inputs.dataset_name }}"
-        TASK_CMD+=" --random-input-len ${{ inputs.random_input_len }}"
-        TASK_CMD+=" --random-output-len ${{ inputs.random_output_len }}"
-        TASK_CMD+=" --random-range-ratio ${{ inputs.random_range_ratio }}"
-        TASK_CMD+=" --flush-cache --seed ${{ inputs.seed }}"
-        TASK_CMD+=" --request-rate ${{ inputs.request_rate }}"
-        TASK_CMD+=" --num-prompts ${{ inputs.num_prompts }}"
-        TASK_CMD+=" --max-concurrency ${{ inputs.max_concurrency }}"
-        TASK_CMD+=" ${{ inputs.extra_bench_args }}"
-        echo "task_command=${TASK_CMD}" >> "$GITHUB_OUTPUT"
 
         # TPU coordinator address for 16chip
         if [ "${{ inputs.topology }}" = "16chip" ]; then
@@ -202,10 +167,8 @@ jobs:
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
-        export MODEL_PATH="${{ inputs.model_path }}"
-        export TP_SIZE="${{ inputs.tp_size }}"
         export SERVER_ARGS="${{ inputs.server_args }}"
-        export TASK_COMMAND="${{ steps.config.outputs.task_command }}"
+        export TASK_COMMAND="python3 -m sgl_jax.bench_serving ${{ inputs.bench_args }}"
         export TASK_TYPE="benchmark"
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="7200"

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -164,11 +164,13 @@ jobs:
           app=ci-sglang ci-task=benchmark --overwrite
 
     - name: Deploy job
+      env:
+        BENCH_ARGS: ${{ inputs.bench_args }}
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
         export SERVER_ARGS="${{ inputs.server_args }}"
-        export TASK_COMMAND="python3 -m sgl_jax.bench_serving ${{ inputs.bench_args }}"
+        export TASK_COMMAND_B64=$(printf '%s' "python3 -m sgl_jax.bench_serving ${BENCH_ARGS}" | base64 -w0)
         export TASK_TYPE="benchmark"
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="7200"
@@ -177,7 +179,7 @@ jobs:
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 
-        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
           envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -19,7 +19,7 @@ on:
         description: "sglang server launch args (all flags except --host/--port/--nnodes/--node-rank/--dist-init-addr)"
         required: true
         default: >-
-          --model-path /models/MiMo-V2-Flash
+          --model-path /inference-models/MiMo-V2-Flash
           --trust-remote-code
           --tp-size 16 --dp-size 4 --ep-size 16
           --moe-backend fused

--- a/.github/workflows/benchmark_gke.yml
+++ b/.github/workflows/benchmark_gke.yml
@@ -173,8 +173,11 @@ jobs:
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="7200"
         export EXTRA_DEPS=""
+        export RESULTS_PATH="/inference-models/workflow/MiMo-V2-Flash/benchmark/workflow-${{ github.run_number }}"
+        export GITHUB_RUN_NUMBER="${{ github.run_number }}"
+        export TOPOLOGY="${{ inputs.topology }}"
 
-        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS'
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
           envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
@@ -215,8 +218,9 @@ jobs:
 
     - name: Stream logs
       run: |
-        # Stream from coordinator pod (index 0)
-        kubectl logs -f "job/${{ steps.config.outputs.job_name }}" \
+        # Stream from coordinator pod (index 0) only
+        kubectl logs -f \
+          -l job-name=${{ steps.config.outputs.job_name }},batch.kubernetes.io/job-completion-index=0 \
           -c sglang-tpu --tail=1000 || true
 
     # Re-authenticate after log stream
@@ -236,12 +240,29 @@ jobs:
 
     - name: Wait for completion
       run: |
-        kubectl wait --for=condition=complete "job/${{ steps.config.outputs.job_name }}" \
-          --timeout=600s 2>/dev/null && echo "JOB SUCCEEDED" || {
-          kubectl wait --for=condition=failed "job/${{ steps.config.outputs.job_name }}" \
-            --timeout=10s 2>/dev/null && echo "JOB FAILED" && exit 1
-          echo "JOB TIMED OUT" && exit 1
-        }
+        JOB_NAME="${{ steps.config.outputs.job_name }}"
+        TIMEOUT=600
+        ELAPSED=0
+        echo "Waiting for coordinator pod to complete (timeout ${TIMEOUT}s)..."
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+          PHASE=$(kubectl get pod \
+            -l job-name=${JOB_NAME},batch.kubernetes.io/job-completion-index=0 \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null)
+          if [ "$PHASE" = "Succeeded" ]; then
+            echo "JOB SUCCEEDED"
+            break
+          fi
+          if [ "$PHASE" = "Failed" ]; then
+            echo "JOB FAILED"
+            exit 1
+          fi
+          sleep 10
+          ELAPSED=$((ELAPSED + 10))
+        done
+        if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "JOB TIMED OUT"
+          exit 1
+        fi
 
     - name: Cleanup
       if: always()

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -54,9 +54,9 @@ on:
           --host 127.0.0.1 --port 30271
           --dataset-name random
           --random-input-len 512
-          --random-output-len 128
+          --random-output-len 32
           --random-range-ratio 1.0
-          --num-prompts 32
+          --num-prompts 8
           --warmup-requests 0
 
 permissions:

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -37,6 +37,15 @@ on:
         description: "Number of steps to profile"
         required: true
         default: "5"
+      profile_by_stage:
+        description: "Profile prefill/decode separately"
+        required: true
+        type: boolean
+        default: false
+      profile_stages:
+        description: "Stages to profile (comma-separated, e.g. prefill,decode)"
+        required: false
+        default: "prefill,decode"
       profile_output_dir:
         description: "GCS output dir for profile traces"
         required: true
@@ -176,6 +185,8 @@ jobs:
         PROFILE_DIR: ${{ steps.config.outputs.profile_dir }}
         TRAFFIC_ARGS: ${{ inputs.traffic_args }}
         NUM_STEPS: ${{ inputs.num_steps }}
+        PROFILE_BY_STAGE: ${{ inputs.profile_by_stage }}
+        PROFILE_STAGES: ${{ inputs.profile_stages }}
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
@@ -188,8 +199,17 @@ jobs:
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 
+        # Build profile JSON payload
+        PROFILE_JSON="{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}"
+        if [ "${PROFILE_BY_STAGE}" = "true" ]; then
+          # Convert comma-separated stages to JSON array: "prefill,decode" → '["prefill","decode"]'
+          STAGES_JSON=$(echo "${PROFILE_STAGES}" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip().split(',')))")
+          PROFILE_JSON="${PROFILE_JSON}, \"profile_by_stage\": true, \"profile_stages\": ${STAGES_JSON}"
+        fi
+        PROFILE_JSON="${PROFILE_JSON}}"
+
         # Task: background traffic, trigger profiling (async), poll /profile_status until idle
-        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; STATUS=\$(curl -sf 'http://127.0.0.1:30271/profile_status' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"status\"])' 2>/dev/null); echo \"  profile_status: \$STATUS\"; if [ \"\$STATUS\" = 'idle' ]; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
+        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '${PROFILE_JSON}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; STATUS=\$(curl -sf 'http://127.0.0.1:30271/profile_status' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"status\"])' 2>/dev/null); echo \"  profile_status: \$STATUS\"; if [ \"\$STATUS\" = 'idle' ]; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
         export TASK_COMMAND_B64=$(printf '%s' "$TASK_CMD" | base64 -w0)
 
         VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -6,23 +6,33 @@ on:
       branch:
         description: "Branch to profile"
         required: true
-        default: "epic/mimo-v2-flash"
-      model_path:
-        description: "Model path (HuggingFace ID or /models/...)"
-        required: true
-        default: "XiaomiMiMo/MiMo-V2-Flash"
+        default: "exp/scatter-optimization"
       topology:
         description: "TPU topology"
         required: true
         type: choice
         options:
-          - "4chip"
           - "16chip"
-        default: "4chip"
-      tp_size:
-        description: "Tensor parallel size"
+          - "4chip"
+        default: "16chip"
+      server_args:
+        description: "sglang server launch args (all flags except --host/--port/--nnodes/--node-rank/--dist-init-addr)"
         required: true
-        default: "4"
+        default: >-
+          --model-path /models/MiMo-V2-Flash
+          --trust-remote-code
+          --tp-size 16 --dp-size 4 --ep-size 16
+          --moe-backend fused
+          --page-size 256
+          --context-length 262144
+          --disable-radix-cache
+          --chunked-prefill-size 2048
+          --dtype bfloat16
+          --mem-fraction-static 0.95
+          --swa-full-tokens-ratio 0.2
+          --skip-server-warmup
+          --log-level info
+          --max-running-requests 128
       num_steps:
         description: "Number of steps to profile"
         required: true
@@ -31,22 +41,18 @@ on:
         description: "GCS output dir for profile traces"
         required: true
         default: "gs://inference-model-storage-poc-tpu/profiling/sglang-jax"
-      num_prompts:
-        description: "Number of prompts for traffic generation"
+      traffic_args:
+        description: "bench_serving args for traffic generation during profiling"
         required: true
-        default: "32"
-      random_input_len:
-        description: "Input length for traffic generation"
-        required: true
-        default: "512"
-      random_output_len:
-        description: "Output length for traffic generation"
-        required: true
-        default: "128"
-      server_args:
-        description: "Extra sglang server args"
-        required: false
-        default: ""
+        default: >-
+          --backend sgl-jax
+          --host 127.0.0.1 --port 30271
+          --dataset-name random
+          --random-input-len 512
+          --random-output-len 128
+          --random-range-ratio 1.0
+          --num-prompts 32
+          --warmup-requests 0
 
 permissions:
   actions: read
@@ -55,7 +61,7 @@ permissions:
 
 jobs:
   profiling:
-    name: "Profiling (${{ inputs.topology }}, tp=${{ inputs.tp_size }})"
+    name: "Profiling (${{ inputs.topology }})"
     runs-on: ubuntu-latest
     timeout-minutes: 120
     steps:
@@ -100,28 +106,7 @@ jobs:
         PROFILE_DIR="${{ inputs.profile_output_dir }}/${JOB_NAME}"
         echo "profile_dir=${PROFILE_DIR}" >> "$GITHUB_OUTPUT"
 
-        # Build task command:
-        # 1. Trigger profiling (async, waits for num_steps forward passes)
-        # 2. Simultaneously send traffic to generate those forward passes
-        # 3. Print the output path
-        TASK_CMD='echo "=== Starting profiling ===" '
-        TASK_CMD+="&& curl -sf -X POST 'http://127.0.0.1:30271/start_profile'"
-        TASK_CMD+=" -H 'Content-Type: application/json'"
-        TASK_CMD+=" -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${{ inputs.num_steps }}}' &"
-        TASK_CMD+=" PROFILE_PID=\$!"
-        TASK_CMD+=" && sleep 5"
-        TASK_CMD+=" && python3 -m sgl_jax.bench_serving"
-        TASK_CMD+=" --backend sgl-jax --host 127.0.0.1 --port 30271"
-        TASK_CMD+=" --dataset-name random"
-        TASK_CMD+=" --random-input-len ${{ inputs.random_input_len }}"
-        TASK_CMD+=" --random-output-len ${{ inputs.random_output_len }}"
-        TASK_CMD+=" --random-range-ratio 1.0"
-        TASK_CMD+=" --num-prompts ${{ inputs.num_prompts }}"
-        TASK_CMD+=" --warmup-requests 0"
-        TASK_CMD+=" && wait \$PROFILE_PID"
-        TASK_CMD+=" && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
-        echo "task_command=${TASK_CMD}" >> "$GITHUB_OUTPUT"
-
+        # TPU coordinator address for 16chip
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           COORD="${JOB_NAME}-0.${JOB_NAME}-headless-svc:10011"
           echo "coordinator=${COORD}" >> "$GITHUB_OUTPUT"
@@ -187,17 +172,19 @@ jobs:
           app=ci-sglang ci-task=profiling --overwrite
 
     - name: Deploy job
+      env:
+        PROFILE_DIR: ${{ steps.config.outputs.profile_dir }}
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
-        export MODEL_PATH="${{ inputs.model_path }}"
-        export TP_SIZE="${{ inputs.tp_size }}"
         export SERVER_ARGS="${{ inputs.server_args }}"
-        export TASK_COMMAND="${{ steps.config.outputs.task_command }}"
         export TASK_TYPE="profiling"
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="7200"
         export EXTRA_DEPS=""
+
+        # Task: trigger profiling + send traffic concurrently
+        export TASK_COMMAND="curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${{ inputs.num_steps }}}' & PROFILE_PID=\$! && sleep 5 && python3 -m sgl_jax.bench_serving ${{ inputs.traffic_args }} && wait \$PROFILE_PID && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
 
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -46,10 +46,6 @@ on:
         description: "Stages to profile (comma-separated, e.g. prefill,decode)"
         required: false
         default: "prefill,decode"
-      profile_output_dir:
-        description: "GCS output dir for profile traces"
-        required: true
-        default: "gs://inference-model-storage-poc-tpu/profiling/sglang-jax"
       traffic_args:
         description: "bench_serving args for traffic generation during profiling"
         required: true
@@ -112,7 +108,7 @@ jobs:
         ACTOR_SAFE="${ACTOR_SAFE:-unknown}"
         echo "actor_safe=${ACTOR_SAFE}" >> "$GITHUB_OUTPUT"
 
-        PROFILE_DIR="${{ inputs.profile_output_dir }}/${JOB_NAME}"
+        PROFILE_DIR="/inference-models/workflow/MiMo-V2-Flash/profiling/workflow-${GITHUB_RUN_NUMBER}"
         echo "profile_dir=${PROFILE_DIR}" >> "$GITHUB_OUTPUT"
 
         # TPU coordinator address for 16chip

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -19,7 +19,7 @@ on:
         description: "sglang server launch args (all flags except --host/--port/--nnodes/--node-rank/--dist-init-addr)"
         required: true
         default: >-
-          --model-path /models/MiMo-V2-Flash
+          --model-path /inference-models/MiMo-V2-Flash
           --trust-remote-code
           --tp-size 16 --dp-size 4 --ep-size 16
           --moe-backend fused

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -188,8 +188,10 @@ jobs:
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 
-        # Task: start traffic in background, trigger profiling (blocking), then kill traffic
-        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
+        # Task: background traffic, trigger profiling (async), wait for it to finish, cleanup
+        # /start_profile returns immediately; server logs "Profiling done" after N steps
+        # We poll /stop_profile — it returns error if profiling already stopped, success if still active
+        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; if curl -sf 'http://127.0.0.1:30271/stop_profile' 2>&1 | grep -q 'not in progress'; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
         export TASK_COMMAND_B64=$(printf '%s' "$TASK_CMD" | base64 -w0)
 
         VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -174,6 +174,8 @@ jobs:
     - name: Deploy job
       env:
         PROFILE_DIR: ${{ steps.config.outputs.profile_dir }}
+        TRAFFIC_ARGS: ${{ inputs.traffic_args }}
+        NUM_STEPS: ${{ inputs.num_steps }}
       run: |
         export JOB_NAME="${{ steps.config.outputs.job_name }}"
         export BRANCH="${{ inputs.branch }}"
@@ -187,9 +189,10 @@ jobs:
         export TOPOLOGY="${{ inputs.topology }}"
 
         # Task: trigger profiling + send traffic concurrently
-        export TASK_COMMAND="curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${{ inputs.num_steps }}}' & PROFILE_PID=\$! && sleep 5 && python3 -m sgl_jax.bench_serving ${{ inputs.traffic_args }} && wait \$PROFILE_PID && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
+        TASK_CMD="curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' & PROFILE_PID=\$! && sleep 5 && python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} && wait \$PROFILE_PID && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
+        export TASK_COMMAND_B64=$(printf '%s' "$TASK_CMD" | base64 -w0)
 
-        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
           envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -182,11 +182,14 @@ jobs:
         export GITHUB_ACTOR="${{ steps.config.outputs.actor_safe }}"
         export ACTIVE_DEADLINE="7200"
         export EXTRA_DEPS=""
+        export RESULTS_PATH=""
+        export GITHUB_RUN_NUMBER="${{ github.run_number }}"
+        export TOPOLOGY="${{ inputs.topology }}"
 
         # Task: trigger profiling + send traffic concurrently
         export TASK_COMMAND="curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${{ inputs.num_steps }}}' & PROFILE_PID=\$! && sleep 5 && python3 -m sgl_jax.bench_serving ${{ inputs.traffic_args }} && wait \$PROFILE_PID && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
 
-        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS'
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
           envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
@@ -226,7 +229,9 @@ jobs:
 
     - name: Stream logs
       run: |
-        kubectl logs -f "job/${{ steps.config.outputs.job_name }}" \
+        # Stream from coordinator pod (index 0) only
+        kubectl logs -f \
+          -l job-name=${{ steps.config.outputs.job_name }},batch.kubernetes.io/job-completion-index=0 \
           -c sglang-tpu --tail=1000 || true
 
     - name: Re-authenticate to GCP (post-logs)
@@ -245,12 +250,29 @@ jobs:
 
     - name: Wait for completion
       run: |
-        kubectl wait --for=condition=complete "job/${{ steps.config.outputs.job_name }}" \
-          --timeout=600s 2>/dev/null && echo "JOB SUCCEEDED" || {
-          kubectl wait --for=condition=failed "job/${{ steps.config.outputs.job_name }}" \
-            --timeout=10s 2>/dev/null && echo "JOB FAILED" && exit 1
-          echo "JOB TIMED OUT" && exit 1
-        }
+        JOB_NAME="${{ steps.config.outputs.job_name }}"
+        TIMEOUT=600
+        ELAPSED=0
+        echo "Waiting for coordinator pod to complete (timeout ${TIMEOUT}s)..."
+        while [ $ELAPSED -lt $TIMEOUT ]; do
+          PHASE=$(kubectl get pod \
+            -l job-name=${JOB_NAME},batch.kubernetes.io/job-completion-index=0 \
+            -o jsonpath='{.items[0].status.phase}' 2>/dev/null)
+          if [ "$PHASE" = "Succeeded" ]; then
+            echo "JOB SUCCEEDED"
+            break
+          fi
+          if [ "$PHASE" = "Failed" ]; then
+            echo "JOB FAILED"
+            exit 1
+          fi
+          sleep 10
+          ELAPSED=$((ELAPSED + 10))
+        done
+        if [ $ELAPSED -ge $TIMEOUT ]; then
+          echo "JOB TIMED OUT"
+          exit 1
+        fi
 
     - name: Print profile location
       if: success()

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -188,10 +188,8 @@ jobs:
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 
-        # Task: background traffic, trigger profiling (async), wait for it to finish, cleanup
-        # /start_profile returns immediately; server logs "Profiling done" after N steps
-        # We poll /stop_profile — it returns error if profiling already stopped, success if still active
-        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; if curl -sf 'http://127.0.0.1:30271/stop_profile' 2>&1 | grep -q 'not in progress'; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
+        # Task: background traffic, trigger profiling (async), poll /profile_status until idle
+        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; STATUS=\$(curl -sf 'http://127.0.0.1:30271/profile_status' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"status\"])' 2>/dev/null); echo \"  profile_status: \$STATUS\"; if [ \"\$STATUS\" = 'idle' ]; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
         export TASK_COMMAND_B64=$(printf '%s' "$TASK_CMD" | base64 -w0)
 
         VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -186,11 +186,12 @@ jobs:
         # Task: trigger profiling + send traffic concurrently
         export TASK_COMMAND="curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${{ inputs.num_steps }}}' & PROFILE_PID=\$! && sleep 5 && python3 -m sgl_jax.bench_serving ${{ inputs.traffic_args }} && wait \$PROFILE_PID && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
 
+        VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS'
         if [ "${{ inputs.topology }}" = "16chip" ]; then
           export TPU_COORDINATOR_ADDRESS="${{ steps.config.outputs.coordinator }}"
-          envsubst < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
+          envsubst "$VARS" < .github/ci/sglang-16chip-job.yaml | kubectl apply -f -
         else
-          envsubst < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
+          envsubst "$VARS" < .github/ci/sglang-4chip-job.yaml | kubectl apply -f -
         fi
 
     - name: Wait for pods

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -188,8 +188,8 @@ jobs:
         export GITHUB_RUN_NUMBER="${{ github.run_number }}"
         export TOPOLOGY="${{ inputs.topology }}"
 
-        # Task: trigger profiling + send traffic concurrently
-        TASK_CMD="curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' & PROFILE_PID=\$! && sleep 5 && python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} && wait \$PROFILE_PID && echo '=== Profile saved to: ${PROFILE_DIR} ==='"
+        # Task: start traffic in background, trigger profiling (blocking), then kill traffic
+        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '{\"output_dir\": \"${PROFILE_DIR}\", \"num_steps\": ${NUM_STEPS}}' && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
         export TASK_COMMAND_B64=$(printf '%s' "$TASK_CMD" | base64 -w0)
 
         VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'

--- a/.github/workflows/profiling_gke.yml
+++ b/.github/workflows/profiling_gke.yml
@@ -46,18 +46,18 @@ on:
         description: "Stages to profile (comma-separated, e.g. prefill,decode)"
         required: false
         default: "prefill,decode"
-      traffic_args:
-        description: "bench_serving args for traffic generation during profiling"
+      traffic_input_len:
+        description: "Input token length for traffic generation"
         required: true
-        default: >-
-          --backend sgl-jax
-          --host 127.0.0.1 --port 30271
-          --dataset-name random
-          --random-input-len 512
-          --random-output-len 32
-          --random-range-ratio 1.0
-          --num-prompts 8
-          --warmup-requests 0
+        default: "512"
+      traffic_output_len:
+        description: "Output token length for traffic generation"
+        required: true
+        default: "32"
+      traffic_num_prompts:
+        description: "Number of concurrent prompts for traffic generation"
+        required: true
+        default: "8"
 
 permissions:
   actions: read
@@ -179,7 +179,9 @@ jobs:
     - name: Deploy job
       env:
         PROFILE_DIR: ${{ steps.config.outputs.profile_dir }}
-        TRAFFIC_ARGS: ${{ inputs.traffic_args }}
+        TRAFFIC_INPUT_LEN: ${{ inputs.traffic_input_len }}
+        TRAFFIC_OUTPUT_LEN: ${{ inputs.traffic_output_len }}
+        TRAFFIC_NUM_PROMPTS: ${{ inputs.traffic_num_prompts }}
         NUM_STEPS: ${{ inputs.num_steps }}
         PROFILE_BY_STAGE: ${{ inputs.profile_by_stage }}
         PROFILE_STAGES: ${{ inputs.profile_stages }}
@@ -204,8 +206,10 @@ jobs:
         fi
         PROFILE_JSON="${PROFILE_JSON}}"
 
+        BENCH_CMD="python3 -m sgl_jax.bench_serving --backend sgl-jax --host 127.0.0.1 --port 30271 --dataset-name random --random-input-len ${TRAFFIC_INPUT_LEN} --random-output-len ${TRAFFIC_OUTPUT_LEN} --random-range-ratio 1.0 --num-prompts ${TRAFFIC_NUM_PROMPTS} --warmup-requests 0"
+
         # Task: background traffic, trigger profiling (async), poll /profile_status until idle
-        TASK_CMD="python3 -m sgl_jax.bench_serving ${TRAFFIC_ARGS} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '${PROFILE_JSON}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; STATUS=\$(curl -sf 'http://127.0.0.1:30271/profile_status' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"status\"])' 2>/dev/null); echo \"  profile_status: \$STATUS\"; if [ \"\$STATUS\" = 'idle' ]; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
+        TASK_CMD="${BENCH_CMD} & BENCH_PID=\$! && sleep 10 && echo 'Triggering profiling...' && curl -sf -X POST 'http://127.0.0.1:30271/start_profile' -H 'Content-Type: application/json' -d '${PROFILE_JSON}' && echo 'Profiling triggered, waiting for completion...' && for i in \$(seq 1 120); do sleep 5; STATUS=\$(curl -sf 'http://127.0.0.1:30271/profile_status' | python3 -c 'import sys,json; print(json.load(sys.stdin)[\"status\"])' 2>/dev/null); echo \"  profile_status: \$STATUS\"; if [ \"\$STATUS\" = 'idle' ]; then echo 'Profiling completed.'; break; fi; done && echo '=== Profile saved to: ${PROFILE_DIR} ===' && kill \$BENCH_PID 2>/dev/null; wait \$BENCH_PID 2>/dev/null; true"
         export TASK_COMMAND_B64=$(printf '%s' "$TASK_CMD" | base64 -w0)
 
         VARS='$JOB_NAME $BRANCH $SERVER_ARGS $TASK_COMMAND_B64 $TASK_TYPE $GITHUB_ACTOR $ACTIVE_DEADLINE $EXTRA_DEPS $TPU_COORDINATOR_ADDRESS $RESULTS_PATH $GITHUB_RUN_NUMBER $TOPOLOGY'

--- a/python/sgl_jax/srt/entrypoints/http_server.py
+++ b/python/sgl_jax/srt/entrypoints/http_server.py
@@ -403,6 +403,13 @@ async def stop_profile_async():
     )
 
 
+@app.api_route("/profile_status", methods=["GET"])
+async def profile_status_async():
+    """Get profiling status."""
+    result = await _global_state.tokenizer_manager.get_profile_status()
+    return ORJSONResponse(content={"status": result.message})
+
+
 @app.api_route("/start_trace", methods=["GET", "POST"])
 async def start_trace_async(obj: StartTraceReqInput | None = None):
     """Start precision tracing."""

--- a/python/sgl_jax/srt/managers/io_struct.py
+++ b/python/sgl_jax/srt/managers/io_struct.py
@@ -661,6 +661,7 @@ class ProfileReqInput:
 class ProfileReqType(Enum):
     START_PROFILE = 1
     STOP_PROFILE = 2
+    GET_STATUS = 3
 
 
 @dataclass

--- a/python/sgl_jax/srt/managers/scheduler_profiler_mixing.py
+++ b/python/sgl_jax/srt/managers/scheduler_profiler_mixing.py
@@ -333,5 +333,11 @@ class SchedulerProfilerMixin:
                 recv_req.python_tracer_level,
                 recv_req.profile_id,
             )
+        elif recv_req.type == ProfileReqType.GET_STATUS:
+            in_progress = self.profile_in_progress or self._profile_manager.is_configured
+            return ProfileReqOutput(
+                success=True,
+                message="in_progress" if in_progress else "idle",
+            )
         else:
             return self.stop_profile()

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -660,6 +660,11 @@ class TokenizerManager:
         req = ProfileReq(type=ProfileReqType.STOP_PROFILE)
         return await self._execute_profile(req)
 
+    async def get_profile_status(self):
+        self.auto_create_handle_loop()
+        req = ProfileReq(type=ProfileReqType.GET_STATUS)
+        return await self._execute_profile(req)
+
     async def _execute_profile(self, req: ProfileReq):
         result = (await self.profile_communicator(req))[0]
         if not result.success:


### PR DESCRIPTION
## Summary
- Add three `workflow_dispatch` workflows for running benchmark, accuracy, and profiling on GKE TPU v6e (4chip / 16chip)
- K8s Job templates for single-machine (2x2) and multi-machine (4x4) TPU topologies
- Results saved to GCS at `/inference-models/workflow/MiMo-V2-Flash/{benchmark,accuracy,profiling}/workflow-{run_number}`
- TPU queue management: max 4 concurrent jobs, 2 per actor

## Key features
- **Benchmark**: configurable bench_serving args, metadata + output persisted to GCS
- **Accuracy**: evalscope eval with full JSON support (base64-encoded TASK_COMMAND)
- **Profiling**: polls `/profile_status` endpoint for completion, configurable input/output len, num_prompts, profile_by_stage
- Worker pod exit handling for multi-host jobs (16chip)
- Stream logs from coordinator pod only, poll pod-0 phase for completion

## Test results
- Benchmark: pass (run #8)
- Accuracy: pass, gsm8k=0.9325 (run #2)
- Profiling: pass (run #5)

## Test plan
- [x] Benchmark workflow completes and saves results to GCS
- [x] Accuracy workflow completes with correct eval scores
- [x] Profiling workflow captures traces and exits cleanly
- [x] All workflows handle 16chip multi-pod correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/profile_status` endpoint for monitoring profiling state.
  * Enhanced result persistence with automatic metadata tracking including run ID, branch, and topology information.

* **Chores**
  * Simplified GitHub Actions workflow inputs by consolidating parameters into server/benchmark arguments.
  * Updated default topology from 4-chip to 16-chip configurations.
  * Revised Kubernetes job infrastructure for improved resource management and model storage paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->