### PR TITLE
fix: use Explicit axis type in quantized_linear_test mesh

### DIFF
--- a/python/sgl_jax/test/kernels/quantized_linear_test.py
+++ b/python/sgl_jax/test/kernels/quantized_linear_test.py
@@ -25,7 +25,11 @@ blockwise_quant_util = importlib.import_module(
 
 
 def _create_single_device_mesh():
-    return Mesh(np.array(jax.devices()[:1]).reshape(1, 1), axis_names=("data", "tensor"))
+    return Mesh(
+        np.array(jax.devices()[:1]).reshape(1, 1),
+        axis_names=("data", "tensor"),
+        axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit),
+    )
 
 
 def _make_linear_test_inputs():


### PR DESCRIPTION
## Summary
- Test `quantized_linear_test.py` created mesh without explicit axis types, defaulting to `AxisType.Auto` in JAX 0.8.1
- `dot_general` rejects `PartitionSpec` with Auto-typed axis names, causing 3 test failures
- Fixed by adding `axis_types=(AxisType.Explicit, AxisType.Explicit)` to match `create_device_mesh` behavior

## Test plan
- [x] Verified all 16 tests pass on TPU v6e-1 cluster with JAX 0.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)