### PR TITLE
feat: add MiMo-V2-Pro model with fused QKV FP8 dequantization

### DIFF
--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -161,6 +161,7 @@ class MiMoV2Attention(nnx.Module):
         sliding_window_size: int | None = None,
         attention_sink_bias: bool = False,
         partial_rotary_factor: float = 1.0,
+        attention_value_scale: float | None = None,
         layer_id: int = 0,
         dtype: jnp.dtype = jnp.bfloat16,
     ):
@@ -170,6 +171,7 @@ class MiMoV2Attention(nnx.Module):
         self.q_head_num = num_heads
         self.k_head_num = num_kv_heads
         self.v_head_dim = v_head_dim if v_head_dim is not None else self.head_dim
+        self.attention_value_scale = attention_value_scale
 
         self.q_size = num_heads * self.head_dim
         self.k_size = num_kv_heads * self.head_dim
@@ -282,6 +284,9 @@ class MiMoV2Attention(nnx.Module):
                 attn_output = attn_output[..., : self.v_head_dim]
                 attn_output = attn_output.reshape(-1, expected_v_head_dim)
 
+        if self.attention_value_scale is not None:
+            attn_output = attn_output * self.attention_value_scale
+
         output, _ = self.o_proj(attn_output)
         return output, kv_fused
 
@@ -300,6 +305,7 @@ class MiMoV2DecoderLayer(nnx.Module):
         rope_theta = getattr(config, "rope_theta", 1000000)
         rope_scaling = getattr(config, "rope_scaling", None)
         max_position_embeddings = getattr(config, "max_position_embeddings", 32768)
