### PR TITLE
fix(swa): use min(sliding_window_size, page_size) for decode eviction interval (#227)

### DIFF
--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1335,11 +1335,16 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
+            # Evict at the smaller of sliding_window_size and page_size to avoid
+            # stale SWA slot accumulation. For large windows (e.g., 4096) this
+            # prevents holding memory far beyond what's needed; for small windows
+            # (e.g., 128) it aligns with the natural eviction boundary.
+            evict_interval = max(min(sliding_window_size, page_size), 1)
             for dp_rank, info in enumerate(self.reqs_info):
                 if not info.reqs:
                     continue
                 for req in info.reqs:
-                    if req.decode_batch_idx % sliding_window_size == 1:
+                    if req.decode_batch_idx % evict_interval == 1:
                         self._evict_swa(
                             req, req.seqlen - 1, sliding_window_size, page_size, dp_rank
                         )


### PR DESCRIPTION
## Summary

The decode path evicts SWA slots every `sliding_window_size` steps. For models with large sliding windows (e.g., 4096), this holds stale SWA memory far longer than needed.

Use `min(sliding_window_size, page_size)` as the eviction interval:
- Small windows (128, e.g. MiMo): evict every 128 steps (same as before)
- Large windows (4096): evict every `page_size` steps (frees memory sooner)

Closes #227

## Changes

- `python/sgl_jax/srt/managers/schedule_batch.py`: 6 insertions, 1 deletion

## Test plan

- [x] Pre-commit hooks pass
- [ ] Lint CI
- [ ] No regression on MiMo-V2-Flash benchmark (small window = same behavior)

🤖 Generated with [Claude Code](https://claude.com/claude-code)