### PR TITLE
fix: set req.latest_bid to fix routed experts TypeError

### DIFF
--- a/python/sgl_jax/srt/layers/routed_experts_capturer.py
+++ b/python/sgl_jax/srt/layers/routed_experts_capturer.py
@@ -223,7 +223,7 @@ class _RoutedExpertsCapturerReal(RoutedExpertsCapturer):
             raise RuntimeError("Host buffer is disabled. enable_return_routed_experts is required.")
         cache_pool_idx = req_to_token_pool.req_to_token[req_pool_idx][: seqlen - 1]
         while True:
-            if self.bid >= bid:
+            if self.bid is not None and bid is not None and self.bid >= bid:
                 return self.host_buffer[:, cache_pool_idx, :]
             else:
                 time.sleep(0.001)

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -107,6 +107,8 @@ class SchedulerOutputProcessorMixin:
                 if req.is_retracted:
                     continue
 
+                req.latest_bid = result.bid
+
                 if (
                     self.is_mixed_chunk and self.enable_overlap and req.finished()
                 ):  # TODO @Brian fix it
@@ -322,6 +324,8 @@ class SchedulerOutputProcessorMixin:
                 req: Req
                 if req.is_retracted:
                     continue
+
+                req.latest_bid = result.bid
 
                 indices_to_free = None
                 if self.enable_overlap and req.finished():


### PR DESCRIPTION
## Summary
- `Req.latest_bid` was initialized to `None` and never assigned during output processing, causing `TypeError: '>=' not supported between instances of 'int' and 'NoneType'` in `routed_experts_capturer.py:226`
- Set `req.latest_bid = result.bid` in both prefill and decode output processing loops
- Added None guard in `get_routed_experts()` as defensive check

## Test plan
- [x] `test/srt/rl/test_return_routed_experts.py` passes on v6e-4 TPU pod (was failing with TypeError before fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)