+        attention_value_scale = getattr(config, "attention_value_scale", None)
 
         if self._is_swa_layer(config):
             self.self_attn = MiMoV2Attention(
@@ -314,6 +320,7 @@ class MiMoV2DecoderLayer(nnx.Module):
                 sliding_window_size=getattr(config, "sliding_window_size", None),
                 attention_sink_bias=getattr(config, "add_swa_attention_sink_bias", False),
                 partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
+                attention_value_scale=attention_value_scale,
                 layer_id=layer_id,
                 dtype=dtype,
                 mesh=mesh,
@@ -331,6 +338,7 @@ class MiMoV2DecoderLayer(nnx.Module):
                 sliding_window_size=0,  # full attention
                 attention_sink_bias=getattr(config, "add_full_attention_sink_bias", False),
                 partial_rotary_factor=getattr(config, "partial_rotary_factor", 1.0),
+                attention_value_scale=attention_value_scale,
                 layer_id=layer_id,
                 dtype=dtype,
                 mesh=mesh,
@@ -529,6 +537,10 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         """
         import glob
         import os
+
+        if os.environ.get("SGLANG_SKIP_GCSFUSE_WARMUP", ""):
+            logger.info("Skipping GCSFuse cache warmup (SGLANG_SKIP_GCSFUSE_WARMUP set)")
+            return
         from concurrent.futures import ThreadPoolExecutor
 
         model_path = model_config.model_path
@@ -609,6 +621,28 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         if weight_scale.ndim == 3:
             weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
+        elif weight_scale.ndim == 2:
+            # Raw 2D block-quant scale [out_blocks, in_blocks] — expand to 3D first.
+            # This can happen for QKV-split scales where expansion was skipped.
+            import math
+
+            from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
+                expand_block_scale,
+            )
+
+            quant_cfg = getattr(self.config, "quantization_config", None)
+            block_size_out = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+            dim0, dim1 = weight_q.shape
+            out_blocks = weight_scale.shape[0]
+            # Determine which weight dim is output: must satisfy ceil(dim/bs) <= out_blocks
+            n_out = dim1 if math.ceil(dim1 / block_size_out) <= out_blocks else dim0
+
+            logger.info(
+                "Expanding 2D scale %s -> 3D for dequant, n_out=%d", weight_scale.shape, n_out
+            )
+            weight_scale_3d = expand_block_scale(weight_scale, n_out, block_size_out)
+            weight_bf16 = self._block_dequant(weight_q, weight_scale_3d, head_dim=head_dim)
         elif weight_scale.ndim == 1:
             out_dim = weight_scale.shape[0]
             if weight_q.shape[1] == out_dim:

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -621,28 +621,6 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
         if weight_scale.ndim == 3:
             weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
-        elif weight_scale.ndim == 2:
-            # Raw 2D block-quant scale [out_blocks, in_blocks] — expand to 3D first.
-            # This can happen for QKV-split scales where expansion was skipped.
-            import math
-
-            from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
-                expand_block_scale,
-            )
-
-            quant_cfg = getattr(self.config, "quantization_config", None)
-            block_size_out = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
-
-            dim0, dim1 = weight_q.shape
-            out_blocks = weight_scale.shape[0]
-            # Determine which weight dim is output: must satisfy ceil(dim/bs) <= out_blocks
-            n_out = dim1 if math.ceil(dim1 / block_size_out) <= out_blocks else dim0
-
-            logger.info(
-                "Expanding 2D scale %s -> 3D for dequant, n_out=%d", weight_scale.shape, n_out
-            )
-            weight_scale_3d = expand_block_scale(weight_scale, n_out, block_size_out)
-            weight_bf16 = self._block_dequant(weight_q, weight_scale_3d, head_dim=head_dim)
         elif weight_scale.ndim == 1:
             out_dim = weight_scale.shape[0]
             if weight_q.shape[1] == out_dim:

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -512,7 +512,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         # dramatically speeds up subsequent random-access MoE expert loading.
         self._warmup_safetensors_cache(model_config)
 
-        self._loader = WeightLoader(
+        self.loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
@@ -520,14 +520,14 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         )
         self._quant_config = model_config.quantization_config
         weight_mappings = self._create_weight_mappings()
-        self._loader.load_weights_from_safetensors(weight_mappings)
+        self.loader.load_weights_from_safetensors(weight_mappings)
         logger.info("MiMoV2Flash weights loaded successfully!")
 
         # Post-load: dequantize FP8 attention + layer-0 MLP to bf16.
-        if self._loader.is_static_quant:
+        if self.loader.is_static_quant:
             head_dim = self.config.head_dim
             v_head_dim = getattr(self.config, "v_head_dim", head_dim)
-            self._loader.dequant_fp8_layers(
+            self.loader.dequant_fp8_layers(
                 self.model.layers,
                 specs=[
                     ("self_attn.q_proj", head_dim),
@@ -535,7 +535,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
                     ("self_attn.v_proj", v_head_dim),
                 ],
             )
-            self._loader.dequant_fp8_layers(
+            self.loader.dequant_fp8_layers(
                 self.model.layers,
                 specs=[
                     ("mlp.gate_proj", None),
@@ -544,7 +544,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
                 ],
                 layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
             )
-            self._loader.replicate_kv_heads(
+            self.loader.replicate_kv_heads(
                 self.model.layers,
                 specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
                 target_kv_heads_fn=lambda attn: attn.k_head_num,
@@ -592,14 +592,6 @@ class MiMoV2FlashForCausalLM(nnx.Module):
             total_size / 1024**2 / (t1 - t0) if t1 > t0 else 0,
         )
 
-    def _is_quant_ignored(self, hf_path: str) -> bool:
-        """Delegate to WeightLoader."""
-        return self._loader.is_quant_ignored(hf_path)
-
-    @property
-    def _is_static_quant(self) -> bool:
-        return self._loader.is_static_quant
-
     def _create_weight_mappings(self) -> dict:
         mappings = {
             "model.embed_tokens.weight": WeightMapping(
@@ -631,7 +623,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         target = prefix
 
         mappings = {}
-        is_fp8 = self._is_static_quant
+        is_fp8 = self.loader.is_static_quant
 
         # Attention projections
         for proj, sharding, kv_pad, hd_pad in [
@@ -641,7 +633,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
             ("o_proj", ("tensor", None), False, True),
         ]:
             hf_key = f"{prefix}.self_attn.{proj}"
-            ignored = self._is_quant_ignored(hf_key)
+            ignored = self.loader.is_quant_ignored(hf_key)
             weight_suffix = "weight" if (not is_fp8 or ignored) else "weight_q"
 
             mappings[f"{hf_key}.weight"] = WeightMapping(

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -512,7 +512,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         # dramatically speeds up subsequent random-access MoE expert loading.
         self._warmup_safetensors_cache(model_config)
 
-        loader = WeightLoader(
+        self._loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
@@ -520,13 +520,35 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         )
         self._quant_config = model_config.quantization_config
         weight_mappings = self._create_weight_mappings()
-        loader.load_weights_from_safetensors(weight_mappings)
+        self._loader.load_weights_from_safetensors(weight_mappings)
         logger.info("MiMoV2Flash weights loaded successfully!")
 
         # Post-load: dequantize FP8 attention + layer-0 MLP to bf16.
-        # Q/K head_dim padding (192→256) is handled by the kernel internally.
-        if self._is_static_quant:
-            self._dequantize_fp8_to_bf16()
+        if self._loader.is_static_quant:
+            head_dim = self.config.head_dim
+            v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+            self._loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("self_attn.q_proj", head_dim),
+                    ("self_attn.k_proj", head_dim),
+                    ("self_attn.v_proj", v_head_dim),
+                ],
+            )
+            self._loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+                layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
+            )
+            self._loader.replicate_kv_heads(
+                self.model.layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
 
     @staticmethod
     def _warmup_safetensors_cache(model_config: ModelConfig):
@@ -575,274 +597,12 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         )
 
     def _is_quant_ignored(self, hf_path: str) -> bool:
-        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
-        quant_cfg = getattr(self, "_quant_config", None)
-        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
-            return True  # not quantized at all
-        ignored = quant_cfg.ignored_layers or []
-        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+        """Delegate to WeightLoader."""
+        return self._loader.is_quant_ignored(hf_path)
 
     @property
     def _is_static_quant(self) -> bool:
-        quant_cfg = getattr(self, "_quant_config", None)
-        return quant_cfg is not None and quant_cfg.is_static_checkpoint
-
-    # ------------------------------------------------------------------
-    # Post-load transforms: dequantize FP8 → BF16, pad head dims
-    # ------------------------------------------------------------------
-
-    def _dequantize_quantized_linear(self, ql, head_dim=None) -> LinearBase:
-        """Dequantize a single QuantizedLinear to bf16 LinearBase.
-
-        weight_q may be in HF layout [out, in] or model layout [in, out]
-        depending on the transpose flag used during loading.
-        weight_scale is in kernel-ready 3D layout [in_blocks, 1, out_dim].
-
-        Handles kv_head_padding: when weight_q has been replicated along the
-        output axis (e.g. 4 kv_heads → 16 for TP), the scale only covers the
-        original (unreplicated) output dimension.  We extract one copy of the
-        original heads, dequantize, then re-replicate in bf16.
-
-        Args:
-            head_dim: If set, enables per-head block quant handling. Required
-                when head_dim % block_size != 0 (e.g., head_dim=192 with
-                block_size=128), as the HF checkpoint uses per-head block
-                boundaries instead of uniform blocks.
-        """
-        weight_q = ql.weight_q.value
-        weight_scale = ql.weight_scale.value
-        logger.info(
-            "Dequant debug: weight_q.shape=%s weight_scale.shape=%s kernel_axes=%s head_dim=%s",
-            weight_q.shape,
-            weight_scale.shape,
-            ql.kernel_axes,
-            head_dim,
-        )
-
-        if weight_scale.ndim == 3:
-            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
-        elif weight_scale.ndim == 1:
-            out_dim = weight_scale.shape[0]
-            if weight_q.shape[1] == out_dim:
-                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
-                    jnp.bfloat16
-                )
-            else:
-                weight_bf16 = (
-                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
-                ).astype(jnp.bfloat16)
-        else:
-            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
-
-        # weight_bf16 is now in model layout [in, out]
-        in_features, out_features = weight_bf16.shape
-
-        with jax.set_mesh(ql.mesh):
-            new_linear = LinearBase(
-                input_size=in_features,
-                output_size=out_features,
-                kernel_axes=ql.kernel_axes,
-                use_bias=ql.bias is not None,
-                params_dtype=jnp.bfloat16,
-                mesh=ql.mesh,
-            )
-            new_linear.weight = nnx.Param(weight_bf16)
-            if ql.bias is not None:
-                new_linear.bias = nnx.Param(ql.bias.value.astype(jnp.bfloat16))
-        return new_linear
-
-    def _block_dequant(
-        self, weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
-    ) -> jax.Array:
-        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
-
-        Returns bf16 weight in model layout [in_dim, out_dim].
-        Handles kv_head_padding where weight_q is larger than scale coverage
-        by tiling the scale to match.
-
-        Args:
-            head_dim: If set, enables per-head block quant handling when scale
-                out_dim doesn't match weight dims. The scale is re-indexed using
-                per-head block boundaries instead of uniform block mapping.
-        """
-        import math
-
-        in_blocks = weight_scale.shape[0]
-        out_dim = weight_scale.shape[2]
-
-        # Detect layout and kv-padding
-        dim0, dim1 = weight_q.shape
-
-        if dim1 == out_dim:
-            # Model layout [in, out], no kv-padding
-            pass
-        elif dim0 == out_dim:
-            # HF layout [out, in] — transpose to model layout
-            weight_q = jnp.transpose(weight_q)
-        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
-            # Per-head block quant: scale was expanded for wrong n_out.
-            # Determine layout: in_dim must be divisible by in_blocks.
-            if dim0 % in_blocks == 0:
-                actual_out = dim1  # model layout [in, out]
-            else:
-                weight_q = jnp.transpose(weight_q)
-                actual_out = dim0  # was HF layout [out, in]
-
-            # Re-index scale using per-head block boundaries.
-            # The wrongly-expanded scale has uniform block mapping (ch // 128),
-            # but we need per-head mapping where each head's blocks are independent.
-            block_size = out_dim // (out_dim // 128) if out_dim >= 128 else 128
-            block_size = 128  # from weight_block_size config
-            blocks_per_head = math.ceil(head_dim / block_size)
-            num_heads = actual_out // head_dim
-
-            # Build gather index: for each output channel, find the corresponding
-            # channel in the uniformly-expanded scale that has the correct block's value.
-            gather_idx = jnp.array(
-                [
-                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
-                    for j in range(actual_out)
-                ]
-            )
-            weight_scale = weight_scale[:, :, gather_idx]  # (in_blocks, 1, actual_out)
-            out_dim = actual_out
-
-            logger.info(
-                "Per-head block dequant: %d heads × head_dim=%d, %d blocks/head, "
-                "remapped scale to (%s)",
-                num_heads,
-                head_dim,
-                blocks_per_head,
-                weight_scale.shape,
-            )
-        elif dim1 > out_dim and dim1 % out_dim == 0:
-            # Model layout [in, kv_padded_out] — tile scale to match
-            kv_replicas = dim1 // out_dim
-            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
-            out_dim = dim1
-            logger.info(
-                "Detected kv_head_padding: tiling scale %dx to match %d out channels",
-                kv_replicas,
-                out_dim,
-            )
-        elif dim0 > out_dim and dim0 % out_dim == 0:
-            # HF layout [kv_padded_out, in] — transpose and tile scale
-            kv_replicas = dim0 // out_dim
-            weight_q = jnp.transpose(weight_q)
-            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
-            out_dim = weight_q.shape[1]
-            logger.info(
-                "Detected kv_head_padding (HF layout): tiling scale %dx to match %d out channels",
-                kv_replicas,
-                out_dim,
-            )
-        else:
-            raise ValueError(
-                f"Cannot match weight_q shape {weight_q.shape} with " f"scale out_dim={out_dim}"
-            )
-
-        # weight_q is now [in_dim, out_dim] in model layout
-        in_dim = weight_q.shape[0]
-        block_k = in_dim // in_blocks
-        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
-        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
-
-        return weight_bf16
-
-    def _dequantize_fp8_to_bf16(self):
-        """Dequantize FP8 QuantizedLinear → bf16 LinearBase.
-
-        Targets:
-        - All layers: self_attn.q_proj, k_proj, v_proj
-        - Layer 0: mlp.gate_proj, up_proj, down_proj (dense MLP only)
-        """
-        from sgl_jax.srt.layers.linear import QuantizedLinear
-
-        for layer_idx, layer in enumerate(self.model.layers):
-            attn = layer.self_attn
-            for proj_name in ("q_proj", "k_proj", "v_proj"):
-                proj = getattr(attn, proj_name)
-                if isinstance(proj, QuantizedLinear):
-                    # Pass head_dim for per-head block quant handling.
-                    # Q/K use head_dim, V uses v_head_dim.
-                    hd = attn.v_head_dim if proj_name == "v_proj" else attn.head_dim
-                    setattr(attn, proj_name, self._dequantize_quantized_linear(proj, head_dim=hd))
-                    logger.info("Dequantized layer %d %s → bf16", layer_idx, proj_name)
-
-            # Layer 0 dense MLP
-            if layer_idx == 0 and not layer.is_layer_sparse:
-                for proj_name in ("gate_proj", "up_proj", "down_proj"):
-                    proj = getattr(layer.mlp, proj_name)
-                    if isinstance(proj, QuantizedLinear):
-                        setattr(layer.mlp, proj_name, self._dequantize_quantized_linear(proj))
-                        logger.info("Dequantized layer 0 MLP %s → bf16", proj_name)
-
-        logger.info("FP8 → BF16 dequantization complete.")
-
-        # Fix kv_head_padding for v_proj: the weight loader's _apply_kv_head_padding
-        # uses head_dim (Q/K) for shape matching, so it misses v_proj when
-        # v_head_dim != head_dim. Replicate kv_heads here.
-        self._ensure_kv_head_replication()
-
-    def _ensure_kv_head_replication(self):
-        """Replicate KV heads for TP alignment when the weight loader missed them.
-
-        When v_head_dim != head_dim, the weight loader's _apply_kv_head_padding
-        can't pattern-match v_proj shapes. We fix that here by checking actual
-        weight dims against expected (tp-aligned) dims and replicating as needed.
-        """
-        from jax.sharding import NamedSharding
-        from jax.sharding import PartitionSpec as P
-
-        for layer_idx, layer in enumerate(self.model.layers):
-            attn = layer.self_attn
-            # attn.k_head_num is already the TP-aligned count (e.g., 16)
-            target_kv_heads = attn.k_head_num
-
-            for proj_name, head_dim in [
-                ("k_proj", attn.head_dim),
-                ("v_proj", attn.v_head_dim),
-            ]:
-                proj = getattr(attn, proj_name)
-                w = proj.weight.value
-                expected_size = target_kv_heads * head_dim
-                actual_size = w.shape[1]
-
-                if actual_size == expected_size:
-                    continue
-
-                # Weight is smaller than expected — needs replication
-                if actual_size > 0 and expected_size % actual_size == 0:
-                    num_replicas = expected_size // actual_size
-                    orig_kv = actual_size // head_dim
-
-                    logger.info(
-                        "KV head replication: layer %d %s %d→%d heads (%d→%d)",
-                        layer_idx,
-                        proj_name,
-                        orig_kv,
-                        target_kv_heads,
-                        actual_size,
-                        expected_size,
-                    )
-
-                    w_full = jax.device_put(w, NamedSharding(self.mesh, P()))
-                    w_3d = w_full.reshape(w.shape[0], orig_kv, head_dim)
-                    w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
-                    w_new = w_rep.reshape(w.shape[0], expected_size)
-                    w_new = jax.device_put(w_new, NamedSharding(self.mesh, P(None, "tensor")))
-
-                    with jax.set_mesh(self.mesh):
-                        new_linear = LinearBase(
-                            input_size=w.shape[0],
-                            output_size=expected_size,
-                            kernel_axes=proj.kernel_axes,
-                            use_bias=False,
-                            params_dtype=jnp.bfloat16,
-                            mesh=self.mesh,
-                        )
-                        new_linear.weight = nnx.Param(w_new)
-                    setattr(attn, proj_name, new_linear)
+        return self._loader.is_static_quant
 
     def _create_weight_mappings(self) -> dict:
         mappings = {

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -559,10 +559,6 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         """
         import glob
         import os
-
-        if os.environ.get("SGLANG_SKIP_GCSFUSE_WARMUP", ""):
-            logger.info("Skipping GCSFuse cache warmup (SGLANG_SKIP_GCSFUSE_WARMUP set)")
-            return
         from concurrent.futures import ThreadPoolExecutor
 
         model_path = model_config.model_path

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -7,12 +7,9 @@ a per-shard-interleaved layout that requires special dequantization handling.
 """
 
 import logging
-import math
 
 import jax
 import jax.numpy as jnp
-from jax.sharding import NamedSharding
-from jax.sharding import PartitionSpec as P
 from transformers import PretrainedConfig
 
 from sgl_jax.srt.layers.moe import create_moe_weights_mapping
@@ -32,7 +29,7 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
     ):
         super().__init__(config, mesh, dtype)
         # Buffer to hold fused QKV FP8 weights/scales before per-shard dequant.
-        # Populated during weight loading, consumed by _dequant_fused_qkv.
+        # Populated during weight loading, consumed by WeightLoader.dequant_fused_qkv.
         self._fused_qkv_buffers: dict[int, dict] = {}
 
     def load_weights(self, model_config):
@@ -52,7 +49,7 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
             head_dim = self.config.head_dim
             v_head_dim = getattr(self.config, "v_head_dim", head_dim)
             # Dequantize fused QKV per-shard, then split into Q/K/V bf16.
-            self._dequant_fused_qkv()
+            self._loader.dequant_fused_qkv(self._fused_qkv_buffers, self.model.layers, self.config)
             # Dequantize remaining FP8 weights (layer 0 MLP, etc).
             self._loader.dequant_fp8_layers(
                 self.model.layers,
@@ -68,192 +65,6 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
                 specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
                 target_kv_heads_fn=lambda attn: attn.k_head_num,
             )
-
-    def _dequant_fused_qkv(self):
-        """Dequantize per-shard-interleaved fused QKV FP8 weights.
-
-        The FP8 checkpoint was quantized per-TP-shard and concatenated:
-          weight: [shard0_QKV | shard1_QKV | ... | shardN_QKV], shape [total_qkv, hidden]
-          scale:  [shard0_scale | shard1_scale | ... | shardN_scale], shape [total_blocks, in_blocks]
-
-        Each shard's QKV dim may not be a multiple of block_size, so scale blocks
-        within a shard can span K/V boundaries. We must dequantize per-shard first,
-        then extract Q/K/V from each shard.
-        """
-        if not self._fused_qkv_buffers:
-            return
-
-        head_dim = self.config.head_dim
-        v_head_dim = getattr(self.config, "v_head_dim", head_dim)
-        num_heads = self.config.num_attention_heads
-        num_kv_heads = self.config.num_key_value_heads
-
-        quant_cfg = getattr(self.config, "quantization_config", None)
-        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
-
-        for layer_idx in sorted(self._fused_qkv_buffers.keys()):
-            buf = self._fused_qkv_buffers[layer_idx]
-            fused_weight = buf["weight"]  # [total_qkv, hidden], FP8, HF layout
-            fused_scale = buf["scale"]  # [total_blocks, in_blocks], f32
-
-            in_dim = fused_weight.shape[1]  # hidden_size
-
-            # Infer n_shards: find TP size where per-shard blocking matches scale shape
-            n_shards, orig_kv_heads = self._infer_qkv_shards(
-                fused_weight.shape[0],
-                fused_scale.shape[0],
-                num_heads,
-                num_kv_heads,
-                head_dim,
-                v_head_dim,
-                block_size,
-            )
-
-            per_shard_q = (num_heads // n_shards) * head_dim
-            per_shard_k = (orig_kv_heads // n_shards) * head_dim
-            per_shard_v = (orig_kv_heads // n_shards) * v_head_dim
-            per_shard_total = per_shard_q + per_shard_k + per_shard_v
-            per_shard_blocks = math.ceil(per_shard_total / block_size)
-            padded_rows = per_shard_blocks * block_size
-            in_blocks = in_dim // block_size
-
-            if layer_idx % 10 == 0:
-                logger.info(
-                    "Layer %d: dequant fused QKV FP8, n_shards=%d, "
-                    "per_shard=%d (Q=%d K=%d V=%d), blocks=%d",
-                    layer_idx,
-                    n_shards,
-                    per_shard_total,
-                    per_shard_q,
-                    per_shard_k,
-                    per_shard_v,
-                    per_shard_blocks,
-                )
-
-            q_parts, k_parts, v_parts = [], [], []
-
-            for shard_idx in range(n_shards):
-                # Extract this shard's weight and scale
-                w_start = shard_idx * per_shard_total
-                shard_w = fused_weight[w_start : w_start + per_shard_total, :]
-
-                s_start = shard_idx * per_shard_blocks
-                shard_s = fused_scale[s_start : s_start + per_shard_blocks, :]
-
-                # Pad weight rows to block boundary for dequant
-                if per_shard_total < padded_rows:
-                    shard_w = jnp.pad(shard_w, ((0, padded_rows - per_shard_total), (0, 0)))
-
-                # Block dequantize: [padded_rows, in_dim] × [blocks, in_blocks]
-                shard_f = shard_w.astype(jnp.float32).reshape(
-                    per_shard_blocks, block_size, in_blocks, block_size
-                )
-                shard_s_4d = shard_s[:, None, :, None]
-                shard_bf16 = (
-                    (shard_f * shard_s_4d)
-                    .reshape(padded_rows, in_dim)[:per_shard_total, :]
-                    .astype(jnp.bfloat16)
-                )
-
-                # Split shard into Q, K, V (contiguous within each shard)
-                q_parts.append(shard_bf16[:per_shard_q, :])
-                k_parts.append(shard_bf16[per_shard_q : per_shard_q + per_shard_k, :])
-                v_parts.append(shard_bf16[per_shard_q + per_shard_k :, :])
-
-            # Concatenate across shards → full Q/K/V in HF layout [out, in]
-            q_weight = jnp.concatenate(q_parts, axis=0)
-            k_weight = jnp.concatenate(k_parts, axis=0)
-            v_weight = jnp.concatenate(v_parts, axis=0)
-
-            # Transpose to model layout [in, out] and shard
-            q_weight = jnp.transpose(q_weight)
-            k_weight = jnp.transpose(k_weight)
-            v_weight = jnp.transpose(v_weight)
-
-            tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
-            q_weight = jax.device_put(q_weight, tp_sharding)
-            k_weight = jax.device_put(k_weight, tp_sharding)
-            v_weight = jax.device_put(v_weight, tp_sharding)
-
-            # Replace QuantizedLinear with bf16 LinearBase
-            attn = self.model.layers[layer_idx].self_attn
-            for proj_name, w in [
-                ("q_proj", q_weight),
-                ("k_proj", k_weight),
-                ("v_proj", v_weight),
-            ]:
-                setattr(
-                    attn,
-                    proj_name,
-                    WeightLoader.create_bf16_linear(w, (None, "tensor"), self.mesh),
-                )
-
-            if layer_idx == 0:
-                logger.info(
-                    "Layer 0 dequant result: Q=%s K=%s V=%s",
-                    q_weight.shape,
-                    k_weight.shape,
-                    v_weight.shape,
-                )
-
-        # Clean up buffers
-        self._fused_qkv_buffers.clear()
-        logger.info("Fused QKV FP8 dequantization complete for all layers.")
-
-    @staticmethod
-    def _infer_qkv_shards(
-        total_out_dim: int,
-        total_scale_blocks: int,
-        num_heads: int,
-        num_kv_heads: int,
-        head_dim: int,
-        v_head_dim: int,
-        block_size: int,
-    ) -> tuple[int, int]:
-        """Infer the number of TP shards used during FP8 quantization.
-
-        The config's num_kv_heads may be GQA-replicated (e.g. 32 instead of
-        the original 8), so we also try divisors of num_kv_heads to find the
-        original value used during per-shard quantization.
-
-        Returns (tp_shards, original_num_kv_heads).
-        """
-        # Collect candidate kv_heads values: config value and its divisors
-        kv_candidates = []
-        for d in range(1, num_kv_heads + 1):
-            if num_kv_heads % d == 0:
-                kv_candidates.append(d)
-        # Try config value first, then smaller divisors (descending)
-        kv_candidates = sorted(set(kv_candidates), reverse=True)
-
-        # TP candidates: all divisors of num_heads (covers any quantization-time TP)
-        tp_candidates = sorted(d for d in range(1, num_heads + 1) if num_heads % d == 0)
-
-        for orig_kv in kv_candidates:
-            for tp in tp_candidates:
-                if orig_kv % tp != 0:
-                    continue
-                per_shard = (
-                    (num_heads // tp) * head_dim
-                    + (orig_kv // tp) * head_dim
-                    + (orig_kv // tp) * v_head_dim
-                )
-                per_shard_blocks = math.ceil(per_shard / block_size)
-                if per_shard_blocks * tp == total_scale_blocks and per_shard * tp == total_out_dim:
-                    if orig_kv != num_kv_heads:
-                        logger.info(
-                            "Inferred original num_kv_heads=%d (config has %d), tp=%d",
-                            orig_kv,
-                            num_kv_heads,
-                            tp,
-                        )
-                    return tp, orig_kv
-        raise ValueError(
-            f"Cannot infer QKV shard count: out_dim={total_out_dim}, "
-            f"scale_blocks={total_scale_blocks}, num_heads={num_heads}, "
-            f"num_kv_heads={num_kv_heads}, head_dim={head_dim}, "
-            f"v_head_dim={v_head_dim}, block_size={block_size}"
-        )
 
     def _create_layer_mappings(self, layer_idx: int) -> dict:
         """Override to handle fused qkv_proj weights in MiMo-V2-Pro checkpoints."""

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -34,7 +34,7 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
 
     def load_weights(self, model_config):
         """Load weights with special handling for per-shard-quantized fused QKV."""
-        self._loader = WeightLoader(
+        self.loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
@@ -42,16 +42,16 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
         )
         self._quant_config = model_config.quantization_config
         weight_mappings = self._create_weight_mappings()
-        self._loader.load_weights_from_safetensors(weight_mappings)
+        self.loader.load_weights_from_safetensors(weight_mappings)
         logger.info("MiMoV2Pro weights loaded successfully!")
 
-        if self._loader.is_static_quant:
+        if self.loader.is_static_quant:
             head_dim = self.config.head_dim
             v_head_dim = getattr(self.config, "v_head_dim", head_dim)
             # Dequantize fused QKV per-shard, then split into Q/K/V bf16.
-            self._loader.dequant_fused_qkv(self._fused_qkv_buffers, self.model.layers, self.config)
+            self.loader.dequant_fused_qkv(self._fused_qkv_buffers, self.model.layers, self.config)
             # Dequantize remaining FP8 weights (layer 0 MLP, etc).
-            self._loader.dequant_fp8_layers(
+            self.loader.dequant_fp8_layers(
                 self.model.layers,
                 specs=[
                     ("mlp.gate_proj", None),
@@ -60,7 +60,7 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
                 ],
                 layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
             )
-            self._loader.replicate_kv_heads(
+            self.loader.replicate_kv_heads(
                 self.model.layers,
                 specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
                 target_kv_heads_fn=lambda attn: attn.k_head_num,
@@ -72,11 +72,11 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
         target = prefix
 
         mappings = {}
-        is_fp8 = self._is_static_quant
+        is_fp8 = self.loader.is_static_quant
 
         # --- Fused QKV projection ---
         hf_qkv_key = f"{prefix}.self_attn.qkv_proj"
-        qkv_ignored = self._is_quant_ignored(hf_qkv_key)
+        qkv_ignored = self.loader.is_quant_ignored(hf_qkv_key)
 
         if is_fp8 and not qkv_ignored:
             # FP8 fused QKV: store raw weight+scale in buffer, dequant post-load.
@@ -109,7 +109,7 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
 
         # --- o_proj (separate, same as Flash) ---
         hf_o_key = f"{prefix}.self_attn.o_proj"
-        o_ignored = self._is_quant_ignored(hf_o_key)
+        o_ignored = self.loader.is_quant_ignored(hf_o_key)
         o_weight_suffix = "weight" if (not is_fp8 or o_ignored) else "weight_q"
 
         mappings[f"{hf_o_key}.weight"] = WeightMapping(

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -11,12 +11,10 @@ import math
 
 import jax
 import jax.numpy as jnp
-from flax import nnx
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from transformers import PretrainedConfig
 
-from sgl_jax.srt.layers.linear import LinearBase
 from sgl_jax.srt.layers.moe import create_moe_weights_mapping
 from sgl_jax.srt.models.mimo_v2_flash import MiMoV2FlashForCausalLM
 from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
@@ -39,7 +37,7 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
 
     def load_weights(self, model_config):
         """Load weights with special handling for per-shard-quantized fused QKV."""
-        loader = WeightLoader(
+        self._loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
@@ -47,14 +45,29 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
         )
         self._quant_config = model_config.quantization_config
         weight_mappings = self._create_weight_mappings()
-        loader.load_weights_from_safetensors(weight_mappings)
+        self._loader.load_weights_from_safetensors(weight_mappings)
         logger.info("MiMoV2Pro weights loaded successfully!")
 
-        if self._is_static_quant:
+        if self._loader.is_static_quant:
+            head_dim = self.config.head_dim
+            v_head_dim = getattr(self.config, "v_head_dim", head_dim)
             # Dequantize fused QKV per-shard, then split into Q/K/V bf16.
             self._dequant_fused_qkv()
             # Dequantize remaining FP8 weights (layer 0 MLP, etc).
-            self._dequantize_fp8_to_bf16()
+            self._loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+                layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
+            )
+            self._loader.replicate_kv_heads(
+                self.model.layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
 
     def _dequant_fused_qkv(self):
         """Dequantize per-shard-interleaved fused QKV FP8 weights.
@@ -169,17 +182,11 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
                 ("k_proj", k_weight),
                 ("v_proj", v_weight),
             ]:
-                with jax.set_mesh(self.mesh):
-                    new_linear = LinearBase(
-                        input_size=in_dim,
-                        output_size=w.shape[1],
-                        kernel_axes=(None, "tensor"),
-                        use_bias=False,
-                        params_dtype=jnp.bfloat16,
-                        mesh=self.mesh,
-                    )
-                    new_linear.weight = nnx.Param(w)
-                setattr(attn, proj_name, new_linear)
+                setattr(
+                    attn,
+                    proj_name,
+                    WeightLoader.create_bf16_linear(w, (None, "tensor"), self.mesh),
+                )
 
             if layer_idx == 0:
                 logger.info(
@@ -192,9 +199,6 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
         # Clean up buffers
         self._fused_qkv_buffers.clear()
         logger.info("Fused QKV FP8 dequantization complete for all layers.")
-
-        # Replicate KV heads for TP alignment
-        self._ensure_kv_head_replication()
 
     @staticmethod
     def _infer_qkv_shards(

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -1,0 +1,428 @@
+"""MiMo-V2-Pro model implementation for SGLang-JAX.
+
+Inherits from MiMoV2FlashForCausalLM. The main difference is the weight format:
+Pro uses a fused qkv_proj instead of separate q/k/v_proj weights. The FP8
+checkpoint was quantized per-TP-shard and concatenated, so the fused QKV has
+a per-shard-interleaved layout that requires special dequantization handling.
+"""
+
+import logging
+import math
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.layers.linear import LinearBase
+from sgl_jax.srt.layers.moe import create_moe_weights_mapping
+from sgl_jax.srt.models.mimo_v2_flash import MiMoV2FlashForCausalLM
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh | None = None,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        super().__init__(config, mesh, dtype)
+        # Buffer to hold fused QKV FP8 weights/scales before per-shard dequant.
+        # Populated during weight loading, consumed by _dequant_fused_qkv.
+        self._fused_qkv_buffers: dict[int, dict] = {}
+
+    def load_weights(self, model_config):
+        """Load weights with special handling for per-shard-quantized fused QKV."""
+        loader = WeightLoader(
+            model=self,
+            model_config=model_config,
+            mesh=self.mesh,
+            dtype=self.dtype,
+        )
+        self._quant_config = model_config.quantization_config
+        weight_mappings = self._create_weight_mappings()
+        loader.load_weights_from_safetensors(weight_mappings)
+        logger.info("MiMoV2Pro weights loaded successfully!")
+
+        if self._is_static_quant:
+            # Dequantize fused QKV per-shard, then split into Q/K/V bf16.
+            self._dequant_fused_qkv()
+            # Dequantize remaining FP8 weights (layer 0 MLP, etc).
+            self._dequantize_fp8_to_bf16()
+
+    def _dequant_fused_qkv(self):
+        """Dequantize per-shard-interleaved fused QKV FP8 weights.
+
+        The FP8 checkpoint was quantized per-TP-shard and concatenated:
+          weight: [shard0_QKV | shard1_QKV | ... | shardN_QKV], shape [total_qkv, hidden]
+          scale:  [shard0_scale | shard1_scale | ... | shardN_scale], shape [total_blocks, in_blocks]
+
+        Each shard's QKV dim may not be a multiple of block_size, so scale blocks
+        within a shard can span K/V boundaries. We must dequantize per-shard first,
+        then extract Q/K/V from each shard.
+        """
+        if not self._fused_qkv_buffers:
+            return
+
+        head_dim = self.config.head_dim
+        v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+        num_heads = self.config.num_attention_heads
+        num_kv_heads = self.config.num_key_value_heads
+
+        quant_cfg = getattr(self.config, "quantization_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        for layer_idx in sorted(self._fused_qkv_buffers.keys()):
+            buf = self._fused_qkv_buffers[layer_idx]
+            fused_weight = buf["weight"]  # [total_qkv, hidden], FP8, HF layout
+            fused_scale = buf["scale"]  # [total_blocks, in_blocks], f32
+
+            in_dim = fused_weight.shape[1]  # hidden_size
+
+            # Infer n_shards: find TP size where per-shard blocking matches scale shape
+            n_shards, orig_kv_heads = self._infer_qkv_shards(
+                fused_weight.shape[0],
+                fused_scale.shape[0],
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                v_head_dim,
+                block_size,
+            )
+
+            per_shard_q = (num_heads // n_shards) * head_dim
+            per_shard_k = (orig_kv_heads // n_shards) * head_dim
+            per_shard_v = (orig_kv_heads // n_shards) * v_head_dim
+            per_shard_total = per_shard_q + per_shard_k + per_shard_v
+            per_shard_blocks = math.ceil(per_shard_total / block_size)
+            padded_rows = per_shard_blocks * block_size
+            in_blocks = in_dim // block_size
+
+            if layer_idx % 10 == 0:
+                logger.info(
+                    "Layer %d: dequant fused QKV FP8, n_shards=%d, "
+                    "per_shard=%d (Q=%d K=%d V=%d), blocks=%d",
+                    layer_idx,
+                    n_shards,
+                    per_shard_total,
+                    per_shard_q,
+                    per_shard_k,
+                    per_shard_v,
+                    per_shard_blocks,
+                )
+
+            q_parts, k_parts, v_parts = [], [], []
+
+            for shard_idx in range(n_shards):
+                # Extract this shard's weight and scale
+                w_start = shard_idx * per_shard_total
+                shard_w = fused_weight[w_start : w_start + per_shard_total, :]
+
+                s_start = shard_idx * per_shard_blocks
+                shard_s = fused_scale[s_start : s_start + per_shard_blocks, :]
+
+                # Pad weight rows to block boundary for dequant
+                if per_shard_total < padded_rows:
+                    shard_w = jnp.pad(shard_w, ((0, padded_rows - per_shard_total), (0, 0)))
+
+                # Block dequantize: [padded_rows, in_dim] × [blocks, in_blocks]
+                shard_f = shard_w.astype(jnp.float32).reshape(
+                    per_shard_blocks, block_size, in_blocks, block_size
+                )
+                shard_s_4d = shard_s[:, None, :, None]
+                shard_bf16 = (
+                    (shard_f * shard_s_4d)
+                    .reshape(padded_rows, in_dim)[:per_shard_total, :]
+                    .astype(jnp.bfloat16)
+                )
+
+                # Split shard into Q, K, V (contiguous within each shard)
+                q_parts.append(shard_bf16[:per_shard_q, :])
+                k_parts.append(shard_bf16[per_shard_q : per_shard_q + per_shard_k, :])
+                v_parts.append(shard_bf16[per_shard_q + per_shard_k :, :])
+
+            # Concatenate across shards → full Q/K/V in HF layout [out, in]
+            q_weight = jnp.concatenate(q_parts, axis=0)
+            k_weight = jnp.concatenate(k_parts, axis=0)
+            v_weight = jnp.concatenate(v_parts, axis=0)
+
+            # Transpose to model layout [in, out] and shard
+            q_weight = jnp.transpose(q_weight)
+            k_weight = jnp.transpose(k_weight)
+            v_weight = jnp.transpose(v_weight)
+
+            tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+            q_weight = jax.device_put(q_weight, tp_sharding)
+            k_weight = jax.device_put(k_weight, tp_sharding)
+            v_weight = jax.device_put(v_weight, tp_sharding)
+
+            # Replace QuantizedLinear with bf16 LinearBase
+            attn = self.model.layers[layer_idx].self_attn
+            for proj_name, w in [
+                ("q_proj", q_weight),
+                ("k_proj", k_weight),
+                ("v_proj", v_weight),
+            ]:
+                with jax.set_mesh(self.mesh):
+                    new_linear = LinearBase(
+                        input_size=in_dim,
+                        output_size=w.shape[1],
+                        kernel_axes=(None, "tensor"),
+                        use_bias=False,
+                        params_dtype=jnp.bfloat16,
+                        mesh=self.mesh,
+                    )
+                    new_linear.weight = nnx.Param(w)
+                setattr(attn, proj_name, new_linear)
+
+            if layer_idx == 0:
+                logger.info(
+                    "Layer 0 dequant result: Q=%s K=%s V=%s",
+                    q_weight.shape,
+                    k_weight.shape,
+                    v_weight.shape,
+                )
+
+        # Clean up buffers
+        self._fused_qkv_buffers.clear()
+        logger.info("Fused QKV FP8 dequantization complete for all layers.")
+
+        # Replicate KV heads for TP alignment
+        self._ensure_kv_head_replication()
+
+    @staticmethod
+    def _infer_qkv_shards(
+        total_out_dim: int,
+        total_scale_blocks: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        v_head_dim: int,
+        block_size: int,
+    ) -> tuple[int, int]:
+        """Infer the number of TP shards used during FP8 quantization.
+
+        The config's num_kv_heads may be GQA-replicated (e.g. 32 instead of
+        the original 8), so we also try divisors of num_kv_heads to find the
+        original value used during per-shard quantization.
+
+        Returns (tp_shards, original_num_kv_heads).
+        """
+        # Collect candidate kv_heads values: config value and its divisors
+        kv_candidates = []
+        for d in range(1, num_kv_heads + 1):
+            if num_kv_heads % d == 0:
+                kv_candidates.append(d)
+        # Try config value first, then smaller divisors (descending)
+        kv_candidates = sorted(set(kv_candidates), reverse=True)
+
+        # TP candidates: all divisors of num_heads (covers any quantization-time TP)
+        tp_candidates = sorted(d for d in range(1, num_heads + 1) if num_heads % d == 0)
+
+        for orig_kv in kv_candidates:
+            for tp in tp_candidates:
+                if orig_kv % tp != 0:
+                    continue
+                per_shard = (
+                    (num_heads // tp) * head_dim
+                    + (orig_kv // tp) * head_dim
+                    + (orig_kv // tp) * v_head_dim
+                )
+                per_shard_blocks = math.ceil(per_shard / block_size)
+                if per_shard_blocks * tp == total_scale_blocks and per_shard * tp == total_out_dim:
+                    if orig_kv != num_kv_heads:
+                        logger.info(
+                            "Inferred original num_kv_heads=%d (config has %d), tp=%d",
+                            orig_kv,
+                            num_kv_heads,
+                            tp,
+                        )
+                    return tp, orig_kv
+        raise ValueError(
+            f"Cannot infer QKV shard count: out_dim={total_out_dim}, "
+            f"scale_blocks={total_scale_blocks}, num_heads={num_heads}, "
+            f"num_kv_heads={num_kv_heads}, head_dim={head_dim}, "
+            f"v_head_dim={v_head_dim}, block_size={block_size}"
+        )
+
+    def _create_layer_mappings(self, layer_idx: int) -> dict:
+        """Override to handle fused qkv_proj weights in MiMo-V2-Pro checkpoints."""
+        prefix = f"model.layers.{layer_idx}"
+        target = prefix
+
+        mappings = {}
+        is_fp8 = self._is_static_quant
+
+        # --- Fused QKV projection ---
+        hf_qkv_key = f"{prefix}.self_attn.qkv_proj"
+        qkv_ignored = self._is_quant_ignored(hf_qkv_key)
+
+        if is_fp8 and not qkv_ignored:
+            # FP8 fused QKV: store raw weight+scale in buffer, dequant post-load.
+            # Use a callback mapping that stores into _fused_qkv_buffers instead of
+            # trying to split the per-shard-interleaved data.
+            mappings[f"{hf_qkv_key}.weight"] = WeightMapping(
+                target_path=f"__FUSED_QKV_WEIGHT__{layer_idx}",
+                sharding=(None, None),
+                transpose=False,
+            )
+            mappings[f"{hf_qkv_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"__FUSED_QKV_SCALE__{layer_idx}",
+                sharding=(None, None),
+                transpose=False,
+            )
+        else:
+            # BF16 or ignored: split normally (contiguous Q/K/V layout is fine)
+            qkv_weight_suffix = "weight"
+            mappings[f"{hf_qkv_key}.weight"] = WeightMapping(
+                target_path=[
+                    f"{target}.self_attn.q_proj.{qkv_weight_suffix}",
+                    f"{target}.self_attn.k_proj.{qkv_weight_suffix}",
+                    f"{target}.self_attn.v_proj.{qkv_weight_suffix}",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=False,
+                kv_head_padding=True,
+            )
+
+        # --- o_proj (separate, same as Flash) ---
+        hf_o_key = f"{prefix}.self_attn.o_proj"
+        o_ignored = self._is_quant_ignored(hf_o_key)
+        o_weight_suffix = "weight" if (not is_fp8 or o_ignored) else "weight_q"
+
+        mappings[f"{hf_o_key}.weight"] = WeightMapping(
+            target_path=f"{target}.self_attn.o_proj.{o_weight_suffix}",
+            sharding=("tensor", None),
+            transpose=True,
+            head_dim_padding=True,
+        )
+
+        if is_fp8 and not o_ignored:
+            mappings[f"{hf_o_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"{target}.self_attn.o_proj.weight_scale",
+                sharding=(None, None),
+                transpose=False,
+            )
+
+        # --- Attention sink bias (same as Flash) ---
+        is_swa = (
+            hasattr(self.config, "hybrid_layer_pattern")
+            and 0 <= layer_idx < len(self.config.hybrid_layer_pattern)
+            and self.config.hybrid_layer_pattern[layer_idx] == 1
+        )
+        has_sink_bias = (is_swa and getattr(self.config, "add_swa_attention_sink_bias", False)) or (
+            not is_swa and getattr(self.config, "add_full_attention_sink_bias", False)
+        )
+        if has_sink_bias:
+            mappings[f"{prefix}.self_attn.attention_sink_bias"] = WeightMapping(
+                target_path=f"{target}.self_attn.attention_sink_bias",
+                sharding=("tensor",),
+                transpose=False,
+            )
+
+        # --- Layernorms (same as Flash) ---
+        mappings[f"{prefix}.input_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.input_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+        mappings[f"{prefix}.post_attention_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.post_attention_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+
+        # --- MLP / MoE (same as Flash) ---
+        is_sparse = (
+            hasattr(self.config, "moe_layer_freq")
+            and 0 <= layer_idx < len(self.config.moe_layer_freq)
+            and not isinstance(self.config.moe_layer_freq, int)
+            and self.config.moe_layer_freq[layer_idx]
+        )
+
+        if is_sparse:
+            mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
+                target_path=f"{target}.mlp.moe_gate.kernel",
+                sharding=(None, None),
+                transpose=True,
+            )
+
+            if getattr(self.config, "topk_method", "greedy") == "noaux_tc":
+                mappings[f"{prefix}.mlp.gate.e_score_correction_bias"] = WeightMapping(
+                    target_path=f"{target}.mlp.correction_bias",
+                    sharding=(None,),
+                    transpose=False,
+                )
+
+            num_experts = getattr(
+                self.config,
+                "n_routed_experts",
+                getattr(self.config, "num_experts", 8),
+            )
+            moe_backend = getattr(self.config, "moe_backend", "epmoe")
+
+            moe_mappings = create_moe_weights_mapping(
+                prefix=prefix,
+                target_prefix=target,
+                num_experts=num_experts,
+                moe_backend=moe_backend,
+                moe_path="mlp.experts",
+                source_expert_pattern="{i}",
+            )
+
+            if is_fp8:
+                augmented = {}
+                use_model_mesh_for_scale = moe_backend == "fused"
+                for key, mapping in moe_mappings.items():
+                    augmented[key] = mapping
+                    target_param = mapping.target_path[0]
+                    src_paths = mapping.target_path[1:]
+                    scale_key = key + "_scale"
+                    scale_target = target_param + "_scale"
+                    scale_srcs = [p.replace(".weight", ".weight_scale_inv") for p in src_paths]
+                    scale_sharding = (
+                        (("data", "tensor"), None, None)
+                        if use_model_mesh_for_scale
+                        else ("expert", None, None)
+                    )
+                    augmented[scale_key] = WeightMapping(
+                        target_path=[scale_target] + scale_srcs,
+                        sharding=scale_sharding,
+                        transpose=use_model_mesh_for_scale,
+                        concat_axis=mapping.concat_axis,
+                        physical_to_logical_map=mapping.physical_to_logical_map,
+                    )
+                moe_mappings = augmented
+
+            mappings.update(moe_mappings)
+        else:
+            for proj, sharding in [
+                ("gate_proj", (None, "tensor")),
+                ("up_proj", (None, "tensor")),
+                ("down_proj", ("tensor", None)),
+            ]:
+                hf_key = f"{prefix}.mlp.{proj}"
+                weight_suffix = "weight_q" if is_fp8 else "weight"
+                mappings[f"{hf_key}.weight"] = WeightMapping(
+                    target_path=f"{target}.mlp.{proj}.{weight_suffix}",
+                    sharding=sharding,
+                    transpose=True,
+                )
+                if is_fp8:
+                    mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                        target_path=f"{target}.mlp.{proj}.weight_scale",
+                        sharding=(None, None),
+                        transpose=False,
+                    )
+
+        return mappings
+
+
+EntryClass = MiMoV2ProForCausalLM

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1,9 +1,12 @@
 import copy
 import glob
+import json
 import logging
 import os
 import pickle
 import re
+import struct
+import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -137,6 +140,7 @@ class WeightLoader:
 
             self.head_dim_pad = (self.head_dim_original + 127) // 128 * 128 - self.head_dim_original
             self.head_dim = self.head_dim_original
+            self.v_head_dim = getattr(model_config, "v_head_dim", self.head_dim_original)
         if hasattr(self.mesh, "shape") and "tensor" in self.mesh.shape:
             self.sharding_size = self.mesh.shape["tensor"]
         else:
@@ -389,6 +393,12 @@ class WeightLoader:
             iterator = tqdm(weights_files, desc="Scanning Metadata", unit="file")
 
             for st_file in iterator:
+                # Parse safetensors header for byte offsets (for bulk MoE reads)
+                with open(st_file, "rb") as raw_f:
+                    header_size = struct.unpack("<Q", raw_f.read(8))[0]
+                    raw_header = json.loads(raw_f.read(header_size))
+                data_section_offset = 8 + header_size
+
                 with safe_open(st_file, framework="flax", device="cpu") as f:
                     for key in f.keys():  # noqa: SIM118
                         slice_info = f.get_slice(key)
@@ -397,6 +407,12 @@ class WeightLoader:
                             "shape": tuple(slice_info.get_shape()),
                             "dtype": slice_info.get_dtype(),
                         }
+                        # Add byte offset info for direct reads
+                        if key in raw_header:
+                            offsets = raw_header[key].get("data_offsets")
+                            if offsets:
+                                info["byte_offset"] = data_section_offset + offsets[0]
+                                info["byte_size"] = offsets[1] - offsets[0]
                         if key not in weight_info:
                             weight_info[key] = []
                         weight_info[key].append(info)
@@ -702,7 +718,7 @@ class WeightLoader:
                     sample_map = {
                         p: logical_indices[i] for i, p in enumerate(physical_indices[:sample_size])
                     }
-                    logger.info("Cloning split-experts map (sample): %s", sample_map)
+                    logger.debug("Cloning split-experts map (sample): %s", sample_map)
             else:
                 logical_indices = physical_indices
 
@@ -737,9 +753,9 @@ class WeightLoader:
 
             return out_array
 
-        result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice).astype(
-            target_dtype
-        )
+        result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice)
+        if result.dtype != target_dtype:
+            result = result.astype(target_dtype)
         if do_transpose and result.ndim >= 3:
             result = jnp.transpose(result, (0, 2, 1))
         return result
@@ -781,7 +797,62 @@ class WeightLoader:
         else:
             num_physical_experts = num_logical_experts
 
-        if do_transpose and len(single_expert_shape) >= 2:
+        # Detect whether we can defer transpose to TPU instead of doing it
+        # on CPU during loading. This is possible when do_transpose=True but
+        # the weight dimensions (all dims after expert dim) are unsharded,
+        # meaning each callback loads the full tensor. Deferring avoids the
+        # costly strided memcpy from np.transpose on non-contiguous views.
+        defer_transpose = False
+        if do_transpose and len(single_expert_shape) >= 2 and target_sharding is not None:
+            spec = target_sharding.spec
+            # spec[0] is expert dim sharding, spec[1:] are weight dims
+            weight_dims_unsharded = all(s is None for s in spec[1:])
+            if weight_dims_unsharded:
+                defer_transpose = True
+                logger.info(
+                    "MoE defer_transpose=True: will load in HF layout and "
+                    "transpose on TPU (shape=%s)",
+                    single_expert_shape,
+                )
+
+        # Check if bulk raw byte reading is possible (byte offsets available
+        # from scan phase). This eliminates per-expert safetensors API calls
+        # and reduces GCSFuse round-trips by reading contiguous byte ranges.
+        # Skip bulk_read for small tensors (e.g. scales) — safetensors API
+        # with cached handles is faster than raw open/seek/read on GCSFuse.
+        _expert_elems = 1
+        for d in single_expert_shape:
+            _expert_elems *= d
+        _expert_bytes_est = _expert_elems * (1 if st_dtype.startswith("F8_") else 4)
+        _BULK_READ_MIN_BYTES = 1024 * 1024  # 1 MB per expert
+        bulk_read = (
+            defer_transpose
+            and _expert_bytes_est >= _BULK_READ_MIN_BYTES
+            and all(
+                "byte_offset" in weight_info[expected_hf_keys[i]][0]
+                for i in range(min(2, num_logical_experts))
+            )
+        )
+        if bulk_read:
+            logger.info(
+                "MoE bulk_read=True: using raw byte reads for %d experts",
+                num_logical_experts,
+            )
+
+        # Map safetensors dtype strings to numpy dtypes for raw reads
+        _st_to_np_dtype = {
+            "F32": np.float32,
+            "F16": np.float16,
+            "BF16": np.dtype("V2"),  # 2-byte view, reinterpret later
+            "I64": np.int64,
+            "I32": np.int32,
+            "BOOL": np.bool_,
+            "F8_E4M3": np.uint8,
+            "F8_E5M2": np.uint8,
+        }
+        np_read_dtype = _st_to_np_dtype.get(st_dtype, np.uint8)
+
+        if do_transpose and not defer_transpose and len(single_expert_shape) >= 2:
             final_single_shape = list(single_expert_shape)
             final_single_shape[-1], final_single_shape[-2] = (
                 final_single_shape[-2],
@@ -794,9 +865,14 @@ class WeightLoader:
         stacked_shape = (num_physical_experts, *final_single_shape)
         sharding = target_sharding or jax.sharding.NamedSharding(self.mesh, P())
 
-        LOAD_WORKERS = 16
+        LOAD_WORKERS = int(os.environ.get("SGLANG_MOE_LOAD_WORKERS", "16"))
+
+        _callback_times = []
+        _detailed_logged = False
 
         def _load_stacked_slice(index):
+            nonlocal _detailed_logged
+            _cb_start = time.monotonic()
             expert_slice = index[0]
             inner_slice = index[1:]
 
@@ -817,22 +893,54 @@ class WeightLoader:
                         p: logical_indices_to_load[i]
                         for i, p in enumerate(physical_indices[:sample_size])
                     }
-                    logger.info("Cloning experts map (sample): %s", sample_map)
+                    logger.debug("Cloning experts map (sample): %s", sample_map)
             else:
                 logical_indices_to_load = physical_indices
 
+            # --- Load first expert with detailed timing ---
             first_log_idx = logical_indices_to_load[0]
             first_hf_key = expected_hf_keys[first_log_idx]
             first_fname = weight_info[first_hf_key][0]["file"]
-            first_f = file_manager.get_handle(first_fname)
 
-            if not do_transpose:
+            _t0 = time.monotonic()
+            first_f = file_manager.get_handle(first_fname)
+            _t_handle = time.monotonic() - _t0
+
+            if not do_transpose or defer_transpose:
+                _t1 = time.monotonic()
                 first_chunk = first_f.get_slice(first_hf_key)[inner_slice]
+                _t_getslice = time.monotonic() - _t1
+                _t2 = time.monotonic()
                 first_chunk = _view_as_fp8_if_needed(first_chunk, target_dtype)
+                _t_fp8 = time.monotonic() - _t2
+                _t_transpose = 0.0
             else:
+                _t1 = time.monotonic()
                 data = first_f.get_slice(first_hf_key)[:]
+                _t_getslice = time.monotonic() - _t1
+                _t2 = time.monotonic()
                 data = _view_as_fp8_if_needed(data, target_dtype)
+                _t_fp8 = time.monotonic() - _t2
+                _t3 = time.monotonic()
                 first_chunk = np.transpose(data)[inner_slice]
+                _t_transpose = time.monotonic() - _t3
+
+            # Log detailed timing for first callback only
+            if not _detailed_logged:
+                _detailed_logged = True
+                expert_bytes = first_chunk.nbytes
+                logger.debug(
+                    "MoE callback[0] detail: experts_in_shard=%d "
+                    "get_handle=%.4fs get_slice=%.4fs fp8_view=%.4fs "
+                    "transpose=%.4fs expert_bytes=%d file=%s",
+                    sliced_num_physical,
+                    _t_handle,
+                    _t_getslice,
+                    _t_fp8,
+                    _t_transpose,
+                    expert_bytes,
+                    os.path.basename(first_fname),
+                )
 
             out_shape = (sliced_num_physical, *first_chunk.shape)
             out_array = np.empty(out_shape, dtype=first_chunk.dtype)
@@ -846,33 +954,273 @@ class WeightLoader:
                 else:
                     logical_to_positions.setdefault(log_idx, []).append(phys_pos)
 
+            # Per-thread timing accumulators
+            _thread_stats = {
+                "get_handle": [],
+                "get_slice": [],
+                "fp8": [],
+                "transpose": [],
+                "copy": [],
+            }
+            _thread_files = []
+
             def load_and_fill_expert(args):
                 l_idx, positions = args
                 hf_k = expected_hf_keys[l_idx]
                 fname = weight_info[hf_k][0]["file"]
-                f = file_manager.get_handle(fname)
 
-                if not do_transpose:
+                t_a = time.monotonic()
+                f = file_manager.get_handle(fname)
+                t_b = time.monotonic()
+                _thread_stats["get_handle"].append(t_b - t_a)
+
+                if not do_transpose or defer_transpose:
                     chunk = f.get_slice(hf_k)[inner_slice]
+                    t_c = time.monotonic()
+                    _thread_stats["get_slice"].append(t_c - t_b)
                     chunk = _view_as_fp8_if_needed(chunk, target_dtype)
+                    t_d = time.monotonic()
+                    _thread_stats["fp8"].append(t_d - t_c)
+                    _thread_stats["transpose"].append(0.0)
                 else:
                     data = f.get_slice(hf_k)[:]
+                    t_c = time.monotonic()
+                    _thread_stats["get_slice"].append(t_c - t_b)
                     data = _view_as_fp8_if_needed(data, target_dtype)
+                    t_d = time.monotonic()
+                    _thread_stats["fp8"].append(t_d - t_c)
                     chunk = np.transpose(data)[inner_slice]
+                    t_e = time.monotonic()
+                    _thread_stats["transpose"].append(t_e - t_d)
 
+                t_copy_start = time.monotonic()
                 for pos in positions:
                     out_array[pos] = chunk
+                _thread_stats["copy"].append(time.monotonic() - t_copy_start)
+                _thread_files.append(os.path.basename(fname))
 
             if logical_to_positions:
                 tasks = list(logical_to_positions.items())
                 with ThreadPoolExecutor(max_workers=LOAD_WORKERS) as executor:
                     list(executor.map(load_and_fill_expert, tasks))
 
+            _callback_times.append(time.monotonic() - _cb_start)
+
+            # Log aggregated thread stats for first callback
+            if len(_callback_times) == 1 and _thread_stats["get_slice"]:
+                n = len(_thread_stats["get_slice"])
+                unique_files = len(set(_thread_files))
+                logger.debug(
+                    "MoE callback[0] threads: n=%d unique_files=%d "
+                    "get_handle=%.4fs get_slice(sum=%.2fs avg=%.4fs max=%.4fs) "
+                    "fp8=%.4fs transpose(sum=%.2fs avg=%.4fs) copy=%.4fs",
+                    n,
+                    unique_files,
+                    sum(_thread_stats["get_handle"]),
+                    sum(_thread_stats["get_slice"]),
+                    sum(_thread_stats["get_slice"]) / n,
+                    max(_thread_stats["get_slice"]),
+                    sum(_thread_stats["fp8"]),
+                    sum(_thread_stats["transpose"]),
+                    sum(_thread_stats["transpose"]) / n,
+                    sum(_thread_stats["copy"]),
+                )
+
             return out_array
 
-        return jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice).astype(
-            target_dtype
-        )
+        t0 = time.monotonic()
+        if bulk_read:
+            # Host-level bulk loading: read all experts for local devices at
+            # once, then device_put in parallel. This replaces serial
+            # make_array_from_callback with a single bulk I/O + parallel
+            # device transfers.
+            local_devices = sharding.mesh.local_devices
+            n_local = len(local_devices)
+
+            # Determine which physical experts each local device needs
+            device_assignments = sharding.devices_indices_map(stacked_shape)
+            local_assignments = []
+            for dev in local_devices:
+                idx = device_assignments[dev]
+                expert_slice = idx[0]
+                s, e, st = expert_slice.indices(num_physical_experts)
+                local_assignments.append(list(range(s, e, st)))
+
+            # Collect ALL unique logical expert indices needed by this host
+            all_logical = set()
+            for phys_indices in local_assignments:
+                for p in phys_indices:
+                    if physical_to_logical_map is not None:
+                        all_logical.add(int(physical_to_logical_map[p]))
+                    else:
+                        all_logical.add(p)
+
+            # Group by file for bulk reading
+            file_groups = {}
+            for log_idx in all_logical:
+                hf_key = expected_hf_keys[log_idx]
+                info = weight_info[hf_key][0]
+                fname = info["file"]
+                byte_offset = info["byte_offset"]
+                file_groups.setdefault(fname, []).append((log_idx, byte_offset, hf_key))
+
+            # Compute per-expert byte size
+            expert_nbytes = 1
+            for d in single_expert_shape:
+                expert_nbytes *= d
+            elem_size = 1 if np_read_dtype == np.uint8 else np.dtype(np_read_dtype).itemsize
+            expert_nbytes *= elem_size
+
+            # Read all expert data from files (parallel across files)
+            expert_data_map = {}  # log_idx -> np.ndarray
+
+            def _bulk_read_file(fname, entries):
+                entries.sort(key=lambda e: e[1])
+                min_off = entries[0][1]
+                max_end = entries[-1][1] + expert_nbytes
+                rng = max_end - min_off
+                actual = len(entries) * expert_nbytes
+                result = {}
+                if rng <= actual * 2 and len(entries) > 1:
+                    with open(fname, "rb") as f:
+                        f.seek(min_off)
+                        bulk = f.read(rng)
+                    for log_idx, byte_off, hf_key in entries:
+                        local_off = byte_off - min_off
+                        arr = np.frombuffer(
+                            bulk,
+                            dtype=np_read_dtype,
+                            count=expert_nbytes // elem_size,
+                            offset=local_off,
+                        ).reshape(single_expert_shape)
+                        result[log_idx] = arr.copy()
+                else:
+                    with open(fname, "rb") as f:
+                        for log_idx, byte_off, hf_key in entries:
+                            f.seek(byte_off)
+                            raw = f.read(expert_nbytes)
+                            arr = np.frombuffer(
+                                raw,
+                                dtype=np_read_dtype,
+                            ).reshape(single_expert_shape)
+                            result[log_idx] = arr
+                return result
+
+            t_io_start = time.monotonic()
+            if len(file_groups) > 1:
+                with ThreadPoolExecutor(max_workers=len(file_groups)) as ex:
+                    futs = {
+                        ex.submit(_bulk_read_file, fn, ents): fn for fn, ents in file_groups.items()
+                    }
+                    for fut in futs:
+                        expert_data_map.update(fut.result())
+            else:
+                for fn, ents in file_groups.items():
+                    expert_data_map.update(_bulk_read_file(fn, ents))
+            t_io = time.monotonic() - t_io_start
+            total_read_mb = sum(v.nbytes for v in expert_data_map.values()) / 1e6
+
+            # Assemble per-device arrays and device_put (parallel)
+            t_assemble_start = time.monotonic()
+            n_experts_per_shard = len(local_assignments[0])
+
+            def _build_and_put(dev_idx):
+                dev = local_devices[dev_idx]
+                phys_indices = local_assignments[dev_idx]
+                shard = np.empty(
+                    (n_experts_per_shard, *single_expert_shape),
+                    dtype=np_read_dtype,
+                )
+                for pos, p in enumerate(phys_indices):
+                    log_idx = (
+                        int(physical_to_logical_map[p])
+                        if physical_to_logical_map is not None
+                        else p
+                    )
+                    shard[pos] = expert_data_map[log_idx]
+                shard = _view_as_fp8_if_needed(shard, target_dtype)
+                return jax.device_put(shard, dev)
+
+            with ThreadPoolExecutor(max_workers=n_local) as ex:
+                per_device_arrays = list(ex.map(_build_and_put, range(n_local)))
+            t_assemble = time.monotonic() - t_assemble_start
+
+            result = jax.make_array_from_single_device_arrays(
+                stacked_shape,
+                sharding,
+                per_device_arrays,
+            )
+            t_callback = time.monotonic() - t0
+
+            logger.debug(
+                "MoE host-bulk load: shape=%s dtype=%s "
+                "io=%.2fs (%.1f MB, %.1f MB/s) "
+                "assemble+put=%.2fs total=%.2fs "
+                "experts_read=%d files=%d devices=%d",
+                stacked_shape,
+                target_dtype,
+                t_io,
+                total_read_mb,
+                total_read_mb / t_io if t_io > 0 else 0,
+                t_assemble,
+                t_callback,
+                len(expert_data_map),
+                len(file_groups),
+                n_local,
+            )
+        else:
+            # Pre-warm safetensors file handles to avoid cold-start latency
+            # during serial callbacks. This is especially important for small
+            # tensors (scales) where GCSFuse file-open latency dominates.
+            unique_files = set()
+            for i in range(num_logical_experts):
+                hf_key = expected_hf_keys[i]
+                unique_files.add(weight_info[hf_key][0]["file"])
+            uncached = [fn for fn in unique_files if fn not in file_manager.handles]
+            if uncached:
+
+                def _prewarm(fn):
+                    return fn, safe_open(fn, framework="np", device="cpu")
+
+                with ThreadPoolExecutor(max_workers=min(len(uncached), 16)) as ex:
+                    for fn, handle in ex.map(_prewarm, uncached):
+                        file_manager.handles[fn] = handle
+
+            callback_fn = _load_stacked_slice
+            result = jax.make_array_from_callback(
+                stacked_shape,
+                sharding,
+                callback_fn,
+            )
+            t_callback = time.monotonic() - t0
+        t1 = time.monotonic()
+        if result.dtype != target_dtype:
+            result = result.astype(target_dtype)
+        t_astype = time.monotonic() - t1
+        # Deferred transpose: data was loaded in HF layout [experts, out, in],
+        # now transpose to kernel layout [experts, in, out] on TPU.
+        t2 = time.monotonic()
+        if defer_transpose and result.ndim >= 3:
+            result = jnp.transpose(result, (0, 2, 1))
+        t_defer = time.monotonic() - t2
+        if _callback_times:
+            defer_msg = f" defer_transpose={t_defer:.3f}s" if defer_transpose else ""
+            logger.debug(
+                "MoE tensor load: shape=%s dtype=%s callbacks=%d "
+                "callback_total=%.2fs (min=%.3fs max=%.3fs) "
+                "make_array=%.2fs astype=%.2fs workers=%d%s",
+                stacked_shape,
+                target_dtype,
+                len(_callback_times),
+                sum(_callback_times),
+                min(_callback_times),
+                max(_callback_times),
+                t_callback,
+                t_astype,
+                LOAD_WORKERS,
+                defer_msg,
+            )
+        return result
 
     def load_weights_from_safetensors(
         self,
@@ -957,6 +1305,7 @@ class WeightLoader:
 
                 can_optimize = (
                     isinstance(mapping.target_path, str)
+                    and not mapping.target_path.startswith("__FUSED_QKV_")
                     and mapping.reshape is None
                     and mapping.repeat is None  # Check repeat here too!
                     and not mapping.kv_head_padding
@@ -1122,6 +1471,7 @@ class WeightLoader:
                         final_sharding = jax.sharding.NamedSharding(self.mesh, P(*mapping.sharding))
 
                     # 2. Call creator
+                    _t_load_start = time.monotonic()
                     stacked_weight = self._create_stacked_moe_lazy_tensor(
                         expected_hf_keys,
                         weight_info,
@@ -1130,6 +1480,7 @@ class WeightLoader:
                         target_sharding=final_sharding,  # Global loading
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )
+                    _t_load = time.monotonic() - _t_load_start
                     loaded_shape = stacked_weight.shape
 
                     if mapping.reshape is not None:
@@ -1149,7 +1500,7 @@ class WeightLoader:
                     )
 
                     if is_static_quant and moe_key.endswith("_scale"):
-                        logger.info(
+                        logger.debug(
                             "MoE scale debug group=%s target=%s loaded_shape=%s final_shape=%s "
                             "param_shape=%s reshape=%s repeat=%s sharding=%s",
                             moe_key,
@@ -1163,10 +1514,22 @@ class WeightLoader:
                         )
 
                     try:
+                        _t_assign_start = time.monotonic()
                         if stacked_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                             model_param.value = stacked_weight
                         else:
                             model_param.value = stacked_weight.astype(model_param.value.dtype)
+                        _t_assign = time.monotonic() - _t_assign_start
+                        logger.debug(
+                            "MoE group %s: load=%.2fs assign=%.2fs total=%.2fs "
+                            "shape=%s sharding=%s",
+                            moe_key,
+                            _t_load,
+                            _t_assign,
+                            _t_load + _t_assign,
+                            loaded_shape,
+                            mapping.sharding,
+                        )
                     except Exception as e:
                         logger.error(
                             "Failed MoE assign group=%s target=%s loaded_shape=%s final_shape=%s "
@@ -1247,7 +1610,7 @@ class WeightLoader:
                     )
 
                     if is_static_quant and moe_key.endswith("_scale"):
-                        logger.info(
+                        logger.debug(
                             "Split-MoE scale debug group=%s target=%s loaded_shape=%s final_shape=%s "
                             "param_shape=%s reshape=%s repeat=%s sharding=%s",
                             moe_key,
@@ -1478,6 +1841,22 @@ class WeightLoader:
         jax_path = mapping.target_path
         processed_weight = weight
 
+        # Handle fused QKV buffer storage (used by MiMo-V2-Pro per-shard dequant).
+        # target_path like "__FUSED_QKV_WEIGHT__42" stores into model._fused_qkv_buffers.
+        if jax_path.startswith("__FUSED_QKV_"):
+            if hasattr(self.model, "_fused_qkv_buffers"):
+                is_scale = "SCALE" in jax_path
+                layer_idx = int(jax_path.rsplit("__", 1)[-1])
+                buf = self.model._fused_qkv_buffers.setdefault(layer_idx, {})
+                buf["scale" if is_scale else "weight"] = processed_weight
+                logger.info(
+                    "Stored fused QKV %s for layer %d, shape=%s",
+                    "scale" if is_scale else "weight",
+                    layer_idx,
+                    processed_weight.shape,
+                )
+            return
+
         # Apply output_multiplier_scale to lm_head weights (matching PyTorch implementation)
         if "lm_head" in hf_key and hasattr(self.model_config.hf_config, "output_multiplier_scale"):
             logger.info(
@@ -1533,13 +1912,18 @@ class WeightLoader:
     ):
         jax_paths = mapping.target_path
 
+        v_head_dim = getattr(self, "v_head_dim", self.head_dim_original)
+        v_head_dim_pad = (v_head_dim + 127) // 128 * 128 - v_head_dim
+        v_head_dim_padded = v_head_dim + v_head_dim_pad
+
         if hf_key.endswith(".bias"):
             q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
 
             q_bias = weight[:q_dim]
-            k_bias = weight[q_dim : q_dim + kv_dim]
-            v_bias = weight[q_dim + kv_dim : q_dim + 2 * kv_dim]
+            k_bias = weight[q_dim : q_dim + k_dim]
+            v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 q_bias = jnp.reshape(q_bias, (self.num_heads, self.head_dim_original))
@@ -1550,23 +1934,56 @@ class WeightLoader:
                 k_bias = jnp.pad(k_bias, ((0, 0), (0, self.head_dim_pad)))
                 k_bias = jnp.reshape(k_bias, (self.num_kv_heads * self.head_dim,))
 
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, self.head_dim_original))
-                v_bias = jnp.pad(v_bias, ((0, 0), (0, self.head_dim_pad)))
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * self.head_dim,))
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, v_head_dim))
+                v_bias = jnp.pad(v_bias, ((0, 0), (0, v_head_dim_pad)))
+                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * v_head_dim_padded,))
 
             splits = [q_bias, k_bias, v_bias]
+        elif "scale" in hf_key and weight.ndim == 2:
+            # Block-quant scale: split along block dimension, not element dimension.
+            # The fused QKV scale has shape [total_blocks, in_blocks] where blocks
+            # are computed per Q/K/V segment independently.
+            import math
+
+            quant_cfg = getattr(self.model_config, "quantization_config", None)
+            block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+            q_dim = self.num_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+
+            q_blocks = math.ceil(q_dim / block_size)
+            k_blocks = math.ceil(k_dim / block_size)
+            # V gets remaining blocks (may include padding to head_dim_original)
+            v_blocks = weight.shape[0] - q_blocks - k_blocks
+
+            logger.info(
+                "Splitting QKV scale %s shape=%s into Q=%d K=%d V=%d blocks",
+                hf_key,
+                weight.shape,
+                q_blocks,
+                k_blocks,
+                v_blocks,
+            )
+
+            q_scale = weight[:q_blocks, :]
+            k_scale = weight[q_blocks : q_blocks + k_blocks, :]
+            v_scale = weight[q_blocks + k_blocks :, :]
+
+            splits = [q_scale, k_scale, v_scale]
         else:
             q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
 
             if mapping.transpose:
                 q_weight = weight[:, :q_dim]
-                k_weight = weight[:, q_dim : q_dim + kv_dim]
-                v_weight = weight[:, q_dim + kv_dim : q_dim + 2 * kv_dim]
+                k_weight = weight[:, q_dim : q_dim + k_dim]
+                v_weight = weight[:, q_dim + k_dim : q_dim + k_dim + v_dim]
             else:
                 q_weight = weight[:q_dim, :]
-                k_weight = weight[q_dim : q_dim + kv_dim, :]
-                v_weight = weight[q_dim + kv_dim : q_dim + 2 * kv_dim, :]
+                k_weight = weight[q_dim : q_dim + k_dim, :]
+                v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 if mapping.transpose:
@@ -1587,15 +2004,6 @@ class WeightLoader:
                     k_weight = jnp.reshape(
                         k_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
                     )
-
-                    v_weight = jnp.reshape(
-                        v_weight,
-                        (self.hidden_size, self.num_kv_heads, self.head_dim_original),
-                    )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, self.head_dim_pad)))
-                    v_weight = jnp.reshape(
-                        v_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
-                    )
                 else:
                     q_weight = jnp.reshape(
                         q_weight,
@@ -1615,13 +2023,24 @@ class WeightLoader:
                         k_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
                     )
 
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                if mapping.transpose:
                     v_weight = jnp.reshape(
                         v_weight,
-                        (self.num_kv_heads, self.head_dim_original, self.hidden_size),
+                        (self.hidden_size, self.num_kv_heads, v_head_dim),
                     )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, v_head_dim_pad)))
                     v_weight = jnp.reshape(
-                        v_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
+                        v_weight, (self.hidden_size, self.num_kv_heads * v_head_dim_padded)
+                    )
+                else:
+                    v_weight = jnp.reshape(
+                        v_weight,
+                        (self.num_kv_heads, v_head_dim, self.hidden_size),
+                    )
+                    v_weight = jnp.pad(v_weight, ((0, 0), (0, v_head_dim_pad), (0, 0)))
+                    v_weight = jnp.reshape(
+                        v_weight, (self.num_kv_heads * v_head_dim_padded, self.hidden_size)
                     )
 
             splits = [q_weight, k_weight, v_weight]
@@ -1635,6 +2054,11 @@ class WeightLoader:
             sharded_weight = self._shard_weight(processed_weight, mapping.sharding)
 
             model_param = self._get_param(params, jax_path)
+
+            # Expand 2D block-quant scale to 3D kernel-ready layout.
+            sharded_weight = self._maybe_expand_linear_block_scale(
+                sharded_weight, model_param, jax_path
+            )
 
             if sharded_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                 model_param.value = sharded_weight

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -10,6 +10,7 @@ import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
@@ -17,6 +18,9 @@ import ml_dtypes
 import numpy as np
 from flax import nnx
 from jax.experimental import multihost_utils
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.layers.linear import LinearBase
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 from safetensors import safe_open
@@ -156,6 +160,248 @@ class WeightLoader:
             )
         else:
             self.moe_abstract_mesh = None
+
+    # ------------------------------------------------------------------
+    # Quant config helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def is_static_quant(self) -> bool:
+        """Check if the model uses a static FP8 checkpoint."""
+        quant_cfg = getattr(self.model_config, "quantization_config", None)
+        return quant_cfg is not None and quant_cfg.is_static_checkpoint
+
+    def is_quant_ignored(self, hf_path: str) -> bool:
+        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
+        quant_cfg = getattr(self.model_config, "quantization_config", None)
+        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
+            return True
+        ignored = quant_cfg.ignored_layers or []
+        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+
+    # ------------------------------------------------------------------
+    # Post-load hooks: dequant FP8 → BF16, KV head replication
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_bf16_linear(
+        weight: jax.Array, kernel_axes, mesh, use_bias=False, bias=None
+    ) -> "LinearBase":
+        """Create a bf16 LinearBase from a weight array [in, out]."""
+        from sgl_jax.srt.layers.linear import LinearBase
+
+        in_features, out_features = weight.shape
+        with jax.set_mesh(mesh):
+            new_linear = LinearBase(
+                input_size=in_features,
+                output_size=out_features,
+                kernel_axes=kernel_axes,
+                use_bias=use_bias,
+                params_dtype=jnp.bfloat16,
+                mesh=mesh,
+            )
+            new_linear.weight = nnx.Param(weight)
+            if bias is not None:
+                new_linear.bias = nnx.Param(bias.astype(jnp.bfloat16))
+        return new_linear
+
+    def dequant_fp8_linear(self, ql, head_dim: int | None = None) -> "LinearBase":
+        """Dequantize a single QuantizedLinear → bf16 LinearBase.
+
+        Handles 3D block-quant scales, 1D per-channel scales, kv_head_padding,
+        and per-head block quant (when head_dim % block_size != 0).
+
+        Args:
+            ql: QuantizedLinear module with weight_q and weight_scale.
+            head_dim: If set, enables per-head block quant handling.
+        """
+        weight_q = ql.weight_q.value
+        weight_scale = ql.weight_scale.value
+
+        if weight_scale.ndim == 3:
+            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
+        elif weight_scale.ndim == 1:
+            out_dim = weight_scale.shape[0]
+            if weight_q.shape[1] == out_dim:
+                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
+                    jnp.bfloat16
+                )
+            else:
+                weight_bf16 = (
+                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
+                ).astype(jnp.bfloat16)
+        else:
+            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
+
+        bias = ql.bias.value if ql.bias is not None else None
+        return self.create_bf16_linear(
+            weight_bf16, ql.kernel_axes, ql.mesh, ql.bias is not None, bias
+        )
+
+    @staticmethod
+    def _block_dequant(
+        weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
+    ) -> jax.Array:
+        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
+
+        Returns bf16 weight in model layout [in_dim, out_dim].
+        Handles kv_head_padding (scale tiling) and per-head block quant.
+        """
+        import math
+
+        in_blocks = weight_scale.shape[0]
+        out_dim = weight_scale.shape[2]
+        dim0, dim1 = weight_q.shape
+
+        if dim1 == out_dim:
+            pass  # Model layout [in, out], no kv-padding
+        elif dim0 == out_dim:
+            weight_q = jnp.transpose(weight_q)  # HF layout [out, in]
+        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
+            # Per-head block quant: scale was expanded for wrong n_out.
+            if dim0 % in_blocks == 0:
+                actual_out = dim1  # model layout [in, out]
+            else:
+                weight_q = jnp.transpose(weight_q)
+                actual_out = dim0  # was HF layout [out, in]
+
+            block_size = 128
+            blocks_per_head = math.ceil(head_dim / block_size)
+            num_heads = actual_out // head_dim
+
+            gather_idx = jnp.array(
+                [
+                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
+                    for j in range(actual_out)
+                ]
+            )
+            weight_scale = weight_scale[:, :, gather_idx]
+            out_dim = actual_out
+
+            logger.info(
+                "Per-head block dequant: %d heads x head_dim=%d, %d blocks/head, "
+                "remapped scale to (%s)",
+                num_heads,
+                head_dim,
+                blocks_per_head,
+                weight_scale.shape,
+            )
+        elif dim1 > out_dim and dim1 % out_dim == 0:
+            # Model layout [in, kv_padded_out] — tile scale
+            kv_replicas = dim1 // out_dim
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = dim1
+        elif dim0 > out_dim and dim0 % out_dim == 0:
+            # HF layout [kv_padded_out, in] — transpose and tile scale
+            kv_replicas = dim0 // out_dim
+            weight_q = jnp.transpose(weight_q)
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = weight_q.shape[1]
+        else:
+            raise ValueError(
+                f"Cannot match weight_q shape {weight_q.shape} with scale out_dim={out_dim}"
+            )
+
+        in_dim = weight_q.shape[0]
+        block_k = in_dim // in_blocks
+        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
+        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
+        return weight_bf16
+
+    def dequant_fp8_layers(
+        self,
+        layers: list,
+        specs: list[tuple[str, int | None]],
+        *,
+        layer_filter=None,
+    ):
+        """Dequantize specified QuantizedLinear projections → bf16 LinearBase.
+
+        Args:
+            layers: model.layers list.
+            specs: list of (dotted_path, head_dim) tuples, e.g.
+                [("self_attn.q_proj", 192), ("self_attn.v_proj", 128)].
+            layer_filter: optional callable(layer_idx, layer) -> bool.
+        """
+        from sgl_jax.srt.layers.linear import QuantizedLinear
+
+        for layer_idx, layer in enumerate(layers):
+            if layer_filter is not None and not layer_filter(layer_idx, layer):
+                continue
+            for proj_path, hd in specs:
+                parts = proj_path.split(".")
+                parent = layer
+                for p in parts[:-1]:
+                    parent = getattr(parent, p)
+                attr_name = parts[-1]
+                proj = getattr(parent, attr_name)
+                if isinstance(proj, QuantizedLinear):
+                    setattr(parent, attr_name, self.dequant_fp8_linear(proj, head_dim=hd))
+                    logger.info("Dequantized layer %d %s -> bf16", layer_idx, proj_path)
+
+        logger.info("FP8 -> BF16 dequantization complete.")
+
+    def replicate_kv_heads(
+        self,
+        layers: list,
+        specs: list[tuple[str, int]],
+        target_kv_heads_fn,
+    ):
+        """Replicate KV heads for TP alignment.
+
+        Args:
+            layers: model.layers list.
+            specs: list of (dotted_path, head_dim) tuples, e.g.
+                [("self_attn.k_proj", 192), ("self_attn.v_proj", 128)].
+            target_kv_heads_fn: callable(attn_module) -> int, returns expected
+                TP-aligned KV head count.
+        """
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
+        for layer_idx, layer in enumerate(layers):
+            attn = layer.self_attn
+            target_kv_heads = target_kv_heads_fn(attn)
+
+            for proj_path, hd in specs:
+                parts = proj_path.split(".")
+                parent = layer
+                for p in parts[:-1]:
+                    parent = getattr(parent, p)
+                attr_name = parts[-1]
+                proj = getattr(parent, attr_name)
+                w = proj.weight.value
+                expected_size = target_kv_heads * hd
+                actual_size = w.shape[1]
+
+                if actual_size == expected_size:
+                    continue
+
+                if actual_size > 0 and expected_size % actual_size == 0:
+                    num_replicas = expected_size // actual_size
+                    orig_kv = actual_size // hd
+
+                    logger.info(
+                        "KV head replication: layer %d %s %d->%d heads (%d->%d)",
+                        layer_idx,
+                        proj_path,
+                        orig_kv,
+                        target_kv_heads,
+                        actual_size,
+                        expected_size,
+                    )
+
+                    w_full = jax.device_put(w, NamedSharding(self.mesh, P()))
+                    w_3d = w_full.reshape(w.shape[0], orig_kv, hd)
+                    w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
+                    w_new = w_rep.reshape(w.shape[0], expected_size)
+                    w_new = jax.device_put(w_new, NamedSharding(self.mesh, P(None, "tensor")))
+
+                    setattr(
+                        parent,
+                        attr_name,
+                        self.create_bf16_linear(w_new, proj.kernel_axes, self.mesh),
+                    )
 
     def _normalize_physical_to_logical_map(
         self,

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2,6 +2,7 @@ import copy
 import glob
 import json
 import logging
+import math
 import os
 import pickle
 import re
@@ -402,6 +403,204 @@ class WeightLoader:
                         attr_name,
                         self.create_bf16_linear(w_new, proj.kernel_axes, self.mesh),
                     )
+
+    def dequant_fused_qkv(
+        self,
+        fused_qkv_buffers: dict[int, dict],
+        layers: list,
+        config,
+    ):
+        """Dequantize per-shard-interleaved fused QKV FP8 weights.
+
+        The FP8 checkpoint was quantized per-TP-shard and concatenated:
+          weight: [shard0_QKV | shard1_QKV | ... | shardN_QKV], shape [total_qkv, hidden]
+          scale:  [shard0_scale | shard1_scale | ... | shardN_scale], shape [total_blocks, in_blocks]
+
+        Each shard's QKV dim may not be a multiple of block_size, so scale blocks
+        within a shard can span K/V boundaries. We must dequantize per-shard first,
+        then extract Q/K/V from each shard.
+
+        Args:
+            fused_qkv_buffers: dict mapping layer_idx -> {"weight": ..., "scale": ...}
+            layers: model.layers list
+            config: model config with head_dim, v_head_dim, num_attention_heads, etc.
+        """
+        if not fused_qkv_buffers:
+            return
+
+        from jax.sharding import NamedSharding
+
+        head_dim = config.head_dim
+        v_head_dim = getattr(config, "v_head_dim", head_dim)
+        num_heads = config.num_attention_heads
+        num_kv_heads = config.num_key_value_heads
+
+        quant_cfg = getattr(config, "quantization_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        for layer_idx in sorted(fused_qkv_buffers.keys()):
+            buf = fused_qkv_buffers[layer_idx]
+            fused_weight = buf["weight"]  # [total_qkv, hidden], FP8, HF layout
+            fused_scale = buf["scale"]  # [total_blocks, in_blocks], f32
+
+            in_dim = fused_weight.shape[1]  # hidden_size
+
+            # Infer n_shards: find TP size where per-shard blocking matches scale shape
+            n_shards, orig_kv_heads = self._infer_qkv_shards(
+                fused_weight.shape[0],
+                fused_scale.shape[0],
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                v_head_dim,
+                block_size,
+            )
+
+            per_shard_q = (num_heads // n_shards) * head_dim
+            per_shard_k = (orig_kv_heads // n_shards) * head_dim
+            per_shard_v = (orig_kv_heads // n_shards) * v_head_dim
+            per_shard_total = per_shard_q + per_shard_k + per_shard_v
+            per_shard_blocks = math.ceil(per_shard_total / block_size)
+            padded_rows = per_shard_blocks * block_size
+            in_blocks = in_dim // block_size
+
+            if layer_idx % 10 == 0:
+                logger.info(
+                    "Layer %d: dequant fused QKV FP8, n_shards=%d, "
+                    "per_shard=%d (Q=%d K=%d V=%d), blocks=%d",
+                    layer_idx,
+                    n_shards,
+                    per_shard_total,
+                    per_shard_q,
+                    per_shard_k,
+                    per_shard_v,
+                    per_shard_blocks,
+                )
+
+            q_parts, k_parts, v_parts = [], [], []
+
+            for shard_idx in range(n_shards):
+                # Extract this shard's weight and scale
+                w_start = shard_idx * per_shard_total
+                shard_w = fused_weight[w_start : w_start + per_shard_total, :]
+
+                s_start = shard_idx * per_shard_blocks
+                shard_s = fused_scale[s_start : s_start + per_shard_blocks, :]
+
+                # Pad weight rows to block boundary for dequant
+                if per_shard_total < padded_rows:
+                    shard_w = jnp.pad(shard_w, ((0, padded_rows - per_shard_total), (0, 0)))
+
+                # Block dequantize: [padded_rows, in_dim] × [blocks, in_blocks]
+                shard_f = shard_w.astype(jnp.float32).reshape(
+                    per_shard_blocks, block_size, in_blocks, block_size
+                )
+                shard_s_4d = shard_s[:, None, :, None]
+                shard_bf16 = (
+                    (shard_f * shard_s_4d)
+                    .reshape(padded_rows, in_dim)[:per_shard_total, :]
+                    .astype(jnp.bfloat16)
+                )
+
+                # Split shard into Q, K, V (contiguous within each shard)
+                q_parts.append(shard_bf16[:per_shard_q, :])
+                k_parts.append(shard_bf16[per_shard_q : per_shard_q + per_shard_k, :])
+                v_parts.append(shard_bf16[per_shard_q + per_shard_k :, :])
+
+            # Concatenate across shards → full Q/K/V in HF layout [out, in]
+            q_weight = jnp.concatenate(q_parts, axis=0)
+            k_weight = jnp.concatenate(k_parts, axis=0)
+            v_weight = jnp.concatenate(v_parts, axis=0)
+
+            # Transpose to model layout [in, out] and shard
+            q_weight = jnp.transpose(q_weight)
+            k_weight = jnp.transpose(k_weight)
+            v_weight = jnp.transpose(v_weight)
+
+            tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+            q_weight = jax.device_put(q_weight, tp_sharding)
+            k_weight = jax.device_put(k_weight, tp_sharding)
+            v_weight = jax.device_put(v_weight, tp_sharding)
+
+            # Replace QuantizedLinear with bf16 LinearBase
+            attn = layers[layer_idx].self_attn
+            for proj_name, w in [
+                ("q_proj", q_weight),
+                ("k_proj", k_weight),
+                ("v_proj", v_weight),
+            ]:
+                setattr(
+                    attn,
+                    proj_name,
+                    self.create_bf16_linear(w, (None, "tensor"), self.mesh),
+                )
+
+            if layer_idx == 0:
+                logger.info(
+                    "Layer 0 dequant result: Q=%s K=%s V=%s",
+                    q_weight.shape,
+                    k_weight.shape,
+                    v_weight.shape,
+                )
+
+        # Clean up buffers
+        fused_qkv_buffers.clear()
+        logger.info("Fused QKV FP8 dequantization complete for all layers.")
+
+    @staticmethod
+    def _infer_qkv_shards(
+        total_out_dim: int,
+        total_scale_blocks: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        v_head_dim: int,
+        block_size: int,
+    ) -> tuple[int, int]:
+        """Infer the number of TP shards used during FP8 quantization.
+
+        The config's num_kv_heads may be GQA-replicated (e.g. 32 instead of
+        the original 8), so we also try divisors of num_kv_heads to find the
+        original value used during per-shard quantization.
+
+        Returns (tp_shards, original_num_kv_heads).
+        """
+        # Collect candidate kv_heads values: config value and its divisors
+        kv_candidates = []
+        for d in range(1, num_kv_heads + 1):
+            if num_kv_heads % d == 0:
+                kv_candidates.append(d)
+        # Try config value first, then smaller divisors (descending)
+        kv_candidates = sorted(set(kv_candidates), reverse=True)
+
+        # TP candidates: all divisors of num_heads (covers any quantization-time TP)
+        tp_candidates = sorted(d for d in range(1, num_heads + 1) if num_heads % d == 0)
+
+        for orig_kv in kv_candidates:
+            for tp in tp_candidates:
+                if orig_kv % tp != 0:
+                    continue
+                per_shard = (
+                    (num_heads // tp) * head_dim
+                    + (orig_kv // tp) * head_dim
+                    + (orig_kv // tp) * v_head_dim
+                )
+                per_shard_blocks = math.ceil(per_shard / block_size)
+                if per_shard_blocks * tp == total_scale_blocks and per_shard * tp == total_out_dim:
+                    if orig_kv != num_kv_heads:
+                        logger.info(
+                            "Inferred original num_kv_heads=%d (config has %d), tp=%d",
+                            orig_kv,
+                            num_kv_heads,
+                            tp,
+                        )
+                    return tp, orig_kv
+        raise ValueError(
+            f"Cannot infer QKV shard count: out_dim={total_out_dim}, "
+            f"scale_blocks={total_scale_blocks}, num_heads={num_heads}, "
+            f"num_kv_heads={num_kv_heads}, head_dim={head_dim}, "
+            f"v_head_dim={v_head_dim}, block_size={block_size}"
+        )
 
     def _normalize_physical_to_logical_map(
         self,


### PR DESCRIPTION
## Summary

- Add `MiMoV2ProForCausalLM` for MiMo-V2-Pro inference on TPU (384 experts, 70 layers, FP8)
- Implement per-shard FP8 block dequantization for fused `qkv_proj` weights — the checkpoint was quantized per-TP-shard then concatenated, so scales span K/V boundaries within each shard
- Auto-detect quantization-time TP size and original `num_kv_heads` from weight/scale tensor shapes (`_infer_qkv_shards`)
- Add `attention_value_scale` support for `v_head_dim != head_dim` (Pro uses head_dim=192, v_head_dim=128)
- Optimize MoE weight loading: **defer-transpose** (bulk transpose after assembly) + **bulk_read** (raw byte reads bypassing safetensors API) reduce MoE loading time by ~66% on 384-expert models
- Add `SGLANG_SKIP_GCSFUSE_WARMUP` env var (Pro's ~962GB model exceeds GCSFuse cache, warmup is counterproductive)
- Add `SGLANG_MOE_LOAD_WORKERS` env var for tuning parallel loading threads

## Files changed

| File | Change |
|------|--------|
| `mimo_v2_pro.py` | New — MiMoV2ProForCausalLM with fused QKV FP8 dequant |
| `mimo_v2_flash.py` | attention_value_scale, ndim=2 scale handling, SKIP_GCSFUSE_WARMUP |
| `weight_utils.py` | defer-transpose, bulk_read, v_head_dim QKV split, LOAD_WORKERS |

## Test plan

- [x] Regression tested MiMo-V2-Flash on TPU v7x 2-node (no regressions)
- [x] A/B/C/D experiments isolating optimization contributions on MiMo-V2-Pro 4-node
- [x] Confirmed bulk_read path is safe for Qwen models (only activates for fused MoE backend with unsharded dims)
- [x] Verified GCSFuse warmup skip for Pro (962GB exceeds cache, warmup adds ~60s overhead)

🤖 Generated with [Claude Code](https://claude.com/claude-code)