### PR TITLE
feat: add MiMo V2 Pro model support

### DIFF
--- a/docs/debug/mimo_v2_pro_debug_log.md
+++ b/docs/debug/mimo_v2_pro_debug_log.md
@@ -1,0 +1,276 @@
+# MiMo V2 Pro 推理乱码 debug 日志
+
+> 记录所有排查路径、修复尝试、验证结果，防止上下文丢失。
+> 分支：`feat/mimo-v2-pro`（直接 push 到 prim）
+
+## 现象
+
+Pro 模型 v7x 部署后 generate 输出**乱码 / 单 token 重复**（早期看到 token 3422 重复），temperature=0 也复现。
+
+Flash 同代码路径在 v7x 上**输出连贯英文**，作为对照基线。
+
+## 模型/部署信息
+
+- **模型**：MiMo V2 Pro Private（FP8 block-quant，weight_block_size=[128,128]）
+- **集群**：TPU v7x，2 节点 × 4 chip = 8 chip = 16 core
+- **拓扑**：tp=16, dp=2, ep=16, fused MoE backend
+- **manifest**：`/tmp/v7x-mimo-pro.yaml`（Indexed Job + headless service）
+- **Flash 对照**：`/tmp/v7x-mimo-flash.yaml`（v7x-4-pool 单机 Pod，tp=8 dp=2 ep=8）
+
+## Architecture diff: Flash vs Pro
+
+确认 Flash 和 Pro **架构完全相同**，只有数值参数不同：
+
+| 项 | Flash | Pro | 影响 |
+|---|---|---|---|
+| 层数 | 48 | 70 | scale only |
+| num_heads | 64 | 128 | TP 切分粒度 |
+| num_kv_heads | 4 | 8 | KV head |
+| head_dim | 192 | 192 | 同 |
+| v_head_dim | 128 | 128 | 同 |
+| hidden_size | 4096 | 6144 | scale only |
+| n_routed_experts | 256 | 384 | EP 排布 |
+| attention_value_scale | 0.707 | 0.612 | v 反量化系数 |
+| n_group / topk_group | 1 / 1 | 1 / 1 | grouped routing 必走 |
+| qkv 存储 | 分离 q/k/v | **fused qkv_proj** | Pro 走 `_split_qkv_weight` |
+| FP8 V scale 排布 | weight 和 scale 都是 compact 1024 | weight compact 1024，**scale padded 到 1536（12 块）** | Pro 需 gather 重映射 |
+
+## 排查时间线
+
+### 阶段 1：MoE TopK grouping fix（commit d7eeb87a, task #17）
+
+**症状**：Pro 输出乱码。
+
+**根因**：`MiMoV2MoE.__init__` (mimo_v2.py:103) 创建 `TopK` 时未传 `n_group`/`topk_group`，默认 0。Pro config 有 `n_group=1, topk_group=1, scoring_func=sigmoid, topk_method=noaux_tc`。SGLang 参考实现要走 `_biased_grouped_topk`，但我们因 `num_expert_group=0` 走了 `_biased_topk`，路由错误。
+
+**修复**：传入 `n_group / topk_group / routed_scaling_factor / layer_id`。
+
+```python
+self.topk = TopK(
+    topk=num_experts_per_tok,
+    renormalize=getattr(config, "norm_topk_prob", True),
+    num_expert_group=getattr(config, "n_group", 0) or 0,
+    topk_group=getattr(config, "topk_group", 0) or 0,
+    routed_scaling_factor=getattr(config, "routed_scaling_factor", None) or 1.0,
+    layer_id=layer_id,
+)
+```
+
+**回归保护**：Flash config 通常 `n_group=1`，会走 grouped 路径同 Pro。
+
+**结果**：Pro **仍然乱码**。继续排查。
+
+### 阶段 2：Padded-V FP8 scale gather fix（commit c91fdccb, task #18）
+
+**症状**：Pro 仍乱码。Flash 在 v7x 跑 OK。
+
+**调查**：
+
+启动日志看到：
+```
+Expanding linear block-quant scale model.layers.0.self_attn.v_proj.weight_scale
+  from (8, 48) to kernel-ready layout [48, 1, 1024]
+```
+
+但 Pro fused QKV 的 weight_scale_inv 形状是 `(216, 48) = (192+12+12, 48)`：
+- Q 部分 192 行（全 padded `head_dim=192`）
+- K 部分 12 行
+- V 部分 **12 行**（V 在量化前被 pad 到 head_dim=192 → 8*192=1536 → 12 个 128 块）
+
+**但 V weight 自己存的是 compact 1024 维**（8 head × 128）！
+
+`_split_qkv_weight` 旧代码取 V scale 的前 8 行（`v_dim_keep = (8*128)//128 = 8`），当作 compact-aligned 用。但 padded 第 0/1 块覆盖 head 0 的 0..127 / 128..255，第 1 块前 64 通道是 head 0 的 pad 区，后 64 通道是 head 1 的 0..63 —— **压根不是 head 0 的数据**。
+
+→ 对 head 0 的 scale 只有第 0 块对，后续每 head 都用错 scale。
+
+**修复方案**（用户指引："不要 padding，直接在切分的原 v proj 运用正确的 scale 反量化"）：
+
+`weight_utils.py::_split_qkv_weight`：
+1. V 切片保留全部 12 个 padded 块（不 drop 末尾）
+2. 在 post-shard loop 里对 V scale 走特殊路径
+3. 用 `expand_block_scale(channel_to_block=...)` 做 per-channel gather：
+   - compact channel `c = h*128 + w` → padded scale row `(h*192 + w) // 128`
+4. 输出直接是 kernel-ready 3D `[48, 1, 1024]`，跳过标准 `_maybe_expand_linear_block_scale`
+
+```python
+n_out_compact = self.num_kv_heads * self.v_head_dim_original  # 1024
+head_idx = jnp.arange(n_out_compact) // self.v_head_dim_original
+within_idx = jnp.arange(n_out_compact) % self.v_head_dim_original
+channel_to_block = (head_idx * self.head_dim_original + within_idx) // block_size
+# expand_block_scale 内部：scale_per_channel = scale_2d[channel_to_block]
+```
+
+**回归保护**：
+- 非 fused QKV 模型：不会进 `_split_qkv_weight` 的 padded 分支
+- Flash：V weight 和 scale 都是 compact，`actual_dim == expected_scale_dim_real`，走原路径不变
+
+**已确认对齐项**（非 bug）：
+1. partial_rotary_factor：SGLang 和我们都是 `int(192 * 0.334) = 64`
+2. attention_value_scale=0.612：mimo_v2.py:265 `v = v * self.v_scale` 已用
+3. V 在 attention 前 pad 到 192、attention 后 slice 回 128：mimo_v2.py:264-291 已实现，与 Flash 一致
+
+**结果**：等 Pro 重启验证（c91fdccb）。
+
+### 阶段 3：c91fdccb 验证失败 + 切换 epmoe 排查 fused MoE 嫌疑
+
+**时间**：2026-04-18 20:14 Pro 启动完成。
+
+**Coherence test 结果**（commit c91fdccb，fused backend）：
+
+```
+"The capital of France is" → "#叉叉##叉叉叉#叉叉叉叉..." (token 102940 重复主导)
+"2+2="                    → "- mountMount:ERSHEY mount mount mount #####  0"
+"Hello, my name is"        → "   ##叉叉叉叉#叉#  叉叉叉叉"
+```
+
+**特征**：
+- 输出**与 prompt 相关**（不同 prompt 出不同 token）→ 模型在算东西，不是完全 dead
+- 但 logits 严重失真，token 102940 / 2 / 220 等"垃圾"token 主导
+- V scale fix 不足以拯救 → 还有别的 bug
+
+**下一步** Direction A：切 `--moe-backend epmoe`（用户建议）
+
+19:14 删 Job，改 `/tmp/v7x-mimo-pro.yaml` 第 75 行 `fused → epmoe`，re-apply。
+20:15 新 Pod `v7x-mimo-pro-0-pwwjk` running，开始 weight load。
+
+**判定**：
+- 如果 epmoe 输出连贯英文 → fused MoE backend 在 grouped routing / EP 排布上有 bug
+- 如果 epmoe 仍乱码 → MoE 不背锅，bug 在 attention path 或别的层
+
+
+## 待验证清单
+
+- [x] Flash v7x-4 输出连贯（验证 #17 不破坏 Flash）— **PASS** (commit c91fdccb)
+  - "The capital of France is" → " Paris."
+  - "2+2=" → "4, 4+2=6, 6+2=8,"
+- [ ] Pro v7x-8 输出连贯（验证 #17+#18 修好 Pro）— 重启中（2026-04-18 18:50 起，MoE load ~3%）
+- [ ] 如 Pro 仍乱码，下一步备选方向
+  - epmoe backend 替换 fused 排除 fused MoE 嫌疑
+  - sink_bias TP sharding 数值检查
+  - V scale sharding mapping `(None, None)` → `(None, "tensor")` 对齐 model param
+  - FP8 dequant 路径 (mimo_v2.py:750-783) 的 V 处理
+
+## 关键文件路径
+
+- 模型实现：`python/sgl_jax/srt/models/mimo_v2.py`
+- Weight loader：`python/sgl_jax/srt/utils/weight_utils.py`（`_split_qkv_weight` 在 line 1534）
+- TopK gate：`python/sgl_jax/srt/layers/gate.py`（grouped 分流在 line 91）
+- Block scale 工具：`python/sgl_jax/srt/kernels/quantized_matmul/blockwise_utils.py`（`expand_block_scale` 在 line 232）
+- SGLang 参考：`/Users/ramezes/job/opensource/sglang/python/sglang/srt/models/mimo_v2_flash.py`
+- Pro Job manifest：`/tmp/v7x-mimo-pro.yaml`
+- Flash Pod manifest：`/tmp/v7x-mimo-flash.yaml`
+
+## Commits（feat/mimo-v2-pro）
+
+- `5568702e` (main) feat: add MiMo V2 Pro model support with fused QKV weight loading
+- `dc985028` fix: v_scale path（attention_value_scale 入参）
+- `d7eeb87a` fix: pass n_group/topk_group/routed_scaling_factor to MoE TopK
+- `c91fdccb` fix: remap padded-V FP8 scale to compact channels in fused QKV split
+
+## 验证日志
+
+### 2026-04-18 19:34 safetensors header 验证
+
+直接读 HF safetensors header 确认 Pro fused QKV 真实 layout（layer 5, layer 0.mtp 都同样）：
+
+```
+model.layers.5.self_attn.qkv_proj.weight       [27136, 6144] F8_E4M3
+model.layers.5.self_attn.qkv_proj.weight_scale_inv [216,   48] F32
+```
+
+- 27136 = q(128*192) + k(8*192) + v(8*128) = 24576 + 1536 + 1024 ✓ **V weight = compact 1024**
+- 216 = q_scale(192) + k_scale(12) + v_scale(12) ✓ **V scale = padded 12 行（per-head 0..191 // 128）**
+
+→ 强证 fix 方向对：weight 和 scale 在 V 部分用不同 head 边界，必须 gather 重映射。
+
+### K scale 边界分析（确认 K 走标准路径无 bug）
+
+K 的 head_dim_original=192，per-head 不整除 128。K weight 和 K scale 都按 192/head 对齐：
+- block 0: head 0 的 ch 0..127
+- block 1: head 0 的 ch 128..191 + head 1 的 ch 0..63（混合）
+- block 2: head 1 的 ch 64..191（混合）...
+
+producer 量化时就用这个 padded 边界算的 scale，loader 用同样 `channel // 128` 反量化 → **数学一致**。
+V 之所以特殊，是因为 V scale 也用 192/head 算（padded），但 V weight 自己却 compact 存 128/head —— **二者用不同的 head 边界**，必须 gather 修正。
+
+### 2026-04-18 18:55 启动观察
+
+Pro 重启后 weight load 阶段 log 关键证据：
+
+```
+Expanding linear block-quant scale model.layers.X.self_attn.q_proj.weight_scale
+  from (192, 48) to kernel-ready layout [48, 1, 24576]
+Expanding linear block-quant scale model.layers.X.self_attn.k_proj.weight_scale
+  from (12, 48) to kernel-ready layout [48, 1, 1536]
+```
+
+**没有 v_proj.weight_scale 的 expand log** —— 这正是预期：我的 fix 让 V scale 直接在 `_split_qkv_weight` 走 `expand_block_scale(channel_to_block=...)`，跳过 `_maybe_expand_linear_block_scale`。
+
+K proj 的 `(12, 48) → [48, 1, 1536]` 证明 K weight 是 padded 存储（8 head × 192 = 1536），原代码对 K 没问题。
+
+### 2026-04-18 21:20 epmoe pod 状态 + 网络中断
+
+切 epmoe 后 Pod 重新部署：`v7x-mimo-pro-0-pwwjk`（20:14 起）。
+- 20:14 prefetch 启动
+- 20:28 layer 22 weight load
+- 20:39 layer 12 MoE 17%
+- 20:49 layer 21 MoE 30%
+- 20:59 layer 36 MoE 52%
+- 21:09 layer 52 MoE 75%
+- 21:19 layer 65 MoE 94%（最后观察）
+
+预计 21:25 左右 ready。但 21:21 起本机 kubectl proxy (127.0.0.1:7890) 连接被重置，无法访问 GKE API。
+
+**待恢复**：
+- 等本机网络恢复后，立即 `kubectl logs v7x-mimo-pro-0-pwwjk -c v7x-mimo-pro --tail=20` 看是否 ready
+- 然后跑 coherence test：
+  ```bash
+  kubectl exec v7x-mimo-pro-0-pwwjk -c v7x-mimo-pro -- curl -s -H 'Content-Type: application/json' \
+    http://localhost:30271/generate \
+    -d '{"text":"The capital of France is","sampling_params":{"temperature":0,"max_new_tokens":32}}'
+  ```
+
+
+
+Flash 启动 log（Pro 没 fused QKV 的对照）：
+```
+Expanding linear block-quant scale model.layers.0.self_attn.v_proj.weight_scale
+  from (4, 32) to kernel-ready layout [32, 1, 512]
+```
+
+Flash full attention：num_kv_heads=4, v_head_dim=128 → V output = 512，scale = (4, 32) — V 没 padding（HF 量化时直接用 v_head_dim_original=128 算 scale）。
+
+→ 证实 **V padding 是 fused QKV 独有的工件**（HF 为了让 cat 后的 Q/K/V 一起 block-quant 时每 head 在 128 块边界上对齐，把 V 从 128/head pad 到 192/head）。Pro 用 fused QKV 才会触发，Flash 分离 q/k/v 不会。
+
+### Dequantize 路径分析
+
+Pro 是 FP8 → 走 `_dequantize_fp8_to_bf16`（mimo_v2.py:530, 1141）：
+- 把 FP8 attention proj + layer-0 MLP 在加载完成后**反量化成 bf16**
+- inference 时 attention 用 bf16 matmul（不走 FP8 kernel）
+- 我的 V scale fix 在 `_split_qkv_weight` 阶段就把 V scale 修正成对的 `[48, 1, 1024]`
+- `_block_dequant` 用这个对的 scale 把 V FP8 weight 反量化成 bf16
+- 所以 fix 直接生效在 dequant 路径
+
+→ MoE 层仍是 FP8 量化跑（fused MoE backend 处理）。
+
+## 备选 debug 方向（如 c91fdccb 后 Pro 仍乱码）
+
+按概率/优先级排序：
+
+### A. 用户建议：epmoe backend 替换 fused
+
+排除 fused MoE 嫌疑。`--moe-backend epmoe` 是 default，最简单切换。
+
+如果 epmoe OK / fused 乱码 → fused MoE 内部有 bug（grouped routing 假设、expert 排布、scale 处理）
+
+### B. V scale sharding mapping 不对齐
+
+WeightMapping 写 `sharding=(None, None)` (mimo_v2.py:1108)。但 model param `weight_scale` 期望 `P(None, None, "tensor")` (linear.py:213)。当前两者 mismatch，JAX 自动 reshard，反量化数值应该正确（用户已确认影响小），但可能引入 perf bug。
+
+### C. Sink bias 数值检查
+
+`attention_sink_bias` 已切 `P("tensor")` (mimo_v2.py:244)。需要 attach 进程 dump 实际值，确认每 TP rank 拿到 `num_heads / tp_size` 个独立值，不是全 0 或重复。
+
+### D. partial RoPE 二次确认（已对齐，低优先级）
+
+SGLang 和我们都是 `int(192 * 0.334) = 64`。RoPE 实现应该一致。

