### PR TITLE
fix: use Explicit axis type and add data axis in swa_radix_cache test mesh

### DIFF
--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -27,7 +27,11 @@ class TestSWARadixCache(unittest.TestCase):
     def setUp(self):
         # Keep KV sizes small to make tests light-weight
         self.devices = jax.devices()
-        self.mesh = Mesh([self.devices[0]], axis_names=("tensor",))
+        self.mesh = Mesh(
+            np.array(self.devices[:1]).reshape(1, 1),
+            axis_names=("data", "tensor"),
+            axis_types=(jax.sharding.AxisType.Explicit, jax.sharding.AxisType.Explicit),
+        )
 
         # Small buffers to avoid heavy allocations
         self.kv_head_num = 1


### PR DESCRIPTION
## Summary
- Test mesh only had `("tensor",)` axis but `MHATokenToKVPool` requires both `"data"` and `"tensor"` axes for 5D KV buffer sharding `P("data", None, "tensor", None, None)`
- Added missing `"data"` axis and `AxisType.Explicit` (required by JAX 0.8.1)
- Same pattern as #261 (quantized_linear_test fix)

## Test plan
- [ ] Run `pytest sgl_jax/test/mem_cache/test_swa_radix_cache.py` on TPU v6e-1

🤖 Generated with [Claude Code](https://claude.com/claude-code)