--- a/docs/debug/mimo_v2_pro_debug_log.md
+++ b/docs/debug/mimo_v2_pro_debug_log.md
@@ -221,14 +221,27 @@ K proj 的 `(12, 48) → [48, 1, 1536]` 证明 K weight 是 padded 存储（8 he
 
 预计 21:25 左右 ready。但 21:21 起本机 kubectl proxy (127.0.0.1:7890) 连接被重置，无法访问 GKE API。
 
-**待恢复**：
-- 等本机网络恢复后，立即 `kubectl logs v7x-mimo-pro-0-pwwjk -c v7x-mimo-pro --tail=20` 看是否 ready
-- 然后跑 coherence test：
-  ```bash
-  kubectl exec v7x-mimo-pro-0-pwwjk -c v7x-mimo-pro -- curl -s -H 'Content-Type: application/json' \
-    http://localhost:30271/generate \
-    -d '{"text":"The capital of France is","sampling_params":{"temperature":0,"max_new_tokens":32}}'
-  ```
+### 2026-04-19 epmoe 验证：megablox GMM kernel tile-size bug
+
+恢复 kubectl 后查 epmoe pod 状态：两个 pod 均 `Completed`（启动后约 75 分钟挂掉）。
+
+抓 `kubectl logs v7x-mimo-pro-0-pwwjk` 末尾发现 precompile 阶段 crash：
+
+```
+[GMM kernel] using default block sizes for key:
+  (1024, 6144, 2048, 384, 24, 'bfloat16', 'float8_e4m3fn', 6144): (128, 2048, 2048)
+  (2048, 6144, 2048, 384, 24, 'bfloat16', 'float8_e4m3fn', 6144): (256, 2048, 2048)
+  (4096, 6144, 2048, 384, 24, 'bfloat16', 'float8_e4m3fn', 6144): (384, 2048, 2048)
+
+ValueError: 4096 must be divisible by x-dimension tile size (384).
+  at megablox_gmm_kernel/gmm.py:80 (_calculate_num_tiles)
+```
+
+**根因**：default block-size 启发式按 `tm = m / 16` 之类规则选 tile_m，m=1024→128，m=2048→256，m=4096→384。但 4096 % 384 ≠ 0，`_calculate_num_tiles` 直接抛错。这是 megablox kernel 的默认 block 选择 bug，与我们的 weight loading / 模型代码无关。
+
+**结论**：epmoe 当前不可用于 chunked-prefill-size=4096 + 384 expert 的 Pro。要么换 chunked-prefill-size（4608=384×12 或 2048），要么继续用 fused 排查别的 bug。
+
+**决策**：fused 路径起码能跑通端到端、能产 logits，是唯一能继续验证 backup B/C/D 假设的 channel。改回 fused，重启。
 
 
 

--- a/docs/deployments/mimo_v2_flash_v7x4_control.md
+++ b/docs/deployments/mimo_v2_flash_v7x4_control.md
@@ -1,0 +1,129 @@
+# MiMo V2 Flash 单机 v7x-4 部署（control test）
+
+## 适用场景
+
+- TPU v7x，单机 4 chips（每 chip 2 cores → tp=8）
+- 验证 sgl_jax MoE / attention 实现整体正确性（Flash 已知数值正确，可作 Pro 对照基线）
+- 复用集群 `tpuv7x-64-node`、节点池 `v7x-4-pool`、PVC `inference-model-storage-poc-tpu-hns-pvc`
+
+## launch 命令
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server \
+  --model-path /models/MiMo-V2-Flash \
+  --trust-remote-code \
+  --tp-size 8 --dp-size 2 --ep-size 8 \
+  --moe-backend fused \
+  --host 0.0.0.0 --port 30271 \
+  --page-size 256 \
+  --context-length 262144 \
+  --disable-radix-cache \
+  --chunked-prefill-size 4096 \
+  --dtype bfloat16 \
+  --mem-fraction-static 0.95 \
+  --swa-full-tokens-ratio 0.2 \
+  --skip-server-warmup \
+  --log-level info \
+  --max-running-requests 128 \
+  --dp-schedule-policy round_robin
+```
+
+注意：v7x 一个 chip 两个 core，`tp-size=8` 用满 4 chips（8 cores）。`dp-size`、`ep-size` 与 tp 独立。
+
+## Pod manifest（`/tmp/v7x-mimo-flash.yaml`）
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: v7x-mimo-flash
+  annotations:
+    gke-gcsfuse/volumes: "true"
+spec:
+  restartPolicy: Never
+  nodeSelector:
+    cloud.google.com/gke-tpu-accelerator: tpu7x
+    cloud.google.com/gke-tpu-topology: 2x2x1
+    cloud.google.com/gke-nodepool: v7x-4-pool
+  serviceAccountName: gcs-account
+  containers:
+  - name: v7x-mimo-flash
+    image: us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.8.1-rev1
+    command: ["bash","-lc"]
+    args:
+    - |
+      set -e
+      cd /tmp
+      git clone https://github.com/primatrix/sglang-jax.git
+      cd sglang-jax
+      git fetch origin feat/mimo-v2-pro
+      git checkout feat/mimo-v2-pro
+      pip install -e .
+      JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -u -m sgl_jax.launch_server \
+        --model-path /models/MiMo-V2-Flash \
+        --trust-remote-code \
+        --tp-size 8 --dp-size 2 --ep-size 8 \
+        --moe-backend fused \
+        --host 0.0.0.0 --port 30271 \
+        --page-size 256 --context-length 262144 \
+        --disable-radix-cache --chunked-prefill-size 4096 \
+        --dtype bfloat16 --mem-fraction-static 0.95 \
+        --swa-full-tokens-ratio 0.2 --skip-server-warmup \
+        --log-level info --max-running-requests 128 \
+        --dp-schedule-policy round_robin
+    ports:
+    - containerPort: 30271
+      name: http
+    resources:
+      requests:
+        google.com/tpu: 4
+      limits:
+        google.com/tpu: 4
+    volumeMounts:
+    - name: model-storage
+      mountPath: /models
+    - name: dev-shm
+      mountPath: /dev/shm
+  volumes:
+  - name: dev-shm
+    emptyDir:
+      medium: Memory
+  - name: gke-gcsfuse-cache
+    emptyDir:
+      medium: Memory
+  - name: model-storage
+    persistentVolumeClaim:
+      claimName: inference-model-storage-poc-tpu-hns-pvc
+```
+
+## 部署 + 健康检查
+
+```bash
+kubectl apply -f /tmp/v7x-mimo-flash.yaml
+kubectl wait --for=condition=Ready pod/v7x-mimo-flash --timeout=900s
+kubectl logs -f v7x-mimo-flash
+```
+
+健康检查：
+
+```bash
+kubectl exec v7x-mimo-flash -- curl -s http://localhost:30271/health
+```
+
+## Coherence test（确定性 generate）
+
+```bash
+for prompt in "The capital of France is" "2+2=" "Write a haiku about autumn:"; do
+  kubectl exec v7x-mimo-flash -- curl -s http://localhost:30271/generate \
+    -d "{\"text\":\"$prompt\",\"sampling_params\":{\"temperature\":0,\"max_new_tokens\":32}}"
+  echo
+done
+```
+
+期望：英文连贯输出，无单 token 重复。
+
+## Teardown
+
+```bash
+kubectl delete pod v7x-mimo-flash
+```

--- a/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/gmm/megablox_gmm_kernel/tuned_block_sizes.py
@@ -504,7 +504,7 @@ TUNED_BLOCK_SIZES = {
 
 
 # TODO (jacobplatin): make this more generic
-def round_up_to_multiple_of_128_within_limit(x: int, limit: int) -> int:
+def round_up_to_multiple_of_128_within_limit(x: int, limit: int, divides: int | None = None) -> int:
     """
     Rounds the given integer `x` up to the nearest multiple of 128, without
     exceeding the specified `limit`.
@@ -517,9 +517,17 @@ def round_up_to_multiple_of_128_within_limit(x: int, limit: int) -> int:
     evenly, and returns it.
     If no such candidate is found, returns `limit`.
 
+    If `divides` is provided, the result is additionally constrained to be a
+    divisor of `divides`: after the above selection, the result is decremented
+    by 128 until `divides % result == 0` (or 128 is reached). This is required
+    by callers (e.g. the GMM tile-size heuristic) where the kernel demands
+    `divides % tm == 0`; without it the small-x branch can return a tile size
+    that fails kernel-level divisibility checks.
+
     Args:
         x (int): The integer to round up.
         limit (int): The upper bound (must be a multiple of 128).
+        divides (int | None): If set, the returned value must divide this.
 
     Returns:
         int: The rounded value according to the rules above.
@@ -529,13 +537,19 @@ def round_up_to_multiple_of_128_within_limit(x: int, limit: int) -> int:
     """
     assert limit >= 128 and limit % 128 == 0
     if x <= 128:
-        return 128
-    if x < limit:
-        return (x + 127) // 128 * 128
-    for candidate in range(limit, 511, -128):
-        if x % candidate == 0:
-            return candidate
-    return limit
+        result = 128
+    elif x < limit:
+        result = (x + 127) // 128 * 128
+    else:
+        result = limit
+        for candidate in range(limit, 511, -128):
+            if x % candidate == 0:
+                result = candidate
+                break
+    if divides is not None:
+        while result > 128 and divides % result != 0:
+            result -= 128
+    return result
 
 
 def get_default_gmm_block_sizes(m: int, k: int, n: int, g: int) -> tuple[int, int, int]:
@@ -558,7 +572,7 @@ def get_default_gmm_block_sizes(m: int, k: int, n: int, g: int) -> tuple[int, in
     # 2m//g can be either greater or less than 512. If there are 32 tokens and
     # topk=2, m=topk * num_tokens=64, in this case, 2*m//g will be less than
     # 512.
-    tm = round_up_to_multiple_of_128_within_limit(2 * m // g, 512)
+    tm = round_up_to_multiple_of_128_within_limit(2 * m // g, 512, divides=m)
     tm = min(tm, m)  # there's a requirement that m % tm == 0
     # k/n correspond to n_input_features/n_output_features in the matmul so they
     # are normally greater than 2048, unless the num shards is large.

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -158,6 +158,7 @@ class MiMoV2Attention(nnx.Module):
         rope_scaling: dict[str, Any] | None = None,
         head_dim: int | None = None,
         v_head_dim: int | None = None,
+        v_scale: float | None = None,
         sliding_window_size: int | None = None,
         attention_sink_bias: bool = False,
         partial_rotary_factor: float = 1.0,
@@ -170,6 +171,7 @@ class MiMoV2Attention(nnx.Module):
         self.q_head_num = num_heads
         self.k_head_num = num_kv_heads
         self.v_head_dim = v_head_dim if v_head_dim is not None else self.head_dim
+        self.v_scale = v_scale
 
         self.q_size = num_heads * self.head_dim
         self.k_size = num_kv_heads * self.head_dim
@@ -256,6 +258,8 @@ class MiMoV2Attention(nnx.Module):
         q = q.reshape(-1, self.q_head_num, self.head_dim)
         k = k.reshape(-1, k.shape[-1] // self.head_dim, self.head_dim)
         v = v.reshape(-1, v.shape[-1] // self.v_head_dim, self.v_head_dim)
+        if self.v_scale is not None:
+            v = v * self.v_scale
         # Pad V to match Q/K head_dim for fused KV cache
         if self.v_head_dim != self.head_dim:
             pad_size = self.head_dim - self.v_head_dim
@@ -311,6 +315,7 @@ class MiMoV2DecoderLayer(nnx.Module):
                 rope_scaling=rope_scaling,
                 head_dim=config.swa_head_dim,
                 v_head_dim=getattr(config, "swa_v_head_dim", None),
+                v_scale=getattr(config, "attention_value_scale", None),
                 sliding_window_size=getattr(config, "sliding_window_size", None),
                 attention_sink_bias=getattr(config, "add_swa_attention_sink_bias", False),
                 partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
@@ -328,6 +333,7 @@ class MiMoV2DecoderLayer(nnx.Module):
                 rope_scaling=rope_scaling,
                 head_dim=config.head_dim,
                 v_head_dim=getattr(config, "v_head_dim", None),
+                v_scale=getattr(config, "attention_value_scale", None),
                 sliding_window_size=0,  # full attention
                 attention_sink_bias=getattr(config, "add_full_attention_sink_bias", False),
                 partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -1,10 +1,12 @@
 """MiMo-V2 model implementations (Flash and Pro) for SGLang-JAX."""
 
 import logging
+import os
 from typing import Any
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 from flax import nnx
 from jax.sharding import PartitionSpec as P
 from transformers import PretrainedConfig
@@ -22,6 +24,25 @@ from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
 from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
+
+
+_DUMP_DIR = "/tmp/mimo_dumps"
+_DUMP_ENABLED = os.environ.get("MIMO_DEBUG_DUMP", "0") == "1"
+
+
+def _dump_array(arr: jax.Array, filename: str) -> None:
+    """Save a JAX array to /tmp/mimo_dumps/<filename>.npy via host callback.
+
+    No-op unless MIMO_DEBUG_DUMP=1 is set. Each host writes its own shards.
+    """
+    if not _DUMP_ENABLED:
+        return
+
+    def _save(a):
+        os.makedirs(_DUMP_DIR, exist_ok=True)
+        np.save(os.path.join(_DUMP_DIR, filename), np.asarray(a))
+
+    jax.debug.callback(_save, arr)
 
 
 class MiMoV2MLP(nnx.Module):
@@ -383,13 +404,7 @@ class MiMoV2DecoderLayer(nnx.Module):
         token_to_kv_pool: KVCache,
         residual: jax.Array | None = None,
     ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array | None]:
-        jax.debug.print(
-            "[DBG L{lid}] in: norm={n} max={mx} hasnan={nan}",
-            lid=self.layer_id,
-            n=jnp.linalg.norm(hidden_states.astype(jnp.float32)),
-            mx=jnp.max(jnp.abs(hidden_states.astype(jnp.float32))),
-            nan=jnp.any(jnp.isnan(hidden_states)),
-        )
+        _dump_array(hidden_states, f"layer{self.layer_id:02d}_in.npy")
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
@@ -404,13 +419,7 @@ class MiMoV2DecoderLayer(nnx.Module):
             forward_batch=forward_batch,
             token_to_kv_pool=token_to_kv_pool,
         )
-        jax.debug.print(
-            "[DBG L{lid}] post-attn: norm={n} max={mx} hasnan={nan}",
-            lid=self.layer_id,
-            n=jnp.linalg.norm(hidden_states.astype(jnp.float32)),
-            mx=jnp.max(jnp.abs(hidden_states.astype(jnp.float32))),
-            nan=jnp.any(jnp.isnan(hidden_states)),
-        )
+        _dump_array(hidden_states, f"layer{self.layer_id:02d}_post_attn.npy")
 
         hidden_states += residual
         residual = hidden_states
@@ -423,14 +432,7 @@ class MiMoV2DecoderLayer(nnx.Module):
             topk_ids = None
 
         hidden_states = mlp_output
-        jax.debug.print(
-            "[DBG L{lid}] post-mlp: norm={n} max={mx} hasnan={nan} sparse={sp}",
-            lid=self.layer_id,
-            n=jnp.linalg.norm(hidden_states.astype(jnp.float32)),
-            mx=jnp.max(jnp.abs(hidden_states.astype(jnp.float32))),
-            nan=jnp.any(jnp.isnan(hidden_states)),
-            sp=int(self.is_layer_sparse),
-        )
+        _dump_array(hidden_states, f"layer{self.layer_id:02d}_post_mlp.npy")
         return hidden_states, residual, kv_fused, topk_ids
 
     def _is_moe_layer(self, config) -> bool:
@@ -485,6 +487,7 @@ class MiMoV2Model(nnx.Module):
     def __call__(self, forward_batch: ForwardBatch, token_to_kv_pool: KVCache):
         residual = None
         hidden_states = self.embed_tokens(forward_batch.input_ids)
+        _dump_array(hidden_states, "embed_out.npy")
 
         layers_kv_fused = []
         layers_topk_ids = []
@@ -504,6 +507,7 @@ class MiMoV2Model(nnx.Module):
             hidden_states += residual
 
         hidden_states = self.norm(hidden_states)
+        _dump_array(hidden_states, "final_norm.npy")
         return hidden_states, layers_kv_fused, layers_topk_ids
 
 

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -571,7 +571,13 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         # Post-load: dequantize FP8 attention + layer-0 MLP to bf16.
         # Q/K head_dim padding (192→256) is handled by the kernel internally.
         if self._is_static_quant:
-            self._dequantize_fp8_to_bf16()
+            if os.environ.get("MIMO_SKIP_DEQUANT", "0") == "1":
+                logger.warning(
+                    "MIMO_SKIP_DEQUANT=1: skipping _dequantize_fp8_to_bf16 — "
+                    "FP8 QuantizedLinear will run via quantized matmul kernel"
+                )
+            else:
+                self._dequantize_fp8_to_bf16()
 
     @staticmethod
     def _warmup_safetensors_cache(model_config: ModelConfig):
@@ -1182,7 +1188,13 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
         logger.info("MiMoV2Pro weights loaded successfully!")
 
         if self._is_static_quant:
-            self._dequantize_fp8_to_bf16()
+            if os.environ.get("MIMO_SKIP_DEQUANT", "0") == "1":
+                logger.warning(
+                    "MIMO_SKIP_DEQUANT=1: skipping _dequantize_fp8_to_bf16 — "
+                    "FP8 QuantizedLinear will run via quantized matmul kernel"
+                )
+            else:
+                self._dequantize_fp8_to_bf16()
 
 
 EntryClass = [MiMoV2FlashForCausalLM, MiMoV2ProForCausalLM]

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -94,10 +94,15 @@ class MiMoV2MLP(nnx.Module):
         self.act_fn = jax.nn.silu
 
     def __call__(self, hidden_states: jax.Array):
+        _dump_array(hidden_states, f"layer{self.layer_id:02d}_mlp_in.npy")
         a1, _ = self.gate_proj(hidden_states)
+        _dump_array(a1, f"layer{self.layer_id:02d}_mlp_gate.npy")
         a2, _ = self.up_proj(hidden_states)
+        _dump_array(a2, f"layer{self.layer_id:02d}_mlp_up.npy")
         intermediate_parallel = a2 * self.act_fn(a1)
+        _dump_array(intermediate_parallel, f"layer{self.layer_id:02d}_mlp_inter.npy")
         output, _ = self.down_proj(intermediate_parallel)
+        _dump_array(output, f"layer{self.layer_id:02d}_mlp_out.npy")
         return output
 
 
@@ -435,6 +440,7 @@ class MiMoV2DecoderLayer(nnx.Module):
         hidden_states += residual
         residual = hidden_states
         hidden_states = self.post_attention_layernorm(hidden_states)
+        _dump_array(hidden_states, f"layer{self.layer_id:02d}_post_attn_norm.npy")
 
         if self.is_layer_sparse:
             mlp_output, topk_ids = self.mlp(hidden_states, forward_batch)

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -1,4 +1,4 @@
-"""MiMo-V2-Flash model implementation for SGLang-JAX."""
+"""MiMo-V2 model implementations (Flash and Pro) for SGLang-JAX."""
 
 import logging
 from typing import Any
@@ -865,12 +865,11 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         mappings = {}
         is_fp8 = self._is_static_quant
 
-        # Attention projections
+        # Attention Q/K/V projections (separate weights for Flash)
         for proj, sharding, kv_pad, hd_pad in [
             ("q_proj", (None, "tensor"), False, True),
             ("k_proj", (None, "tensor"), not is_fp8, True),
             ("v_proj", (None, "tensor"), not is_fp8, False),
-            ("o_proj", ("tensor", None), False, True),
         ]:
             hf_key = f"{prefix}.self_attn.{proj}"
             ignored = self._is_quant_ignored(hf_key)
@@ -890,6 +889,36 @@ class MiMoV2FlashForCausalLM(nnx.Module):
                     sharding=(None, None),
                     transpose=False,
                 )
+
+        # Common mappings: o_proj, sink bias, layernorms, MLP/MoE
+        mappings.update(self._create_common_layer_mappings(layer_idx))
+
+        return mappings
+
+    def _create_common_layer_mappings(self, layer_idx: int) -> dict:
+        """Create weight mappings shared between Flash and Pro: o_proj, sink bias, layernorms, MLP/MoE."""
+        prefix = f"model.layers.{layer_idx}"
+        target = prefix
+        mappings = {}
+        is_fp8 = self._is_static_quant
+
+        # o_proj
+        hf_key = f"{prefix}.self_attn.o_proj"
+        ignored = self._is_quant_ignored(hf_key)
+        weight_suffix = "weight" if (not is_fp8 or ignored) else "weight_q"
+        mappings[f"{hf_key}.weight"] = WeightMapping(
+            target_path=f"{target}.self_attn.o_proj.{weight_suffix}",
+            sharding=("tensor", None),
+            transpose=True,
+            head_dim_padding=True,
+            kv_head_padding=False,
+        )
+        if is_fp8 and not ignored:
+            mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"{target}.self_attn.o_proj.weight_scale",
+                sharding=(None, None),
+                transpose=False,
+            )
 
         # Attention sink bias
         is_swa = (
@@ -1030,4 +1059,77 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         return output, layers_kv_fused, True, layers_topk_ids
 
 
-EntryClass = [MiMoV2FlashForCausalLM]
+class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+    """MiMo V2 Pro variant.
+
+    Same architecture as Flash, but the checkpoint stores fused ``qkv_proj``
+    weights instead of separate ``q_proj``/``k_proj``/``v_proj``.  The weight
+    loader splits the fused tensor via ``_split_qkv_weight``.
+
+    Additionally, ``v_head_dim`` (128) != ``head_dim`` (192), which is handled
+    by ``WeightLoader.v_head_dim_original``.
+    """
+
+    def _create_layer_mappings(self, layer_idx: int) -> dict:
+        prefix = f"model.layers.{layer_idx}"
+        target = prefix
+        mappings = {}
+        is_fp8 = self._is_static_quant
+
+        # Fused QKV mapping: list target_path triggers _split_qkv_weight
+        if is_fp8:
+            mappings[f"{prefix}.self_attn.qkv_proj.weight"] = WeightMapping(
+                target_path=[
+                    f"{target}.self_attn.q_proj.weight_q",
+                    f"{target}.self_attn.k_proj.weight_q",
+                    f"{target}.self_attn.v_proj.weight_q",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=False,
+                kv_head_padding=False,
+            )
+            mappings[f"{prefix}.self_attn.qkv_proj.weight_scale_inv"] = WeightMapping(
+                target_path=[
+                    f"{target}.self_attn.q_proj.weight_scale",
+                    f"{target}.self_attn.k_proj.weight_scale",
+                    f"{target}.self_attn.v_proj.weight_scale",
+                ],
+                sharding=(None, None),
+                transpose=False,
+            )
+        else:
+            mappings[f"{prefix}.self_attn.qkv_proj.weight"] = WeightMapping(
+                target_path=[
+                    f"{target}.self_attn.q_proj.weight",
+                    f"{target}.self_attn.k_proj.weight",
+                    f"{target}.self_attn.v_proj.weight",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=False,
+                kv_head_padding=False,
+            )
+
+        # Common mappings: o_proj, sink bias, layernorms, MLP/MoE
+        mappings.update(self._create_common_layer_mappings(layer_idx))
+        return mappings
+
+    def load_weights(self, model_config: ModelConfig):
+        # Skip _warmup_safetensors_cache: Pro ~1TB exceeds GCSFuse cache capacity
+        loader = WeightLoader(
+            model=self,
+            model_config=model_config,
+            mesh=self.mesh,
+            dtype=self.dtype,
+        )
+        self._quant_config = model_config.quantization_config
+        weight_mappings = self._create_weight_mappings()
+        loader.load_weights_from_safetensors(weight_mappings)
+        logger.info("MiMoV2Pro weights loaded successfully!")
+
+        if self._is_static_quant:
+            self._dequantize_fp8_to_bf16()
+
+
+EntryClass = [MiMoV2FlashForCausalLM, MiMoV2ProForCausalLM]

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -29,6 +29,17 @@ logger = logging.getLogger(__name__)
 _DUMP_DIR = "/tmp/mimo_dumps"
 _DUMP_ENABLED = os.environ.get("MIMO_DEBUG_DUMP", "0") == "1"
 
+# Loud sentinel so we can verify module load + env at server startup.
+print(
+    f"[MIMO_DUMP] module loaded, MIMO_DEBUG_DUMP env={os.environ.get('MIMO_DEBUG_DUMP', 'unset')} "
+    f"_DUMP_ENABLED={_DUMP_ENABLED} pid={os.getpid()}",
+    flush=True,
+)
+if _DUMP_ENABLED:
+    os.makedirs(_DUMP_DIR, exist_ok=True)
+    with open(os.path.join(_DUMP_DIR, f"_loaded_pid{os.getpid()}.txt"), "w") as f:
+        f.write("ok\n")
+
 
 def _dump_array(arr: jax.Array, filename: str) -> None:
     """Save a JAX array to /tmp/mimo_dumps/<filename>.npy via host callback.

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -383,6 +383,13 @@ class MiMoV2DecoderLayer(nnx.Module):
         token_to_kv_pool: KVCache,
         residual: jax.Array | None = None,
     ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array | None]:
+        jax.debug.print(
+            "[DBG L{lid}] in: norm={n} max={mx} hasnan={nan}",
+            lid=self.layer_id,
+            n=jnp.linalg.norm(hidden_states.astype(jnp.float32)),
+            mx=jnp.max(jnp.abs(hidden_states.astype(jnp.float32))),
+            nan=jnp.any(jnp.isnan(hidden_states)),
+        )
         if residual is None:
             residual = hidden_states
             hidden_states = self.input_layernorm(hidden_states)
@@ -397,6 +404,13 @@ class MiMoV2DecoderLayer(nnx.Module):
             forward_batch=forward_batch,
             token_to_kv_pool=token_to_kv_pool,
         )
+        jax.debug.print(
+            "[DBG L{lid}] post-attn: norm={n} max={mx} hasnan={nan}",
+            lid=self.layer_id,
+            n=jnp.linalg.norm(hidden_states.astype(jnp.float32)),
+            mx=jnp.max(jnp.abs(hidden_states.astype(jnp.float32))),
+            nan=jnp.any(jnp.isnan(hidden_states)),
+        )
 
         hidden_states += residual
         residual = hidden_states
@@ -409,6 +423,14 @@ class MiMoV2DecoderLayer(nnx.Module):
             topk_ids = None
 
         hidden_states = mlp_output
+        jax.debug.print(
+            "[DBG L{lid}] post-mlp: norm={n} max={mx} hasnan={nan} sparse={sp}",
+            lid=self.layer_id,
+            n=jnp.linalg.norm(hidden_states.astype(jnp.float32)),
+            mx=jnp.max(jnp.abs(hidden_states.astype(jnp.float32))),
+            nan=jnp.any(jnp.isnan(hidden_states)),
+            sp=int(self.is_layer_sparse),
+        )
         return hidden_states, residual, kv_fused, topk_ids
 
     def _is_moe_layer(self, config) -> bool:

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -103,6 +103,10 @@ class MiMoV2Moe(nnx.Module):
         self.topk = TopK(
             topk=num_experts_per_tok,
             renormalize=getattr(config, "norm_topk_prob", True),
+            num_expert_group=getattr(config, "n_group", 0) or 0,
+            topk_group=getattr(config, "topk_group", 0) or 0,
+            routed_scaling_factor=getattr(config, "routed_scaling_factor", None) or 1.0,
+            layer_id=layer_id,
         )
 
         if self.use_fused:

--- a/python/sgl_jax/srt/models/mimo_v2.py
+++ b/python/sgl_jax/srt/models/mimo_v2.py
@@ -1143,8 +1143,8 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
                     f"{target}.self_attn.k_proj.weight_q",
                     f"{target}.self_attn.v_proj.weight_q",
                 ],
-                sharding=(None, "tensor"),
-                transpose=True,
+                sharding=("tensor", None),
+                transpose=False,
                 head_dim_padding=False,
                 kv_head_padding=False,
             )

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1539,6 +1539,7 @@ class WeightLoader:
         q_dim = self.num_heads * self.head_dim_original
         k_dim = self.num_kv_heads * self.head_dim_original
         v_dim = self.num_kv_heads * self.v_head_dim_original
+        v_scale_padded_per_head = False
 
         if hf_key.endswith(".bias"):
             # Auto-detect scale tensor (block-compressed dimensions). Producer
@@ -1600,6 +1601,7 @@ class WeightLoader:
             split_axis = 1 if mapping.transpose else 0
             actual_dim = weight.shape[split_axis]
             is_scale = False
+            v_scale_padded_per_head = False
             v_dim_keep = v_dim
 
             if actual_dim != total_dim:
@@ -1615,8 +1617,15 @@ class WeightLoader:
                 q_dim //= block_size
                 k_dim //= block_size
                 if actual_dim == expected_scale_dim_padded:
+                    # V scale was computed on a per-head-padded V (each head
+                    # padded from v_head_dim_original to head_dim_original
+                    # before block-quant). The V weight on disk stays compact
+                    # at v_head_dim_original, so we keep ALL padded V scale
+                    # rows here and remap to compact channels in the loop
+                    # below via expand_block_scale(channel_to_block=...).
                     v_dim = v_dim_padded // block_size
-                    v_dim_keep = (self.num_kv_heads * self.v_head_dim_original) // block_size
+                    v_dim_keep = v_dim
+                    v_scale_padded_per_head = True
                 else:
                     v_dim //= block_size
                     v_dim_keep = v_dim
@@ -1706,10 +1715,44 @@ class WeightLoader:
 
             model_param = self._get_param(params, jax_path)
 
-            # Expand 2D block-quant scale to 3D kernel-ready layout.
-            sharded_weight = self._maybe_expand_linear_block_scale(
-                sharded_weight, model_param, jax_path
-            )
+            # Special case: padded-per-head V scale needs per-channel gather
+            # because compact V channels (h * v_head_dim_original + w) map to
+            # non-contiguous padded scale rows ((h * head_dim_original + w)
+            # // block_size). Done here (post-shard) since the per-channel
+            # 3D output bypasses the standard uniform-block expansion below.
+            if (
+                not hf_key.endswith(".bias")
+                and "v_proj" in jax_path
+                and v_scale_padded_per_head
+                and jax_path.endswith("weight_scale")
+            ):
+                from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
+                    expand_block_scale,
+                )
+
+                block_size = 128
+                n_out_compact = self.num_kv_heads * self.v_head_dim_original
+                head_idx = jnp.arange(n_out_compact) // self.v_head_dim_original
+                within_idx = jnp.arange(n_out_compact) % self.v_head_dim_original
+                channel_to_block = (head_idx * self.head_dim_original + within_idx) // block_size
+
+                if mapping.transpose:
+                    # sharded_weight: [hidden_blocks, padded_out_blocks]
+                    scale_2d = jnp.transpose(sharded_weight, (1, 0))
+                else:
+                    scale_2d = sharded_weight
+
+                sharded_weight = expand_block_scale(
+                    scale_2d,
+                    n_out=n_out_compact,
+                    block_size_out=block_size,
+                    channel_to_block=channel_to_block,
+                )
+            else:
+                # Expand 2D block-quant scale to 3D kernel-ready layout.
+                sharded_weight = self._maybe_expand_linear_block_scale(
+                    sharded_weight, model_param, jax_path
+                )
 
             if sharded_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                 model_param.value = sharded_weight

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -795,7 +795,7 @@ class WeightLoader:
         stacked_shape = (num_physical_experts, *final_single_shape)
         sharding = target_sharding or jax.sharding.NamedSharding(self.mesh, P())
 
-        LOAD_WORKERS = 16
+        LOAD_WORKERS = int(os.environ.get("SGLANG_MOE_LOAD_WORKERS", "64"))
 
         def _load_stacked_slice(index):
             expert_slice = index[0]
@@ -822,37 +822,14 @@ class WeightLoader:
             else:
                 logical_indices_to_load = physical_indices
 
-            first_log_idx = logical_indices_to_load[0]
-            first_hf_key = expected_hf_keys[first_log_idx]
-            first_fname = weight_info[first_hf_key][0]["file"]
-            first_f = file_manager.get_handle(first_fname)
+            logical_to_positions: dict[int, list[int]] = {}
+            for phys_pos, log_idx in enumerate(logical_indices_to_load):
+                logical_to_positions.setdefault(log_idx, []).append(phys_pos)
 
-            if not do_transpose:
-                first_chunk = first_f.get_slice(first_hf_key)[inner_slice]
-                first_chunk = _view_as_fp8_if_needed(first_chunk, target_dtype)
-            else:
-                data = first_f.get_slice(first_hf_key)[:]
-                data = _view_as_fp8_if_needed(data, target_dtype)
-                first_chunk = np.transpose(data)[inner_slice]
-
-            out_shape = (sliced_num_physical, *first_chunk.shape)
-            out_array = np.empty(out_shape, dtype=first_chunk.dtype)
-            out_array[0] = first_chunk
-
-            logical_to_positions = {}
-            for phys_pos in range(1, sliced_num_physical):
-                log_idx = logical_indices_to_load[phys_pos]
-                if log_idx == first_log_idx:
-                    out_array[phys_pos] = first_chunk
-                else:
-                    logical_to_positions.setdefault(log_idx, []).append(phys_pos)
-
-            def load_and_fill_expert(args):
-                l_idx, positions = args
+            def _read_expert(l_idx):
                 hf_k = expected_hf_keys[l_idx]
                 fname = weight_info[hf_k][0]["file"]
                 f = file_manager.get_handle(fname)
-
                 if not do_transpose:
                     chunk = f.get_slice(hf_k)[inner_slice]
                     chunk = _view_as_fp8_if_needed(chunk, target_dtype)
@@ -860,14 +837,18 @@ class WeightLoader:
                     data = f.get_slice(hf_k)[:]
                     data = _view_as_fp8_if_needed(data, target_dtype)
                     chunk = np.transpose(data)[inner_slice]
+                return chunk
 
-                for pos in positions:
+            unique_logical = list(logical_to_positions.keys())
+            with ThreadPoolExecutor(max_workers=LOAD_WORKERS) as executor:
+                chunks = list(executor.map(_read_expert, unique_logical))
+
+            first_chunk = chunks[0]
+            out_shape = (sliced_num_physical, *first_chunk.shape)
+            out_array = np.empty(out_shape, dtype=first_chunk.dtype)
+            for l_idx, chunk in zip(unique_logical, chunks, strict=True):
+                for pos in logical_to_positions[l_idx]:
                     out_array[pos] = chunk
-
-            if logical_to_positions:
-                tasks = list(logical_to_positions.items())
-                with ThreadPoolExecutor(max_workers=LOAD_WORKERS) as executor:
-                    list(executor.map(load_and_fill_expert, tasks))
 
             return out_array
 

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -137,6 +137,7 @@ class WeightLoader:
 
             self.head_dim_pad = (self.head_dim_original + 127) // 128 * 128 - self.head_dim_original
             self.head_dim = self.head_dim_original
+            self.v_head_dim_original = getattr(model_config, "v_head_dim", self.head_dim_original)
         if hasattr(self.mesh, "shape") and "tensor" in self.mesh.shape:
             self.sharding_size = self.mesh.shape["tensor"]
         else:
@@ -1533,13 +1534,28 @@ class WeightLoader:
     ):
         jax_paths = mapping.target_path
 
+        q_dim = self.num_heads * self.head_dim_original
+        k_dim = self.num_kv_heads * self.head_dim_original
+        v_dim = self.num_kv_heads * self.v_head_dim_original
+
         if hf_key.endswith(".bias"):
-            q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            # Auto-detect scale tensor (block-compressed dimensions)
+            total_dim = q_dim + k_dim + v_dim
+            actual_dim = weight.shape[0]
+            if actual_dim != total_dim:
+                block_size = 128
+                expected_scale_dim = total_dim // block_size
+                assert actual_dim == expected_scale_dim, (
+                    f"QKV bias/scale split dim mismatch: got {actual_dim}, "
+                    f"expected weight={total_dim} or scale={expected_scale_dim}"
+                )
+                q_dim //= block_size
+                k_dim //= block_size
+                v_dim //= block_size
 
             q_bias = weight[:q_dim]
-            k_bias = weight[q_dim : q_dim + kv_dim]
-            v_bias = weight[q_dim + kv_dim : q_dim + 2 * kv_dim]
+            k_bias = weight[q_dim : q_dim + k_dim]
+            v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 q_bias = jnp.reshape(q_bias, (self.num_heads, self.head_dim_original))
@@ -1550,25 +1566,48 @@ class WeightLoader:
                 k_bias = jnp.pad(k_bias, ((0, 0), (0, self.head_dim_pad)))
                 k_bias = jnp.reshape(k_bias, (self.num_kv_heads * self.head_dim,))
 
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, self.head_dim_original))
-                v_bias = jnp.pad(v_bias, ((0, 0), (0, self.head_dim_pad)))
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * self.head_dim,))
+                v_head_dim_pad = (
+                    self.v_head_dim_original + 127
+                ) // 128 * 128 - self.v_head_dim_original
+                if v_head_dim_pad > 0:
+                    v_bias = jnp.reshape(v_bias, (self.num_kv_heads, self.v_head_dim_original))
+                    v_bias = jnp.pad(v_bias, ((0, 0), (0, v_head_dim_pad)))
+                    v_padded_dim = self.v_head_dim_original + v_head_dim_pad
+                    v_bias = jnp.reshape(v_bias, (self.num_kv_heads * v_padded_dim,))
 
             splits = [q_bias, k_bias, v_bias]
         else:
-            q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            # Auto-detect scale tensor (block-compressed dimensions)
+            total_dim = q_dim + k_dim + v_dim
+            split_axis = 1 if mapping.transpose else 0
+            actual_dim = weight.shape[split_axis]
+            is_scale = False
+
+            if actual_dim != total_dim:
+                block_size = 128
+                expected_scale_dim = total_dim // block_size
+                assert actual_dim == expected_scale_dim, (
+                    f"QKV split dim mismatch: got {actual_dim}, "
+                    f"expected weight={total_dim} or scale={expected_scale_dim}"
+                )
+                q_dim //= block_size
+                k_dim //= block_size
+                v_dim //= block_size
+                is_scale = True
 
             if mapping.transpose:
                 q_weight = weight[:, :q_dim]
-                k_weight = weight[:, q_dim : q_dim + kv_dim]
-                v_weight = weight[:, q_dim + kv_dim : q_dim + 2 * kv_dim]
+                k_weight = weight[:, q_dim : q_dim + k_dim]
+                v_weight = weight[:, q_dim + k_dim : q_dim + k_dim + v_dim]
             else:
                 q_weight = weight[:q_dim, :]
-                k_weight = weight[q_dim : q_dim + kv_dim, :]
-                v_weight = weight[q_dim + kv_dim : q_dim + 2 * kv_dim, :]
+                k_weight = weight[q_dim : q_dim + k_dim, :]
+                v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
 
-            if mapping.head_dim_padding and self.head_dim_pad > 0:
+            if not is_scale and mapping.head_dim_padding and self.head_dim_pad > 0:
+                v_head_dim_pad = (
+                    self.v_head_dim_original + 127
+                ) // 128 * 128 - self.v_head_dim_original
                 if mapping.transpose:
                     q_weight = jnp.reshape(
                         q_weight,
@@ -1588,14 +1627,16 @@ class WeightLoader:
                         k_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
                     )
 
-                    v_weight = jnp.reshape(
-                        v_weight,
-                        (self.hidden_size, self.num_kv_heads, self.head_dim_original),
-                    )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, self.head_dim_pad)))
-                    v_weight = jnp.reshape(
-                        v_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
-                    )
+                    if v_head_dim_pad > 0:
+                        v_weight = jnp.reshape(
+                            v_weight,
+                            (self.hidden_size, self.num_kv_heads, self.v_head_dim_original),
+                        )
+                        v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, v_head_dim_pad)))
+                        v_padded_dim = self.v_head_dim_original + v_head_dim_pad
+                        v_weight = jnp.reshape(
+                            v_weight, (self.hidden_size, self.num_kv_heads * v_padded_dim)
+                        )
                 else:
                     q_weight = jnp.reshape(
                         q_weight,
@@ -1615,14 +1656,16 @@ class WeightLoader:
                         k_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
                     )
 
-                    v_weight = jnp.reshape(
-                        v_weight,
-                        (self.num_kv_heads, self.head_dim_original, self.hidden_size),
-                    )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, self.head_dim_pad), (0, 0)))
-                    v_weight = jnp.reshape(
-                        v_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
-                    )
+                    if v_head_dim_pad > 0:
+                        v_weight = jnp.reshape(
+                            v_weight,
+                            (self.num_kv_heads, self.v_head_dim_original, self.hidden_size),
+                        )
+                        v_weight = jnp.pad(v_weight, ((0, 0), (0, v_head_dim_pad), (0, 0)))
+                        v_padded_dim = self.v_head_dim_original + v_head_dim_pad
+                        v_weight = jnp.reshape(
+                            v_weight, (self.num_kv_heads * v_padded_dim, self.hidden_size)
+                        )
 
             splits = [q_weight, k_weight, v_weight]
 
@@ -1635,6 +1678,11 @@ class WeightLoader:
             sharded_weight = self._shard_weight(processed_weight, mapping.sharding)
 
             model_param = self._get_param(params, jax_path)
+
+            # Expand 2D block-quant scale to 3D kernel-ready layout.
+            sharded_weight = self._maybe_expand_linear_block_scale(
+                sharded_weight, model_param, jax_path
+            )
 
             if sharded_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                 model_param.value = sharded_weight

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1797,7 +1797,15 @@ class WeightLoader:
         total_dim = q_dim + k_dim + v_dim
 
         split_axis = 1 if transpose else 0
+        in_axis = 0 if transpose else 1
         actual_dim = fused_weight.shape[split_axis]
+        assert (
+            fused_weight.shape[in_axis] == hidden
+            or fused_weight.shape[in_axis] == hidden // block_size
+        ), (
+            f"hidden dim mismatch: expected {hidden} or {hidden // block_size} "
+            f"on axis {in_axis}, got {fused_weight.shape[in_axis]}"
+        )
 
         v_dim_keep = v_dim
 

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1539,23 +1539,35 @@ class WeightLoader:
         v_dim = self.num_kv_heads * self.v_head_dim_original
 
         if hf_key.endswith(".bias"):
-            # Auto-detect scale tensor (block-compressed dimensions)
+            # Auto-detect scale tensor (block-compressed dimensions). Producer
+            # may compute scale rows using head_dim_original for V (padding V
+            # per-head to head_dim_original before block-quant), so the scale
+            # has more V rows than v_dim/block_size; drop the trailing pad rows.
             total_dim = q_dim + k_dim + v_dim
+            v_dim_keep = v_dim
             actual_dim = weight.shape[0]
             if actual_dim != total_dim:
                 block_size = 128
-                expected_scale_dim = total_dim // block_size
-                assert actual_dim == expected_scale_dim, (
+                v_dim_padded = self.num_kv_heads * self.head_dim_original
+                expected_scale_dim_real = total_dim // block_size
+                expected_scale_dim_padded = (q_dim + k_dim + v_dim_padded) // block_size
+                assert actual_dim in (expected_scale_dim_real, expected_scale_dim_padded), (
                     f"QKV bias/scale split dim mismatch: got {actual_dim}, "
-                    f"expected weight={total_dim} or scale={expected_scale_dim}"
+                    f"expected weight={total_dim}, scale={expected_scale_dim_real}, "
+                    f"or padded-V scale={expected_scale_dim_padded}"
                 )
                 q_dim //= block_size
                 k_dim //= block_size
-                v_dim //= block_size
+                if actual_dim == expected_scale_dim_padded:
+                    v_dim = v_dim_padded // block_size
+                    v_dim_keep = (self.num_kv_heads * self.v_head_dim_original) // block_size
+                else:
+                    v_dim //= block_size
+                    v_dim_keep = v_dim
 
             q_bias = weight[:q_dim]
             k_bias = weight[q_dim : q_dim + k_dim]
-            v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
+            v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim_keep]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 q_bias = jnp.reshape(q_bias, (self.num_heads, self.head_dim_original))
@@ -1577,32 +1589,45 @@ class WeightLoader:
 
             splits = [q_bias, k_bias, v_bias]
         else:
-            # Auto-detect scale tensor (block-compressed dimensions)
+            # Auto-detect scale tensor (block-compressed dimensions). For
+            # fused FP8 checkpoints, the producer may compute scale rows using
+            # head_dim_original for V (V padded per-head to head_dim_original
+            # before block-quant), so the scale has more V rows than
+            # v_dim/block_size. Drop the trailing pad rows after split.
             total_dim = q_dim + k_dim + v_dim
             split_axis = 1 if mapping.transpose else 0
             actual_dim = weight.shape[split_axis]
             is_scale = False
+            v_dim_keep = v_dim
 
             if actual_dim != total_dim:
                 block_size = 128
-                expected_scale_dim = total_dim // block_size
-                assert actual_dim == expected_scale_dim, (
+                v_dim_padded = self.num_kv_heads * self.head_dim_original
+                expected_scale_dim_real = total_dim // block_size
+                expected_scale_dim_padded = (q_dim + k_dim + v_dim_padded) // block_size
+                assert actual_dim in (expected_scale_dim_real, expected_scale_dim_padded), (
                     f"QKV split dim mismatch: got {actual_dim}, "
-                    f"expected weight={total_dim} or scale={expected_scale_dim}"
+                    f"expected weight={total_dim}, scale={expected_scale_dim_real}, "
+                    f"or padded-V scale={expected_scale_dim_padded}"
                 )
                 q_dim //= block_size
                 k_dim //= block_size
-                v_dim //= block_size
+                if actual_dim == expected_scale_dim_padded:
+                    v_dim = v_dim_padded // block_size
+                    v_dim_keep = (self.num_kv_heads * self.v_head_dim_original) // block_size
+                else:
+                    v_dim //= block_size
+                    v_dim_keep = v_dim
                 is_scale = True
 
             if mapping.transpose:
                 q_weight = weight[:, :q_dim]
                 k_weight = weight[:, q_dim : q_dim + k_dim]
-                v_weight = weight[:, q_dim + k_dim : q_dim + k_dim + v_dim]
+                v_weight = weight[:, q_dim + k_dim : q_dim + k_dim + v_dim_keep]
             else:
                 q_weight = weight[:q_dim, :]
                 k_weight = weight[q_dim : q_dim + k_dim, :]
-                v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
+                v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim_keep, :]
 
             if not is_scale and mapping.head_dim_padding and self.head_dim_pad > 0:
                 v_head_dim_pad = (

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1761,6 +1761,80 @@ class WeightLoader:
 
             logger.debug("Split %s -> %s, shape: %s", hf_key, jax_path, processed_weight.shape)
 
+    @staticmethod
+    def _split_fused_qkv_for_test(
+        fused_weight: jax.Array,
+        *,
+        transpose: bool,
+        is_scale: bool,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim_orig: int,
+        v_head_dim_orig: int,
+        hidden: int,
+    ) -> tuple[jax.Array, jax.Array, jax.Array]:
+        """Return (q, k, v) slices from a fused QKV weight or scale tensor.
+
+        Pure function for unit tests — no nnx.State / mesh / params needed.
+
+        When ``transpose=False`` the input is HF-layout ``[out_total, in]``
+        and each returned slice has shape ``[out_*, in]``.
+
+        When ``transpose=True`` the input was already transposed to
+        ``[in, out_total]`` and each returned slice has shape ``[in, out_*]``.
+
+        When ``is_scale=True`` the input is the block-quant scale
+        ``[out_blocks, in_blocks]`` (or ``[in_blocks, out_blocks]`` for
+        ``transpose=True``).  For padded-V scales (where V was computed per
+        head with padding to ``head_dim_orig``) the V slice keeps ALL padded
+        rows (``num_kv_heads * head_dim_orig // BLOCK``) so that the caller can
+        remap them via ``expand_block_scale(channel_to_block=...)``.
+        """
+        block_size = 128
+        q_dim = num_heads * head_dim_orig
+        k_dim = num_kv_heads * head_dim_orig
+        v_dim = num_kv_heads * v_head_dim_orig
+        total_dim = q_dim + k_dim + v_dim
+
+        split_axis = 1 if transpose else 0
+        actual_dim = fused_weight.shape[split_axis]
+
+        v_dim_keep = v_dim
+
+        if actual_dim != total_dim:
+            # Scale tensor: block-compressed dimensions.
+            v_dim_padded = num_kv_heads * head_dim_orig
+            expected_scale_dim_real = total_dim // block_size
+            expected_scale_dim_padded = (q_dim + k_dim + v_dim_padded) // block_size
+            assert actual_dim in (expected_scale_dim_real, expected_scale_dim_padded), (
+                f"QKV split dim mismatch: got {actual_dim}, "
+                f"expected weight={total_dim}, scale={expected_scale_dim_real}, "
+                f"or padded-V scale={expected_scale_dim_padded}"
+            )
+            assert (
+                is_scale
+            ), f"Unexpected non-scale dim mismatch: actual={actual_dim}, total={total_dim}"
+            q_dim //= block_size
+            k_dim //= block_size
+            if actual_dim == expected_scale_dim_padded:
+                # V scale computed on per-head-padded V: keep all padded rows.
+                v_dim = v_dim_padded // block_size
+                v_dim_keep = v_dim
+            else:
+                v_dim //= block_size
+                v_dim_keep = v_dim
+
+        if transpose:
+            q_out = fused_weight[:, :q_dim]
+            k_out = fused_weight[:, q_dim : q_dim + k_dim]
+            v_out = fused_weight[:, q_dim + k_dim : q_dim + k_dim + v_dim_keep]
+        else:
+            q_out = fused_weight[:q_dim, :]
+            k_out = fused_weight[q_dim : q_dim + k_dim, :]
+            v_out = fused_weight[q_dim + k_dim : q_dim + k_dim + v_dim_keep, :]
+
+        return q_out, k_out, v_out
+
     def _shard_weight(
         self, weight: jax.Array, sharding_spec: tuple, mesh: jax.sharding.Mesh = None
     ) -> jax.Array:

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -368,100 +368,6 @@ class WeightLoader:
         )
         return expand_block_scale(weight, n_out, block_size_out)
 
-    def _prewarm_weight_files(
-        self,
-        weight_info: dict,
-        regular_mappings: dict,
-        moe_mappings: dict,
-    ) -> None:
-        """Stream safetensors files concurrently to populate the gcsfuse
-        file-cache before the loader pulls per-tensor slices. The loader's
-        per-tensor reads are single-stream-bound by gcsfuse (~250 MB/s); a
-        background pool with 8-16 concurrent streams reaches ~2 GB/s
-        aggregate, so the loader hits warm pages.
-
-        Disabled by default; opt in via SGLANG_PREWARM_WEIGHTS=1. Set
-        SGLANG_PREWARM_PARALLELISM (default 8) and SGLANG_PREWARM_MAX_GB
-        (default 0 = no cap) to tune."""
-        if jax.process_index() != 0:
-            return
-        if os.environ.get("SGLANG_PREWARM_WEIGHTS", "0") != "1":
-            return
-
-        files = set()
-        for hf_key in regular_mappings:
-            for info in weight_info.get(hf_key, []):
-                files.add(info["file"])
-        for moe_key, mapping in moe_mappings.items():
-            for hf_key in mapping.target_path[1:]:
-                for info in weight_info.get(hf_key, []):
-                    files.add(info["file"])
-
-        if not files:
-            return
-
-        files = sorted(files)
-        try:
-            sized = [(f, os.path.getsize(f)) for f in files]
-        except OSError as exc:
-            logger.warning("Prewarm stat failed: %s; skipping", exc)
-            return
-
-        max_gb = float(os.environ.get("SGLANG_PREWARM_MAX_GB", "0"))
-        if max_gb > 0:
-            cap_bytes = int(max_gb * 1024 * 1024 * 1024)
-            kept: list[tuple[str, int]] = []
-            running = 0
-            for f, sz in sized:
-                if running + sz > cap_bytes:
-                    break
-                kept.append((f, sz))
-                running += sz
-            sized = kept
-
-        if not sized:
-            return
-
-        max_workers = int(os.environ.get("SGLANG_PREWARM_PARALLELISM", "8"))
-        chunk_size = 8 * 1024 * 1024
-
-        def _stream(path: str) -> int:
-            try:
-                total = 0
-                with open(path, "rb", buffering=0) as fh:
-                    while True:
-                        buf = fh.read(chunk_size)
-                        if not buf:
-                            break
-                        total += len(buf)
-                return total
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("Prewarm failed for %s: %s", path, exc)
-                return 0
-
-        import time
-
-        start = time.time()
-        total_target = sum(sz for _, sz in sized)
-        logger.info(
-            "Prewarming %d files (%.1f GiB) with %d concurrent streams...",
-            len(sized),
-            total_target / (1024 * 1024 * 1024),
-            max_workers,
-        )
-        total_bytes = 0
-        with ThreadPoolExecutor(max_workers=max_workers) as ex:
-            for n in ex.map(_stream, [f for f, _ in sized]):
-                total_bytes += n
-        elapsed = time.time() - start
-        rate_mbps = total_bytes / max(elapsed, 1e-6) / (1024 * 1024)
-        logger.info(
-            "Prewarm complete: %.2f GiB in %.1fs (%.1f MB/s aggregate)",
-            total_bytes / (1024 * 1024 * 1024),
-            elapsed,
-            rate_mbps,
-        )
-
     def _scan_weight_info(self) -> dict[str, list[dict]]:
         """
         Scan all safetensors files to build a mapping from HF key to file info.
@@ -1028,8 +934,6 @@ class WeightLoader:
         logger.info("Starting parallel weight loading via JAX Lazy Loader...")
         quant_cfg = getattr(self.model_config, "quantization_config", None)
         is_static_quant = quant_cfg is not None and quant_cfg.is_static_checkpoint
-
-        self._prewarm_weight_files(weight_info, regular_mappings, moe_mappings)
 
         with SequentialSafetensorManager() as file_manager:
             # 2. Process Regular Weights (Lazy Pull)

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -368,6 +368,100 @@ class WeightLoader:
         )
         return expand_block_scale(weight, n_out, block_size_out)
 
+    def _prewarm_weight_files(
+        self,
+        weight_info: dict,
+        regular_mappings: dict,
+        moe_mappings: dict,
+    ) -> None:
+        """Stream safetensors files concurrently to populate the gcsfuse
+        file-cache before the loader pulls per-tensor slices. The loader's
+        per-tensor reads are single-stream-bound by gcsfuse (~250 MB/s); a
+        background pool with 8-16 concurrent streams reaches ~2 GB/s
+        aggregate, so the loader hits warm pages.
+
+        Disabled by default; opt in via SGLANG_PREWARM_WEIGHTS=1. Set
+        SGLANG_PREWARM_PARALLELISM (default 8) and SGLANG_PREWARM_MAX_GB
+        (default 0 = no cap) to tune."""
+        if jax.process_index() != 0:
+            return
+        if os.environ.get("SGLANG_PREWARM_WEIGHTS", "0") != "1":
+            return
+
+        files = set()
+        for hf_key in regular_mappings:
+            for info in weight_info.get(hf_key, []):
+                files.add(info["file"])
+        for moe_key, mapping in moe_mappings.items():
+            for hf_key in mapping.target_path[1:]:
+                for info in weight_info.get(hf_key, []):
+                    files.add(info["file"])
+
+        if not files:
+            return
+
+        files = sorted(files)
+        try:
+            sized = [(f, os.path.getsize(f)) for f in files]
+        except OSError as exc:
+            logger.warning("Prewarm stat failed: %s; skipping", exc)
+            return
+
+        max_gb = float(os.environ.get("SGLANG_PREWARM_MAX_GB", "0"))
+        if max_gb > 0:
+            cap_bytes = int(max_gb * 1024 * 1024 * 1024)
+            kept: list[tuple[str, int]] = []
+            running = 0
+            for f, sz in sized:
+                if running + sz > cap_bytes:
+                    break
+                kept.append((f, sz))
+                running += sz
+            sized = kept
+
+        if not sized:
+            return
+
+        max_workers = int(os.environ.get("SGLANG_PREWARM_PARALLELISM", "8"))
+        chunk_size = 8 * 1024 * 1024
+
+        def _stream(path: str) -> int:
+            try:
+                total = 0
+                with open(path, "rb", buffering=0) as fh:
+                    while True:
+                        buf = fh.read(chunk_size)
+                        if not buf:
+                            break
+                        total += len(buf)
+                return total
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("Prewarm failed for %s: %s", path, exc)
+                return 0
+
+        import time
+
+        start = time.time()
+        total_target = sum(sz for _, sz in sized)
+        logger.info(
+            "Prewarming %d files (%.1f GiB) with %d concurrent streams...",
+            len(sized),
+            total_target / (1024 * 1024 * 1024),
+            max_workers,
+        )
+        total_bytes = 0
+        with ThreadPoolExecutor(max_workers=max_workers) as ex:
+            for n in ex.map(_stream, [f for f, _ in sized]):
+                total_bytes += n
+        elapsed = time.time() - start
+        rate_mbps = total_bytes / max(elapsed, 1e-6) / (1024 * 1024)
+        logger.info(
+            "Prewarm complete: %.2f GiB in %.1fs (%.1f MB/s aggregate)",
+            total_bytes / (1024 * 1024 * 1024),
+            elapsed,
+            rate_mbps,
+        )
+
     def _scan_weight_info(self) -> dict[str, list[dict]]:
         """
         Scan all safetensors files to build a mapping from HF key to file info.
@@ -934,6 +1028,8 @@ class WeightLoader:
         logger.info("Starting parallel weight loading via JAX Lazy Loader...")
         quant_cfg = getattr(self.model_config, "quantization_config", None)
         is_static_quant = quant_cfg is not None and quant_cfg.is_static_checkpoint
+
+        self._prewarm_weight_files(weight_info, regular_mappings, moe_mappings)
 
         with SequentialSafetensorManager() as file_manager:
             # 2. Process Regular Weights (Lazy Pull)

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 import pickle
 import re
+import threading
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -93,6 +94,8 @@ class SequentialSafetensorManager:
 
     def __init__(self):
         self.handles = {}
+        self._handle_pools: dict[str, list] = {}
+        self._pool_locks: dict[str, threading.Lock] = {}
 
     def get_handle(self, filename):
         if filename not in self.handles:
@@ -100,6 +103,24 @@ class SequentialSafetensorManager:
             # device="cpu" ensures we don't accidentally alloc on GPU/TPU here.
             self.handles[filename] = safe_open(filename, framework="np", device="cpu")
         return self.handles[filename]
+
+    def get_pool_handle(self, filename, pool_size: int = 8):
+        """Return a per-thread-distinct handle to bypass the per-handle read serialization.
+
+        safetensors `safe_open` serializes slice reads on a single handle, capping
+        throughput at ~100MB/s on gcsfuse. Opening multiple handles to the same file
+        and round-robining them across reader threads unlocks per-file parallelism.
+        """
+        if filename not in self._handle_pools:
+            self._pool_locks.setdefault(filename, threading.Lock())
+            with self._pool_locks[filename]:
+                if filename not in self._handle_pools:
+                    self._handle_pools[filename] = [
+                        safe_open(filename, framework="np", device="cpu") for _ in range(pool_size)
+                    ]
+        pool = self._handle_pools[filename]
+        # Round-robin via thread id; collisions are fine since safetensors GIL-releases on read.
+        return pool[threading.get_ident() % len(pool)]
 
     def close_all(self):
         # safe_open objects don't strictly require close() as they rely on RAII/GC,
@@ -829,7 +850,7 @@ class WeightLoader:
             def _read_expert(l_idx):
                 hf_k = expected_hf_keys[l_idx]
                 fname = weight_info[hf_k][0]["file"]
-                f = file_manager.get_handle(fname)
+                f = file_manager.get_pool_handle(fname, pool_size=LOAD_WORKERS)
                 if not do_transpose:
                     chunk = f.get_slice(hf_k)[inner_slice]
                     chunk = _view_as_fp8_if_needed(chunk, target_dtype)

--- a/python/sgl_jax/test/kernels/tuned_block_sizes_test.py
+++ b/python/sgl_jax/test/kernels/tuned_block_sizes_test.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from absl.testing import absltest, parameterized
+
+from sgl_jax.srt.kernels.gmm.megablox_gmm_kernel.tuned_block_sizes import (
+    get_default_gmm_block_sizes,
+    round_up_to_multiple_of_128_within_limit,
+)
+
+
+class RoundUpHeuristicTest(parameterized.TestCase):
+    """Pure-Python tests for the GMM tile-size heuristic.
+
+    The heuristic must (a) preserve legacy behaviour when `divides` is None,
+    and (b) only ever return a value that divides the target when `divides`
+    is set. The latter is required by `_calculate_num_tiles` in gmm.py
+    (`m % tm == 0`); a regression there crashed MiMo V2 Pro EP-MoE on
+    v6e/v7x with m=4096, num_current_groups=24 -> tm=384.
+    """
+
+    def test_divides_none_preserves_legacy(self):
+        # x <= 128 -> 128
+        self.assertEqual(round_up_to_multiple_of_128_within_limit(64, 512), 128)
+        self.assertEqual(round_up_to_multiple_of_128_within_limit(128, 512), 128)
+        # x < limit -> ceil to nearest 128
+        self.assertEqual(round_up_to_multiple_of_128_within_limit(341, 512), 384)
+        self.assertEqual(round_up_to_multiple_of_128_within_limit(129, 512), 256)
+        # x >= limit -> largest 128-multiple >= 512 dividing x
+        self.assertEqual(round_up_to_multiple_of_128_within_limit(2048, 2048), 2048)
+        self.assertEqual(round_up_to_multiple_of_128_within_limit(8192, 2048), 2048)
+
+    def test_divides_walks_down_to_valid_tile(self):
+        # The MiMo V2 Pro regression case: 2*m/g = 341, naive ceil -> 384,
+        # but 4096 % 384 != 0. With divides=4096 we must walk down to 256.
+        self.assertEqual(
+            round_up_to_multiple_of_128_within_limit(341, 512, divides=4096),
+            256,
+        )
+
+    def test_divides_no_op_when_already_divisor(self):
+        # 256 already divides 4096; no decrement should happen.
+        self.assertEqual(
+            round_up_to_multiple_of_128_within_limit(200, 512, divides=4096),
+            256,
+        )
+
+    def test_divides_floor_at_128(self):
+        # 128 always divides any sane m (powers of 2). The decrement loop
+        # must stop at 128 even if the target somehow forbade larger tiles.
+        result = round_up_to_multiple_of_128_within_limit(341, 512, divides=128)
+        self.assertEqual(result, 128)
+
+    @parameterized.named_parameters(
+        # (m, g) -> heuristic must return tm s.t. m % tm == 0
+        ("mimo_v2_pro_v7x", 4096, 24),  # the actual regression
+        ("m4k_g32", 4096, 32),
+        ("m8k_g24", 8192, 24),
+        ("m16k_g32", 16384, 32),
+        ("m1k_g8", 1024, 8),
+        ("m512_g16", 512, 16),
+        ("m4k_g384", 4096, 384),  # all experts on one device (degenerate)
+    )
+    def test_get_default_gmm_block_sizes_tm_divides_m(self, m, g):
+        tm, _, _ = get_default_gmm_block_sizes(m=m, k=4096, n=4096, g=g)
+        self.assertEqual(
+            m % tm,
+            0,
+            msg=f"tm={tm} does not divide m={m} (g={g})",
+        )
+        self.assertGreaterEqual(tm, 128)
+        self.assertEqual(tm % 128, 0, msg=f"tm={tm} is not a multiple of 128")
+
+    def test_mimo_v2_pro_no_longer_picks_384(self):
+        # Tight regression assertion: this exact shape used to return tm=384.
+        tm, _, _ = get_default_gmm_block_sizes(m=4096, k=4096, n=4096, g=24)
+        self.assertNotEqual(tm, 384, msg="heuristic regressed to broken tm=384")
+        self.assertEqual(tm, 256)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tests/srt/models/test_mimo_v2_pro_qkv_split.py
+++ b/tests/srt/models/test_mimo_v2_pro_qkv_split.py
@@ -185,7 +185,10 @@ class TestSplitScalePaddedV:
             np.float32
         )
         self.fused_s = np.concatenate([self.q_scale, self.k_scale, self.v_scale_padded], axis=0)
-        assert self.fused_s.shape == (216, SCALE_COLS), f"fused_s shape: {self.fused_s.shape}"
+        assert self.fused_s.shape == (
+            Q_SCALE_ROWS + K_SCALE_ROWS + V_SCALE_ROWS_PADDED,
+            SCALE_COLS,
+        ), f"fused_s shape: {self.fused_s.shape}"
 
     def test_split_scale_padded_v_keeps_all_v_rows(self):
         helper = _get_helper()
@@ -230,7 +233,7 @@ class TestSplitScaleTransposeTrue:
         )
         fused_s = np.concatenate([self.q_scale, self.k_scale, self.v_scale_padded], axis=0)
         # Pre-transpose to [in_blocks, out_blocks]
-        self.fused_s_t = fused_s.T  # [48, 216]
+        self.fused_s_t = fused_s.T  # [SCALE_COLS, Q_SCALE_ROWS+K_SCALE_ROWS+V_SCALE_ROWS_PADDED]
 
     def test_split_scale_transpose_true_legacy_equivalent(self):
         helper = _get_helper()
@@ -281,8 +284,11 @@ class TestSplitWeightCompactVScale:
             np.float32
         )
         self.fused_s = np.concatenate([self.q_scale, self.k_scale, self.v_scale_compact], axis=0)
-        # 192 + 12 + 8 = 212 rows
-        assert self.fused_s.shape == (212, SCALE_COLS), f"fused_s shape: {self.fused_s.shape}"
+        # Q_SCALE_ROWS + K_SCALE_ROWS + V_SCALE_ROWS_COMPACT rows
+        assert self.fused_s.shape == (
+            Q_SCALE_ROWS + K_SCALE_ROWS + V_SCALE_ROWS_COMPACT,
+            SCALE_COLS,
+        ), f"fused_s shape: {self.fused_s.shape}"
 
     def test_split_weight_compact_v_scale_drops_pad(self):
         helper = _get_helper()
@@ -313,3 +319,216 @@ class TestSplitWeightCompactVScale:
         assert np.array_equal(
             np.asarray(v_out), self.v_scale_compact
         ), "V compact scale content mismatch"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: MiMoV2ProForCausalLM._create_layer_mappings FP8 mapping layout
+# ---------------------------------------------------------------------------
+
+
+def _get_mimo_pro_class():
+    """Load MiMoV2ProForCausalLM with heavy deps stubbed out.
+
+    We only need the class definition and its use of WeightMapping; all other
+    sgl_jax layers/configs are replaced with lightweight stubs.
+    """
+    import importlib.util
+    import sys
+    import types
+
+    def _stub(name, attrs=None):
+        if name not in sys.modules:
+            m = types.ModuleType(name)
+            if attrs:
+                for k, v in attrs.items():
+                    setattr(m, k, v)
+            sys.modules[name] = m
+        return sys.modules[name]
+
+    # --- transformers ---
+    class _PretrainedConfig:
+        pass
+
+    transformers_mod = _stub("transformers")
+    transformers_mod.PretrainedConfig = _PretrainedConfig
+
+    # --- sgl_jax top-level and sub-packages ---
+    for name in [
+        "sgl_jax",
+        "sgl_jax.srt",
+        "sgl_jax.srt.configs",
+        "sgl_jax.srt.configs.model_config",
+        "sgl_jax.srt.layers",
+        "sgl_jax.srt.layers.embeddings",
+        "sgl_jax.srt.layers.fused_moe",
+        "sgl_jax.srt.layers.layernorm",
+        "sgl_jax.srt.layers.linear",
+        "sgl_jax.srt.layers.logits_processor",
+        "sgl_jax.srt.layers.moe",
+        "sgl_jax.srt.layers.radix_attention",
+        "sgl_jax.srt.mem_cache",
+        "sgl_jax.srt.mem_cache.memory_pool",
+        "sgl_jax.srt.model_executor",
+        "sgl_jax.srt.model_executor.forward_batch_info",
+        "sgl_jax.srt.utils",
+        "sgl_jax.srt.utils.weight_utils",
+    ]:
+        _stub(name)
+
+    # Provide minimal real-looking stubs for names used at class-definition time.
+    class _ModelConfig:
+        pass
+
+    class _LinearBase:
+        pass
+
+    class _LogitsMetadata:
+        pass
+
+    class _LogitsProcessor:
+        pass
+
+    class _KVCache:
+        pass
+
+    class _ForwardBatch:
+        pass
+
+    class _RMSNorm:
+        pass
+
+    class _Embed:
+        pass
+
+    class _ParallelLMHead:
+        pass
+
+    def _get_rope(*a, **kw):
+        pass
+
+    class _FusedEPMoE:
+        pass
+
+    class _EPMoE:
+        pass
+
+    class _GateLogit:
+        pass
+
+    class _TopK:
+        pass
+
+    def _create_moe_weights_mapping(*a, **kw):
+        return {}
+
+    class _RadixAttention:
+        pass
+
+    sys.modules["sgl_jax.srt.configs.model_config"].ModelConfig = _ModelConfig
+    sys.modules["sgl_jax.srt.layers.linear"].LinearBase = _LinearBase
+    sys.modules["sgl_jax.srt.layers.logits_processor"].LogitsMetadata = _LogitsMetadata
+    sys.modules["sgl_jax.srt.layers.logits_processor"].LogitsProcessor = _LogitsProcessor
+    sys.modules["sgl_jax.srt.mem_cache.memory_pool"].KVCache = _KVCache
+    sys.modules["sgl_jax.srt.model_executor.forward_batch_info"].ForwardBatch = _ForwardBatch
+    sys.modules["sgl_jax.srt.layers.layernorm"].RMSNorm = _RMSNorm
+    sys.modules["sgl_jax.srt.layers.embeddings"].Embed = _Embed
+    sys.modules["sgl_jax.srt.layers.embeddings"].ParallelLMHead = _ParallelLMHead
+    sys.modules["sgl_jax.srt.layers.embeddings"].get_rope = _get_rope
+    sys.modules["sgl_jax.srt.layers.fused_moe"].FusedEPMoE = _FusedEPMoE
+    sys.modules["sgl_jax.srt.layers.moe"].EPMoE = _EPMoE
+    sys.modules["sgl_jax.srt.layers.moe"].GateLogit = _GateLogit
+    sys.modules["sgl_jax.srt.layers.moe"].TopK = _TopK
+    sys.modules["sgl_jax.srt.layers.moe"].create_moe_weights_mapping = _create_moe_weights_mapping
+    sys.modules["sgl_jax.srt.layers.radix_attention"].RadixAttention = _RadixAttention
+
+    # Load weight_utils first so WeightMapping is real.
+    weight_utils_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "python",
+        "sgl_jax",
+        "srt",
+        "utils",
+        "weight_utils.py",
+    )
+    if "sgl_jax.srt.utils.weight_utils" not in sys.modules or not hasattr(
+        sys.modules["sgl_jax.srt.utils.weight_utils"], "WeightMapping"
+    ):
+        spec = importlib.util.spec_from_file_location(
+            "sgl_jax.srt.utils.weight_utils", weight_utils_path
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules["sgl_jax.srt.utils.weight_utils"] = mod
+        spec.loader.exec_module(mod)
+
+    wu_mod = sys.modules["sgl_jax.srt.utils.weight_utils"]
+    sys.modules["sgl_jax.srt.utils.weight_utils"].WeightLoader = wu_mod.WeightLoader
+    sys.modules["sgl_jax.srt.utils.weight_utils"].WeightMapping = wu_mod.WeightMapping
+
+    # Now load mimo_v2.py
+    mimo_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "python",
+        "sgl_jax",
+        "srt",
+        "models",
+        "mimo_v2.py",
+    )
+    spec = importlib.util.spec_from_file_location("sgl_jax.srt.models.mimo_v2", mimo_path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sgl_jax.srt.models.mimo_v2"] = mod
+    spec.loader.exec_module(mod)
+
+    return mod.MiMoV2ProForCausalLM
+
+
+class TestProFP8MappingLayout:
+    """Test 6: Pro FP8 fused QKV mapping must use transpose=False, sharding=("tensor", None).
+
+    This test calls _create_layer_mappings on a stub MiMoV2ProForCausalLM instance
+    (is_fp8=True) and asserts the weight mapping has the correct layout so that
+    weight_q is stored in HF [out, in] order, matching QuantizedLinear's contract.
+    """
+
+    def test_pro_fp8_qkv_mapping_transpose_false_sharding_tensor_none(self):
+        """FP8 fused QKV mapping: transpose=False, sharding=("tensor", None)."""
+        from unittest.mock import patch
+
+        MiMoV2ProForCausalLM = _get_mimo_pro_class()
+
+        # Create a bare stub instance — no __init__, just set _quant_config.
+        obj = object.__new__(MiMoV2ProForCausalLM)
+
+        class _QuantConfig:
+            is_static_checkpoint = True
+            ignored_layers = []
+
+        object.__setattr__(obj, "_quant_config", _QuantConfig())
+
+        # Stub _create_common_layer_mappings at the class level so we don't
+        # need self.config etc.  Use patch to avoid flax nnx __setattr__ guards.
+        with patch.object(
+            MiMoV2ProForCausalLM,
+            "_create_common_layer_mappings",
+            return_value={},
+        ):
+            mappings = obj._create_layer_mappings(0)
+
+        key = "model.layers.0.self_attn.qkv_proj.weight"
+        assert key in mappings, f"Expected key '{key}' in mappings, got: {list(mappings.keys())}"
+
+        m = mappings[key]
+        assert m.transpose is False, (
+            f"Expected transpose=False for FP8 QKV mapping, got transpose={m.transpose!r}. "
+            "The Pro FP8 fused QKV mapping must store weight_q in HF [out, in] layout "
+            "to match QuantizedLinear's kernel contract."
+        )
+        assert m.sharding == ("tensor", None), (
+            f"Expected sharding=('tensor', None) for FP8 QKV mapping, got sharding={m.sharding!r}. "
+            "With HF [out, in] layout, the output axis (axis-0) maps to 'tensor' shard."
+        )

--- a/tests/srt/models/test_mimo_v2_pro_qkv_split.py
+++ b/tests/srt/models/test_mimo_v2_pro_qkv_split.py
@@ -1,0 +1,315 @@
+"""Equivalence unit tests for the fused QKV weight split logic in WeightLoader.
+
+Tests verify that _split_fused_qkv_for_test (a pure static helper) produces
+the same content in both transpose=True and transpose=False modes, and that
+padded-V scale rows are handled correctly.
+
+Run with:
+    JAX_PLATFORMS=cpu python -m pytest tests/srt/models/test_mimo_v2_pro_qkv_split.py -xvs
+"""
+
+import os
+
+os.environ.setdefault("JAX_PLATFORMS", "cpu")
+
+import numpy as np
+import pytest
+
+# Constants matching real MiMo V2 Pro checkpoint
+NUM_HEADS = 128
+NUM_KV_HEADS = 8
+HEAD_DIM_ORIG = 192
+V_HEAD_DIM_ORIG = 128
+HIDDEN = 6144
+BLOCK = 128
+
+Q_OUT = NUM_HEADS * HEAD_DIM_ORIG  # 24576
+K_OUT = NUM_KV_HEADS * HEAD_DIM_ORIG  # 1536
+V_OUT_COMPACT = NUM_KV_HEADS * V_HEAD_DIM_ORIG  # 1024
+V_OUT_PADDED = NUM_KV_HEADS * HEAD_DIM_ORIG  # 1536 (scale only)
+
+# Scale dimensions
+Q_SCALE_ROWS = Q_OUT // BLOCK  # 192
+K_SCALE_ROWS = K_OUT // BLOCK  # 12
+V_SCALE_ROWS_PADDED = V_OUT_PADDED // BLOCK  # 12
+V_SCALE_ROWS_COMPACT = V_OUT_COMPACT // BLOCK  # 8
+SCALE_COLS = HIDDEN // BLOCK  # 48
+
+
+def _get_helper():
+    """Import the static helper under test.
+
+    Uses importlib to load weight_utils directly, bypassing the
+    sgl_jax.srt.utils __init__.py which requires heavy server deps (zmq,
+    psutil, etc.) not needed for pure weight-split math tests. Also stubs out
+    sgl_jax.srt.configs.model_config (needs transformers, which is heavyweight
+    and may not be installed in a bare JAX-only environment).
+    """
+    import importlib.util
+    import sys
+    import types
+
+    def _stub(name):
+        if name not in sys.modules:
+            sys.modules[name] = types.ModuleType(name)
+
+    # Stub the heavy sub-packages so importing weight_utils.py doesn't fail.
+    for name in [
+        "sgl_jax",
+        "sgl_jax.srt",
+        "sgl_jax.srt.utils",
+        "sgl_jax.srt.configs",
+        "sgl_jax.srt.configs.model_config",
+    ]:
+        _stub(name)
+
+    # Provide a minimal ModelConfig stub so the module-level import resolves.
+    class _ModelConfig:
+        pass
+
+    sys.modules["sgl_jax.srt.configs.model_config"].ModelConfig = _ModelConfig
+
+    weight_utils_path = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "..",
+        "python",
+        "sgl_jax",
+        "srt",
+        "utils",
+        "weight_utils.py",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "sgl_jax.srt.utils.weight_utils",
+        weight_utils_path,
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["sgl_jax.srt.utils.weight_utils"] = mod
+    spec.loader.exec_module(mod)
+
+    WeightLoader = mod.WeightLoader
+    assert hasattr(WeightLoader, "_split_fused_qkv_for_test"), (
+        "WeightLoader._split_fused_qkv_for_test does not exist — "
+        "add the @staticmethod helper to weight_utils.py"
+    )
+    return WeightLoader._split_fused_qkv_for_test
+
+
+class TestSplitWeightTransposeFalse:
+    """Test 1: transpose=False preserves Q/K/V layout from HF [out, in] tensor."""
+
+    def setup_method(self):
+        rng = np.random.default_rng(0)
+        self.q = rng.standard_normal((Q_OUT, HIDDEN)).astype(np.float32)
+        self.k = rng.standard_normal((K_OUT, HIDDEN)).astype(np.float32)
+        self.v = rng.standard_normal((V_OUT_COMPACT, HIDDEN)).astype(np.float32)
+        self.fused_w = np.concatenate([self.q, self.k, self.v], axis=0)
+        assert self.fused_w.shape == (
+            Q_OUT + K_OUT + V_OUT_COMPACT,
+            HIDDEN,
+        ), f"fused_w shape mismatch: {self.fused_w.shape}"
+
+    def test_split_weight_transpose_false_preserves_q_layout(self):
+        helper = _get_helper()
+        import jax.numpy as jnp
+
+        fused_jnp = jnp.asarray(self.fused_w)
+        q_out, k_out, v_out = helper(
+            fused_jnp,
+            transpose=False,
+            is_scale=False,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim_orig=HEAD_DIM_ORIG,
+            v_head_dim_orig=V_HEAD_DIM_ORIG,
+            hidden=HIDDEN,
+        )
+
+        assert q_out.shape == (Q_OUT, HIDDEN), f"q shape: {q_out.shape}"
+        assert k_out.shape == (K_OUT, HIDDEN), f"k shape: {k_out.shape}"
+        assert v_out.shape == (V_OUT_COMPACT, HIDDEN), f"v shape: {v_out.shape}"
+
+        assert np.array_equal(np.asarray(q_out), self.q), "Q content mismatch"
+        assert np.array_equal(np.asarray(k_out), self.k), "K content mismatch"
+        assert np.array_equal(np.asarray(v_out), self.v), "V content mismatch"
+
+
+class TestSplitWeightTransposeTrue:
+    """Test 2: transpose=True (legacy) produces transposed-equivalent content."""
+
+    def setup_method(self):
+        rng = np.random.default_rng(0)
+        self.q = rng.standard_normal((Q_OUT, HIDDEN)).astype(np.float32)
+        self.k = rng.standard_normal((K_OUT, HIDDEN)).astype(np.float32)
+        self.v = rng.standard_normal((V_OUT_COMPACT, HIDDEN)).astype(np.float32)
+        fused_w = np.concatenate([self.q, self.k, self.v], axis=0)
+        # Pre-transpose to [in, out] as done by the legacy transpose=True path
+        self.fused_w_t = fused_w.T  # [HIDDEN, Q_OUT+K_OUT+V_OUT_COMPACT]
+
+    def test_split_weight_transpose_true_legacy_equivalent(self):
+        helper = _get_helper()
+        import jax.numpy as jnp
+
+        fused_jnp_t = jnp.asarray(self.fused_w_t)
+        q_out, k_out, v_out = helper(
+            fused_jnp_t,
+            transpose=True,
+            is_scale=False,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim_orig=HEAD_DIM_ORIG,
+            v_head_dim_orig=V_HEAD_DIM_ORIG,
+            hidden=HIDDEN,
+        )
+
+        # Shapes should be [in, out_*]
+        assert q_out.shape == (HIDDEN, Q_OUT), f"q shape: {q_out.shape}"
+        assert k_out.shape == (HIDDEN, K_OUT), f"k shape: {k_out.shape}"
+        assert v_out.shape == (HIDDEN, V_OUT_COMPACT), f"v shape: {v_out.shape}"
+
+        # Transposing back should equal the originals
+        assert np.array_equal(np.asarray(q_out).T, self.q), "Q content mismatch after transpose"
+        assert np.array_equal(np.asarray(k_out).T, self.k), "K content mismatch after transpose"
+        assert np.array_equal(np.asarray(v_out).T, self.v), "V content mismatch after transpose"
+
+
+class TestSplitScalePaddedV:
+    """Test 3: transpose=False scale with padded V keeps all 12 V scale rows."""
+
+    def setup_method(self):
+        rng = np.random.default_rng(0)
+        self.q_scale = rng.standard_normal((Q_SCALE_ROWS, SCALE_COLS)).astype(np.float32)
+        self.k_scale = rng.standard_normal((K_SCALE_ROWS, SCALE_COLS)).astype(np.float32)
+        self.v_scale_padded = rng.standard_normal((V_SCALE_ROWS_PADDED, SCALE_COLS)).astype(
+            np.float32
+        )
+        self.fused_s = np.concatenate([self.q_scale, self.k_scale, self.v_scale_padded], axis=0)
+        assert self.fused_s.shape == (216, SCALE_COLS), f"fused_s shape: {self.fused_s.shape}"
+
+    def test_split_scale_padded_v_keeps_all_v_rows(self):
+        helper = _get_helper()
+        import jax.numpy as jnp
+
+        fused_jnp = jnp.asarray(self.fused_s)
+        q_out, k_out, v_out = helper(
+            fused_jnp,
+            transpose=False,
+            is_scale=True,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim_orig=HEAD_DIM_ORIG,
+            v_head_dim_orig=V_HEAD_DIM_ORIG,
+            hidden=HIDDEN,
+        )
+
+        assert q_out.shape == (Q_SCALE_ROWS, SCALE_COLS), f"q_scale shape: {q_out.shape}"
+        assert k_out.shape == (K_SCALE_ROWS, SCALE_COLS), f"k_scale shape: {k_out.shape}"
+        # V scale keeps ALL padded rows (12), not truncated to compact (8)
+        assert v_out.shape == (
+            V_SCALE_ROWS_PADDED,
+            SCALE_COLS,
+        ), f"v_scale shape: {v_out.shape}, expected ({V_SCALE_ROWS_PADDED}, {SCALE_COLS})"
+
+        assert np.array_equal(np.asarray(q_out), self.q_scale), "Q scale content mismatch"
+        assert np.array_equal(np.asarray(k_out), self.k_scale), "K scale content mismatch"
+        assert np.array_equal(
+            np.asarray(v_out), self.v_scale_padded
+        ), "V padded scale content mismatch"
+
+
+class TestSplitScaleTransposeTrue:
+    """Test 4: transpose=True scale equivalent — same content in transposed layout."""
+
+    def setup_method(self):
+        rng = np.random.default_rng(0)
+        self.q_scale = rng.standard_normal((Q_SCALE_ROWS, SCALE_COLS)).astype(np.float32)
+        self.k_scale = rng.standard_normal((K_SCALE_ROWS, SCALE_COLS)).astype(np.float32)
+        self.v_scale_padded = rng.standard_normal((V_SCALE_ROWS_PADDED, SCALE_COLS)).astype(
+            np.float32
+        )
+        fused_s = np.concatenate([self.q_scale, self.k_scale, self.v_scale_padded], axis=0)
+        # Pre-transpose to [in_blocks, out_blocks]
+        self.fused_s_t = fused_s.T  # [48, 216]
+
+    def test_split_scale_transpose_true_legacy_equivalent(self):
+        helper = _get_helper()
+        import jax.numpy as jnp
+
+        fused_jnp_t = jnp.asarray(self.fused_s_t)
+        q_out, k_out, v_out = helper(
+            fused_jnp_t,
+            transpose=True,
+            is_scale=True,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim_orig=HEAD_DIM_ORIG,
+            v_head_dim_orig=V_HEAD_DIM_ORIG,
+            hidden=HIDDEN,
+        )
+
+        # Shapes should be [in_blocks, out_blocks]
+        assert q_out.shape == (SCALE_COLS, Q_SCALE_ROWS), f"q_scale shape: {q_out.shape}"
+        assert k_out.shape == (SCALE_COLS, K_SCALE_ROWS), f"k_scale shape: {k_out.shape}"
+        # V scale keeps ALL padded rows (12 in out dimension)
+        assert v_out.shape == (
+            SCALE_COLS,
+            V_SCALE_ROWS_PADDED,
+        ), f"v_scale shape: {v_out.shape}, expected ({SCALE_COLS}, {V_SCALE_ROWS_PADDED})"
+
+        # Transposing back should equal originals
+        assert np.array_equal(
+            np.asarray(q_out).T, self.q_scale
+        ), "Q scale content mismatch after transpose"
+        assert np.array_equal(
+            np.asarray(k_out).T, self.k_scale
+        ), "K scale content mismatch after transpose"
+        assert np.array_equal(
+            np.asarray(v_out).T, self.v_scale_padded
+        ), "V padded scale content mismatch after transpose"
+
+
+class TestSplitWeightCompactVScale:
+    """Test 5: is_scale=True with compact V scale (8 rows, not padded 12)."""
+
+    def setup_method(self):
+        rng = np.random.default_rng(0)
+        self.q_scale = rng.standard_normal((Q_SCALE_ROWS, SCALE_COLS)).astype(np.float32)
+        self.k_scale = rng.standard_normal((K_SCALE_ROWS, SCALE_COLS)).astype(np.float32)
+        # Compact V scale: 8 rows instead of 12
+        self.v_scale_compact = rng.standard_normal((V_SCALE_ROWS_COMPACT, SCALE_COLS)).astype(
+            np.float32
+        )
+        self.fused_s = np.concatenate([self.q_scale, self.k_scale, self.v_scale_compact], axis=0)
+        # 192 + 12 + 8 = 212 rows
+        assert self.fused_s.shape == (212, SCALE_COLS), f"fused_s shape: {self.fused_s.shape}"
+
+    def test_split_weight_compact_v_scale_drops_pad(self):
+        helper = _get_helper()
+        import jax.numpy as jnp
+
+        fused_jnp = jnp.asarray(self.fused_s)
+        q_out, k_out, v_out = helper(
+            fused_jnp,
+            transpose=False,
+            is_scale=True,
+            num_heads=NUM_HEADS,
+            num_kv_heads=NUM_KV_HEADS,
+            head_dim_orig=HEAD_DIM_ORIG,
+            v_head_dim_orig=V_HEAD_DIM_ORIG,
+            hidden=HIDDEN,
+        )
+
+        assert q_out.shape == (Q_SCALE_ROWS, SCALE_COLS), f"q_scale shape: {q_out.shape}"
+        assert k_out.shape == (K_SCALE_ROWS, SCALE_COLS), f"k_scale shape: {k_out.shape}"
+        # Compact V: 8 rows, no padding
+        assert v_out.shape == (
+            V_SCALE_ROWS_COMPACT,
+            SCALE_COLS,
+        ), f"v_scale shape: {v_out.shape}, expected ({V_SCALE_ROWS_COMPACT}, {SCALE_COLS})"
+
+        assert np.array_equal(np.asarray(q_out), self.q_scale), "Q scale content mismatch"
+        assert np.array_equal(np.asarray(k_out), self.k_scale), "K scale content mismatch"
+        assert np.array_equal(
+            np.asarray(v_out), self.v_scale_compact
+        ), "V compact scale content mismatch"


### PR DESCRIPTION
## Summary

- Rename `mimo_v2_flash.py` → `mimo_v2.py`, add `MiMoV2ProForCausalLM` class for fused QKV checkpoint format
- Modify `_split_qkv_weight` to support `v_head_dim != head_dim`, auto-detect scale tensors, and expand block scales via `_maybe_expand_linear_block_scale`
- Skip GCSFuse cache warmup for Pro (~1TB exceeds cache capacity)

## Changes

### `mimo_v2.py`
- Refactor `_create_layer_mappings` into Flash-specific QKV + shared `_create_common_layer_mappings` (o_proj, sink bias, layernorms, MLP/MoE)
- Add `MiMoV2ProForCausalLM` that emits fused `qkv_proj` weight mappings with list `target_path` (triggers `_split_qkv_weight`)
- `EntryClass = [MiMoV2FlashForCausalLM, MiMoV2ProForCausalLM]`

### `weight_utils.py`
- Add `v_head_dim_original` to `WeightLoader.__init__`
- Separate `k_dim` / `v_dim` in `_split_qkv_weight` (was shared `kv_dim`)
- Auto-detect scale tensors by comparing actual dim vs `total_dim / block_size`
- Add `_maybe_expand_linear_block_scale` in split assignment loop for 2D→3D block scale expansion
- V padding uses `v_head_dim_pad` independently from Q/K `head_dim_pad`

## Test plan

- [ ] Flash regression: verify Flash model still loads/runs after file rename
- [ ] Pro weight loading: load FP8 checkpoint, verify fused QKV split dimensions
  - weight: `[27136, 6144]` → q `[24576, 6144]`, k `[1536, 6144]`, v `[1024, 6144]`
  - scale: `[212, 48]` → q `[192, 48]`, k `[12, 48]`, v `[8, 48]`
- [ ] Scale expansion: verify split scales get 2D→3D expansion via `expand_block_scale`
- [ ] Forward pass: verify non-NaN outputs
- [ ] E2E serving: run generation to verify correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)