### PR TITLE
fix(dp): preserve sampler metadata and decode OOM abort

### DIFF
--- a/python/sgl_jax/srt/layers/sampler.py
+++ b/python/sgl_jax/srt/layers/sampler.py
@@ -217,31 +217,48 @@ class Sampler(nnx.Module):
 
 def get_top_logprobs(logprobs: jax.Array, top_logprobs_nums: list[int]):
     max_k = max(top_logprobs_nums)
+    if max_k <= 0:
+        batch_size = len(top_logprobs_nums)
+        return (
+            jnp.zeros((batch_size, 0), dtype=logprobs.dtype),
+            jnp.zeros((batch_size, 0), dtype=jnp.int32),
+        )
     values, indices = jax.lax.top_k(logprobs, max_k)
-
-    output_top_logprobs_val = []
-    output_top_logprobs_idx = []
-    for i, k in enumerate(top_logprobs_nums):
-        output_top_logprobs_val.append(values[i][:k])
-        output_top_logprobs_idx.append(indices[i][:k])
-    return jnp.array(output_top_logprobs_val), jnp.array(output_top_logprobs_idx)
+    return values, indices
 
 
 def get_token_ids_logprobs(logprobs: jax.Array, token_ids_logprobs: list[list[int]], mesh: Mesh):
-    output_token_ids_logprobs_val = []
-    output_token_ids_logprobs_idx = []
-    out_sharding = NamedSharding(mesh, P(None))
-    for i, token_ids in enumerate(token_ids_logprobs):
-        if token_ids is not None:
-            output_token_ids_logprobs_val.append(
-                logprobs.at[i, token_ids].get(out_sharding=out_sharding)
-            )
-            output_token_ids_logprobs_idx.append(token_ids)
-        else:
-            output_token_ids_logprobs_val.append([])
-            output_token_ids_logprobs_idx.append([])
+    normalized_token_ids = [token_ids or [] for token_ids in token_ids_logprobs]
+    max_len = max((len(token_ids) for token_ids in normalized_token_ids), default=0)
+    batch_size = len(normalized_token_ids)
+    if max_len == 0:
+        return (
+            jnp.zeros((batch_size, 0), dtype=logprobs.dtype),
+            jnp.zeros((batch_size, 0), dtype=jnp.int32),
+        )
 
-    return jnp.array(output_token_ids_logprobs_val), jnp.array(output_token_ids_logprobs_idx)
+    padded_token_ids = np.zeros((batch_size, max_len), dtype=np.int32)
+    valid_mask = np.zeros((batch_size, max_len), dtype=bool)
+    for i, token_ids in enumerate(normalized_token_ids):
+        if token_ids:
+            token_ids_len = len(token_ids)
+            padded_token_ids[i, :token_ids_len] = np.asarray(token_ids, dtype=np.int32)
+            valid_mask[i, :token_ids_len] = True
+
+    row_indices = jnp.arange(batch_size, dtype=jnp.int32).reshape(-1, 1)
+    token_ids_device = jnp.asarray(padded_token_ids)
+    out_sharding = NamedSharding(mesh, P(None, None)) if mesh is not None else None
+    values = (
+        logprobs.at[row_indices, token_ids_device].get(out_sharding=out_sharding)
+        if out_sharding is not None
+        else logprobs[row_indices, token_ids_device]
+    )
+    valid_mask_device = jnp.asarray(valid_mask)
+
+    return (
+        jnp.where(valid_mask_device, values, 0.0),
+        jnp.where(valid_mask_device, token_ids_device, 0),
+    )
 
 
 def multinomial(

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1946,11 +1946,13 @@ class ScheduleBatch:
         top_ks = np.ones(total_bs, dtype=np.int32)
         min_ps = np.zeros(total_bs, dtype=np.float32)
         sampling_seeds = None
+        linear_penalty = None
 
         offset_bs = 0
         has_sampling_seeds = False
         vocab_size = 0
         is_all_greedy = True
+        need_min_p_sampling = False
 
         for dp_rank in range(self.dp_size):
             info = self.reqs_info[dp_rank]
@@ -1966,12 +1968,29 @@ class ScheduleBatch:
 
             if not info.sampling_info.is_all_greedy:
                 is_all_greedy = False
+            need_min_p_sampling |= dp_sampling.need_min_p_sampling
 
             # Copy sampling parameters
             temperatures[offset_bs : offset_bs + dp_bs] = dp_sampling.temperatures[:dp_bs]
             top_ps[offset_bs : offset_bs + dp_bs] = dp_sampling.top_ps[:dp_bs]
             top_ks[offset_bs : offset_bs + dp_bs] = dp_sampling.top_ks[:dp_bs]
             min_ps[offset_bs : offset_bs + dp_bs] = dp_sampling.min_ps[:dp_bs]
+
+            dp_linear_penalty = dp_sampling.linear_penalty
+            if (
+                dp_linear_penalty is None
+                and dp_sampling.penalizer_orchestrator
+                and dp_sampling.penalizer_orchestrator.is_required
+            ):
+                dp_linear_penalty = dp_sampling.penalizer_orchestrator.apply()
+
+            if dp_linear_penalty is not None:
+                if linear_penalty is None:
+                    linear_penalty = np.zeros(
+                        (total_bs, dp_linear_penalty.shape[1]),
+                        dtype=dp_linear_penalty.dtype,
+                    )
+                linear_penalty[offset_bs : offset_bs + dp_bs] = dp_linear_penalty[:dp_bs]
 
             if dp_sampling.sampling_seeds is not None:
                 if sampling_seeds is None:
@@ -1989,7 +2008,9 @@ class ScheduleBatch:
             min_ps=min_ps,
             vocab_size=vocab_size,
             is_all_greedy=is_all_greedy,
+            need_min_p_sampling=need_min_p_sampling,
             sampling_seeds=sampling_seeds if has_sampling_seeds else None,
+            linear_penalty=linear_penalty,
             grammars=[req.grammar for req in all_reqs] if self.has_grammar else None,
         )
 
@@ -2721,7 +2742,12 @@ class ModelWorkerSamplingInfo:
         return ret
 
     def update_penalties(self):
-        self.linear_penalty = None
+        if self.linear_penalty is not None:
+            return
+        if self.penalizer_orchestrator and self.penalizer_orchestrator.is_required:
+            self.linear_penalty = self.penalizer_orchestrator.apply()
+        else:
+            self.linear_penalty = None
 
     def update_grammar_vocab_mask(self):
         """Update vocabulary masks from grammars before sampling."""

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -1115,7 +1115,7 @@ class ScheduleBatch:
         self._evict_tree_cache_if_needed(num_tokens_per_dp)
         return self._is_available_size_sufficient(num_tokens_per_dp)
 
-    def retract_decode(self, server_args: ServerArgs):
+    def retract_decode(self, server_args: ServerArgs) -> tuple[list[Req], float, list[Req]]:
         """Retract requests when memory insufficient.
 
         Each DP rank independently:
@@ -1126,6 +1126,7 @@ class ScheduleBatch:
         Returns:
             retracted_reqs: All retracted requests
             new_estimate_ratio: Updated estimate
+            reqs_to_abort: Requests that still cannot fit after retraction
         """
 
         # Helper function: check if memory is sufficient for given DP rank
@@ -1166,6 +1167,7 @@ class ScheduleBatch:
                 return self.token_to_kv_pool_allocator.available_size(dp_rank=dp_rank) >= num_tokens
 
         retracted_reqs = []
+        reqs_to_abort = []
         keep_indices_per_dp = {}
 
         # Process each DP rank independently
@@ -1191,20 +1193,7 @@ class ScheduleBatch:
             first_iter = True
             while not has_sufficient_memory(dp_rank, sorted_indices) or first_iter:
                 if len(sorted_indices) == 1:
-                    # Assert some space available
-                    if self.is_hybrid:
-                        full_avail = self.token_to_kv_pool_allocator.full_available_size(
-                            dp_rank=dp_rank
-                        )
-                        swa_avail = self.token_to_kv_pool_allocator.swa_available_size(
-                            dp_rank=dp_rank
-                        )
-                        assert (
-                            full_avail > 0 and swa_avail > 0
-                        ), f"[DP {dp_rank}] No space for single request (hybrid)"
-                    else:
-                        avail = self.token_to_kv_pool_allocator.available_size(dp_rank=dp_rank)
-                        assert avail > 0, f"[DP {dp_rank}] No space for single request"
+                    # Keep one request long enough to decide whether it should be aborted below.
                     break
 
                 first_iter = False
@@ -1214,6 +1203,23 @@ class ScheduleBatch:
 
                 # Release the request using its local index within this DP rank
                 self.release_req(retract_idx, dp_rank, len(sorted_indices), server_args)
+
+            if len(sorted_indices) == 1 and not has_sufficient_memory(dp_rank, sorted_indices):
+                last_idx = sorted_indices.pop()
+                last_req = info.reqs[last_idx]
+                last_req.to_finish = FINISH_ABORT(
+                    "Out of memory even after retracting all other requests "
+                    "in the decode batch. Aborting the last request.",
+                    HTTPStatus.INTERNAL_SERVER_ERROR,
+                    "InternalServerError",
+                )
+                reqs_to_abort.append(last_req)
+                self.release_req(last_idx, dp_rank, 0, server_args)
+                logger.warning(
+                    "retract_decode: aborted last request %s on DP %d due to OOM",
+                    last_req.rid,
+                    dp_rank,
+                )
 
             keep_indices_per_dp[dp_rank] = sorted_indices
 
@@ -1227,10 +1233,12 @@ class ScheduleBatch:
 
         new_estimate_ratio = (
             total_decoded_tokens + global_config.retract_decode_steps * len(all_reqs)
-        ) / total_max_new_tokens
+        ) / (
+            total_max_new_tokens + 1
+        )  # +1 to avoid zero division when all requests are aborted.
         new_estimate_ratio = min(1.0, new_estimate_ratio)
 
-        return retracted_reqs, new_estimate_ratio
+        return retracted_reqs, new_estimate_ratio, reqs_to_abort
 
     def release_req(self, idx: int, dp_rank: int, remaing_req_count: int, server_args: ServerArgs):
         """Release a request and free its resources.

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1664,13 +1664,22 @@ class Scheduler(
         ):
             old_ratio = self.new_token_ratio
 
-            retracted_reqs, new_token_ratio = batch.retract_decode(self.server_args)
+            retracted_reqs, new_token_ratio, reqs_to_abort = batch.retract_decode(self.server_args)
             num_retracted_reqs = len(retracted_reqs)
             self.new_token_ratio = new_token_ratio
 
+            # Send abort responses so clients get an error instead of a hung connection.
+            for req in reqs_to_abort:
+                abort_out = AbortReq(rid=req.rid)
+                if self._comm_backend is not None:
+                    self._comm_backend.send_pyobj(abort_out)
+                else:
+                    self.send_to_tokenizer.send_pyobj(abort_out)
+
             logger.info(
-                "KV cache pool is full. Retract requests. #retracted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
+                "KV cache pool is full. Retract requests. #retracted_reqs: %d, #aborted_reqs: %d, #new_token_ratio: %.4f -> %.4f",
                 num_retracted_reqs,
+                len(reqs_to_abort),
                 old_ratio,
                 self.new_token_ratio,
             )

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -90,6 +90,7 @@ class SchedulerOutputProcessorMixin:
         per_dp_bs_size = batch.per_dp_bs_size
 
         logprob_pt = 0
+        compact_req_i = 0
 
         for dp_rank in range(batch.dp_size):
             info = batch.reqs_info[dp_rank]
@@ -104,6 +105,9 @@ class SchedulerOutputProcessorMixin:
 
             # Check finish conditions for each request in this DP rank
             for i, (req, next_token_id) in enumerate(zip(reqs, dp_output_ids)):
+                global_i = per_dp_bs_size * dp_rank + i
+                req_compact_i = compact_req_i
+                compact_req_i += 1
                 if req.is_retracted:
                     continue
 
@@ -150,20 +154,22 @@ class SchedulerOutputProcessorMixin:
                         self.tree_cache.cache_unfinished_req(req)
 
                     if req.return_output_logprob_only:
-                        req.output_token_logprobs_val.append(logits_output.next_token_logprobs[i])
+                        req.output_token_logprobs_val.append(
+                            logits_output.next_token_logprobs[global_i]
+                        )
                         req.output_token_logprobs_idx.append(next_token_id)
 
                     if req.return_logprob:
                         assert extend_logprob_start_len_per_req is not None
                         assert extend_input_len_per_req is not None
-                        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
-                        extend_input_len = extend_input_len_per_req[i]
+                        extend_logprob_start_len = extend_logprob_start_len_per_req[req_compact_i]
+                        extend_input_len = extend_input_len_per_req[req_compact_i]
                         num_input_logprobs = extend_input_len - extend_logprob_start_len
                         self.add_logprob_return_values(
-                            i,
+                            global_i,
                             req,
                             logprob_pt,
-                            dp_output_ids,  # Pass current DP rank's output IDs
+                            next_token_ids,
                             num_input_logprobs,
                             logits_output,
                         )
@@ -207,13 +213,13 @@ class SchedulerOutputProcessorMixin:
 
                     # Incrementally update input logprobs.
                     if req.return_logprob:
-                        extend_logprob_start_len = extend_logprob_start_len_per_req[i]
-                        extend_input_len = extend_input_len_per_req[i]
+                        extend_logprob_start_len = extend_logprob_start_len_per_req[req_compact_i]
+                        extend_input_len = extend_input_len_per_req[req_compact_i]
                         if extend_logprob_start_len < extend_input_len:
                             # Update input logprobs.
                             num_input_logprobs = extend_input_len - extend_logprob_start_len
                             self.add_input_logprob_return_values(
-                                i,
+                                global_i,
                                 req,
                                 logits_output,
                                 logprob_pt,
@@ -321,6 +327,7 @@ class SchedulerOutputProcessorMixin:
 
             # Check finish condition for each request in this DP rank
             for i, (req, next_token_id) in enumerate(zip(reqs, dp_output_ids)):
+                global_i = per_dp_bs_size * dp_rank + i
                 req: Req
                 if req.is_retracted:
                     continue
@@ -387,28 +394,37 @@ class SchedulerOutputProcessorMixin:
                     self.tree_cache.cache_finished_req(req)
 
                 if req.return_output_logprob_only:
-                    req.output_token_logprobs_val.append(next_token_logprobs[i])  # TODO @Brian fix
+                    req.output_token_logprobs_val.append(next_token_logprobs[global_i])
                     req.output_token_logprobs_idx.append(next_token_id)
 
                 if req.return_logprob and (
                     batch.spec_algorithm is None or batch.spec_algorithm.is_none()
                 ):
                     # speculative worker handles logprob in speculative decoding
-                    req.output_token_logprobs_val.append(next_token_logprobs[i])
+                    req.output_token_logprobs_val.append(next_token_logprobs[global_i])
                     req.output_token_logprobs_idx.append(next_token_id)
                     if req.top_logprobs_num > 0:
                         req.output_top_logprobs_val.append(
-                            logits_output.next_token_top_logprobs_val[i]
+                            logits_output.next_token_top_logprobs_val[global_i][
+                                : req.top_logprobs_num
+                            ]
                         )
                         req.output_top_logprobs_idx.append(
-                            logits_output.next_token_top_logprobs_idx[i]
+                            logits_output.next_token_top_logprobs_idx[global_i][
+                                : req.top_logprobs_num
+                            ]
                         )
                     if req.token_ids_logprob is not None:
+                        num_token_ids_logprob = len(req.token_ids_logprob)
                         req.output_token_ids_logprobs_val.append(
-                            logits_output.next_token_token_ids_logprobs_val[i]
+                            logits_output.next_token_token_ids_logprobs_val[global_i][
+                                :num_token_ids_logprob
+                            ]
                         )
                         req.output_token_ids_logprobs_idx.append(
-                            logits_output.next_token_token_ids_logprobs_idx[i]
+                            logits_output.next_token_token_ids_logprobs_idx[global_i][
+                                :num_token_ids_logprob
+                            ]
                         )
 
                 # Update grammar state after token sampling
@@ -428,7 +444,7 @@ class SchedulerOutputProcessorMixin:
                         self.abort_request(AbortReq(rid=req.rid))
                     req.grammar.finished = req.finished()
                 if req.return_hidden_states and logits_output.hidden_states is not None:
-                    req.hidden_states.append(logits_output.hidden_states[i])
+                    req.hidden_states.append(logits_output.hidden_states[global_i])
 
         # Collect all requests from all DP ranks for stream output
         all_reqs = []
@@ -597,12 +613,21 @@ class SchedulerOutputProcessorMixin:
         )
 
         if req.top_logprobs_num > 0:
-            req.output_top_logprobs_val.append(output.next_token_top_logprobs_val[i])
-            req.output_top_logprobs_idx.append(output.next_token_top_logprobs_idx[i])
+            req.output_top_logprobs_val.append(
+                output.next_token_top_logprobs_val[i][: req.top_logprobs_num]
+            )
+            req.output_top_logprobs_idx.append(
+                output.next_token_top_logprobs_idx[i][: req.top_logprobs_num]
+            )
 
         if req.token_ids_logprob is not None:
-            req.output_token_ids_logprobs_val.append(output.next_token_token_ids_logprobs_val[i])
-            req.output_token_ids_logprobs_idx.append(output.next_token_token_ids_logprobs_idx[i])
+            num_token_ids_logprob = len(req.token_ids_logprob)
+            req.output_token_ids_logprobs_val.append(
+                output.next_token_token_ids_logprobs_val[i][:num_token_ids_logprob]
+            )
+            req.output_token_ids_logprobs_idx.append(
+                output.next_token_token_ids_logprobs_idx[i][:num_token_ids_logprob]
+            )
 
         return num_input_logprobs
 

--- a/python/sgl_jax/test/test_dp_sampler_regressions.py
+++ b/python/sgl_jax/test/test_dp_sampler_regressions.py
@@ -3,6 +3,7 @@ import importlib.util
 import sys
 import types
 import unittest
+from http import HTTPStatus
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -25,12 +26,23 @@ if importlib.util.find_spec("pybase64") is None:
     pybase64_stub.b64decode = base64.b64decode
     sys.modules["pybase64"] = pybase64_stub
 
+if importlib.util.find_spec("pathwaysutils") is None:
+    sys.modules["pathwaysutils"] = types.ModuleType("pathwaysutils")
+
+if importlib.util.find_spec("setproctitle") is None:
+    setproctitle_stub = types.ModuleType("setproctitle")
+    setproctitle_stub.setproctitle = lambda *args, **kwargs: None
+    sys.modules["setproctitle"] = setproctitle_stub
+
 from sgl_jax.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
+from sgl_jax.srt.managers.io_struct import AbortReq
 from sgl_jax.srt.managers.schedule_batch import (
+    FINISH_ABORT,
     ModelWorkerSamplingInfo,
     ScheduleBatch,
     ScheduleReqsInfo,
 )
+from sgl_jax.srt.managers.scheduler import Scheduler
 from sgl_jax.srt.managers.scheduler_output_processor_mixin import (
     SchedulerOutputProcessorMixin,
 )
@@ -189,6 +201,96 @@ class TestDPSamplerRegressions(unittest.TestCase):
         sampling_info.update_penalties()
 
         np.testing.assert_array_equal(sampling_info.linear_penalty, linear_penalty)
+
+    def test_retract_decode_aborts_single_oom_request(self):
+        req = SimpleNamespace(
+            rid="oom-request",
+            output_ids=[7],
+            origin_input_ids=[1, 2, 3],
+            sampling_params=SimpleNamespace(max_new_tokens=4),
+            to_finish=None,
+        )
+        allocator = SimpleNamespace(
+            page_size=1,
+            available_size=lambda dp_rank=0: 0,
+        )
+        batch = ScheduleBatch(
+            dp_size=1,
+            reqs_info=[
+                ScheduleReqsInfo(
+                    reqs=[req],
+                    seq_lens=np.array([3], dtype=np.int32),
+                )
+            ],
+            token_to_kv_pool_allocator=allocator,
+            tree_cache=None,
+            is_hybrid=False,
+        )
+        released = []
+
+        def release_req(idx, dp_rank, remaining_req_count, server_args):
+            released.append((idx, dp_rank, remaining_req_count))
+
+        batch.release_req = release_req
+
+        retracted, new_ratio, aborted = batch.retract_decode(SimpleNamespace(page_size=1))
+
+        self.assertEqual(retracted, [])
+        self.assertEqual(aborted, [req])
+        self.assertIsInstance(req.to_finish, FINISH_ABORT)
+        self.assertEqual(req.to_finish.status_code, HTTPStatus.INTERNAL_SERVER_ERROR)
+        self.assertEqual(req.to_finish.err_type, "InternalServerError")
+        self.assertEqual(released, [(0, 0, 0)])
+        self.assertEqual(batch.batch_size(), 0)
+        self.assertEqual(new_ratio, 0.0)
+
+    def test_scheduler_update_running_batch_sends_abort_req(self):
+        req = SimpleNamespace(rid="oom-request")
+
+        class FakeBatch:
+            def __init__(self):
+                self.prepared = False
+
+            def batch_size(self):
+                return 1
+
+            def filter_batch(self):
+                return None
+
+            def is_empty(self):
+                return False
+
+            def check_decode_mem(self, buf_multiplier):
+                return False
+
+            def retract_decode(self, server_args):
+                return [], 0.25, [req]
+
+            def prepare_for_decode(self):
+                self.prepared = True
+
+        sender = SimpleNamespace(send_pyobj=MagicMock())
+        scheduler = SimpleNamespace(
+            decode_mem_cache_buf_multiplier=1,
+            new_token_ratio=0.75,
+            server_args=SimpleNamespace(),
+            _comm_backend=None,
+            send_to_tokenizer=sender,
+            _extend_requests_to_queue=MagicMock(),
+            new_token_ratio_decay=0.1,
+            min_new_token_ratio=0.1,
+        )
+        batch = FakeBatch()
+
+        result = Scheduler.update_running_batch(scheduler, batch)
+
+        self.assertIs(result, batch)
+        self.assertTrue(batch.prepared)
+        self.assertEqual(scheduler.new_token_ratio, 0.25)
+        scheduler._extend_requests_to_queue.assert_called_once_with([], is_retracted=True)
+        abort_out = sender.send_pyobj.call_args.args[0]
+        self.assertIsInstance(abort_out, AbortReq)
+        self.assertEqual(abort_out.rid, "oom-request")
 
     def test_get_top_logprobs_handles_padding_rows(self):
         logprobs = jnp.array(

--- a/python/sgl_jax/test/test_dp_sampler_regressions.py
+++ b/python/sgl_jax/test/test_dp_sampler_regressions.py
@@ -1,0 +1,431 @@
+import base64
+import importlib.util
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh
+
+if importlib.util.find_spec("llguidance") is None:
+    llguidance_stub = types.ModuleType("llguidance")
+    llguidance_stub.LLMatcher = object
+    llguidance_stub.LLInterpreter = object
+    llguidance_stub.LLTokenizer = object
+    llguidance_stub.StructTag = object
+    llguidance_stub.grammar_from = lambda *args, **kwargs: None
+    sys.modules["llguidance"] = llguidance_stub
+
+if importlib.util.find_spec("pybase64") is None:
+    pybase64_stub = types.ModuleType("pybase64")
+    pybase64_stub.b64decode = base64.b64decode
+    sys.modules["pybase64"] = pybase64_stub
+
+from sgl_jax.srt.layers.sampler import get_token_ids_logprobs, get_top_logprobs
+from sgl_jax.srt.managers.schedule_batch import (
+    ModelWorkerSamplingInfo,
+    ScheduleBatch,
+    ScheduleReqsInfo,
+)
+from sgl_jax.srt.managers.scheduler_output_processor_mixin import (
+    SchedulerOutputProcessorMixin,
+)
+from sgl_jax.srt.sampling.sampling_batch_info import SamplingBatchInfo
+
+
+class TestDPSamplerRegressions(unittest.TestCase):
+    def _sampling_info(
+        self,
+        *,
+        batch_size: int,
+        need_min_p_sampling: bool = False,
+        min_p: float = 0.0,
+        vocab_size: int = 16,
+        linear_penalty: np.ndarray | None = None,
+    ) -> SamplingBatchInfo:
+        return SamplingBatchInfo(
+            temperatures=np.ones((batch_size, 1), dtype=np.float32),
+            top_ps=np.ones(batch_size, dtype=np.float32),
+            top_ks=np.ones(batch_size, dtype=np.int32),
+            min_ps=np.full(batch_size, min_p, dtype=np.float32),
+            vocab_size=vocab_size,
+            is_all_greedy=False,
+            need_min_p_sampling=need_min_p_sampling,
+            linear_penalty=linear_penalty,
+        )
+
+    def test_merge_sampling_info_preserves_min_p_flag(self):
+        batch = ScheduleBatch(
+            dp_size=2,
+            has_grammar=False,
+            reqs_info=[
+                ScheduleReqsInfo(
+                    reqs=[],
+                    seq_lens=np.array([], dtype=np.int32),
+                    sampling_info=None,
+                ),
+                ScheduleReqsInfo(
+                    reqs=[],
+                    seq_lens=np.array([3], dtype=np.int32),
+                    sampling_info=self._sampling_info(
+                        batch_size=1,
+                        need_min_p_sampling=True,
+                        min_p=0.2,
+                    ),
+                ),
+            ],
+        )
+
+        merged = batch._merge_sampling_info(per_dp_bs_size=2, total_bs=4)
+
+        self.assertTrue(merged.need_min_p_sampling)
+        np.testing.assert_array_equal(
+            merged.min_ps,
+            np.array([0.0, 0.0, 0.2, 0.0], dtype=np.float32),
+        )
+
+    def test_merge_sampling_info_preserves_linear_penalty_layout(self):
+        batch = ScheduleBatch(
+            dp_size=2,
+            has_grammar=False,
+            reqs_info=[
+                ScheduleReqsInfo(
+                    reqs=[],
+                    seq_lens=np.array([3, 2], dtype=np.int32),
+                    sampling_info=self._sampling_info(
+                        batch_size=2,
+                        vocab_size=3,
+                        linear_penalty=np.array(
+                            [
+                                [-1.0, 0.0, 0.0],
+                                [0.0, -2.0, 0.0],
+                            ],
+                            dtype=np.float32,
+                        ),
+                    ),
+                ),
+                ScheduleReqsInfo(
+                    reqs=[],
+                    seq_lens=np.array([4], dtype=np.int32),
+                    sampling_info=self._sampling_info(
+                        batch_size=1,
+                        vocab_size=3,
+                        linear_penalty=np.array([[0.0, 0.0, -3.0]], dtype=np.float32),
+                    ),
+                ),
+            ],
+        )
+
+        merged = batch._merge_sampling_info(per_dp_bs_size=3, total_bs=6)
+
+        expected = np.array(
+            [
+                [-1.0, 0.0, 0.0],
+                [0.0, -2.0, 0.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, -3.0],
+                [0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0],
+            ],
+            dtype=np.float32,
+        )
+        np.testing.assert_array_equal(merged.linear_penalty, expected)
+
+    def test_merge_sampling_info_materializes_penalty_orchestrator(self):
+        class FakePenalizerOrchestrator:
+            is_required = True
+
+            def apply(self):
+                return np.array([[0.0, -4.0, 0.0]], dtype=np.float32)
+
+        batch = ScheduleBatch(
+            dp_size=1,
+            has_grammar=False,
+            reqs_info=[
+                ScheduleReqsInfo(
+                    reqs=[],
+                    seq_lens=np.array([3], dtype=np.int32),
+                    sampling_info=SamplingBatchInfo(
+                        temperatures=np.ones((1, 1), dtype=np.float32),
+                        top_ps=np.ones(1, dtype=np.float32),
+                        top_ks=np.ones(1, dtype=np.int32),
+                        min_ps=np.zeros(1, dtype=np.float32),
+                        vocab_size=3,
+                        is_all_greedy=False,
+                        penalizer_orchestrator=FakePenalizerOrchestrator(),
+                    ),
+                ),
+            ],
+        )
+
+        merged = batch._merge_sampling_info(per_dp_bs_size=2, total_bs=2)
+
+        np.testing.assert_array_equal(
+            merged.linear_penalty,
+            np.array(
+                [
+                    [0.0, -4.0, 0.0],
+                    [0.0, 0.0, 0.0],
+                ],
+                dtype=np.float32,
+            ),
+        )
+
+    def test_model_worker_sampling_info_update_penalties_preserves_linear_penalty(self):
+        linear_penalty = np.array([[-1.0, 0.0, 0.0]], dtype=np.float32)
+        sampling_info = ModelWorkerSamplingInfo(
+            temperatures=np.ones((1, 1), dtype=np.float32),
+            top_ps=np.ones(1, dtype=np.float32),
+            top_ks=np.ones(1, dtype=np.int32),
+            min_ps=np.zeros(1, dtype=np.float32),
+            vocab_size=3,
+            linear_penalty=linear_penalty,
+        )
+
+        sampling_info.update_penalties()
+
+        np.testing.assert_array_equal(sampling_info.linear_penalty, linear_penalty)
+
+    def test_get_top_logprobs_handles_padding_rows(self):
+        logprobs = jnp.array(
+            [
+                [0.1, 0.9, 0.2],
+                [0.3, 0.4, 0.5],
+            ],
+            dtype=jnp.float32,
+        )
+
+        values, indices = get_top_logprobs(logprobs, [2, 0])
+
+        self.assertEqual(values.shape, (2, 2))
+        self.assertEqual(indices.shape, (2, 2))
+        np.testing.assert_allclose(np.asarray(values[0]), np.array([0.9, 0.2], dtype=np.float32))
+        np.testing.assert_array_equal(np.asarray(indices[0]), np.array([1, 2], dtype=np.int32))
+
+    def test_get_token_ids_logprobs_handles_padding_rows(self):
+        logprobs = jnp.array(
+            [
+                [0.0, 0.1, 0.2, 0.3],
+                [0.4, 0.5, 0.6, 0.7],
+                [0.8, 0.9, 1.0, 1.1],
+            ],
+            dtype=jnp.float32,
+        )
+        mesh = Mesh(np.array(jax.devices()[:1]), ("data",))
+
+        values, indices = get_token_ids_logprobs(logprobs, [[1, 3], None, [0]], mesh)
+
+        self.assertEqual(values.shape, (3, 2))
+        self.assertEqual(indices.shape, (3, 2))
+        np.testing.assert_allclose(
+            np.asarray(values),
+            np.array(
+                [
+                    [0.1, 0.3],
+                    [0.0, 0.0],
+                    [0.8, 0.0],
+                ],
+                dtype=np.float32,
+            ),
+        )
+        np.testing.assert_array_equal(
+            np.asarray(indices),
+            np.array(
+                [
+                    [1, 3],
+                    [0, 0],
+                    [0, 0],
+                ],
+                dtype=np.int32,
+            ),
+        )
+
+    def test_decode_logprob_uses_padded_dp_row_index(self):
+        class FakeReq:
+            def __init__(self):
+                self.is_retracted = False
+                self.output_ids = []
+                self.return_output_logprob_only = False
+                self.return_logprob = True
+                self.output_token_logprobs_val = []
+                self.output_token_logprobs_idx = []
+                self.output_top_logprobs_val = []
+                self.output_top_logprobs_idx = []
+                self.output_token_ids_logprobs_val = []
+                self.output_token_ids_logprobs_idx = []
+                self.top_logprobs_num = 1
+                self.token_ids_logprob = [1]
+                self.grammar = None
+                self.return_hidden_states = False
+
+            def check_finished(self, new_accepted_len=1):
+                return None
+
+            def finished(self):
+                return False
+
+        req = FakeReq()
+        batch = SimpleNamespace(
+            dp_size=2,
+            per_dp_bs_size=2,
+            return_logprob=True,
+            return_output_logprob_only=False,
+            spec_algorithm=None,
+            cache_miss_count=0,
+            reqs_info=[
+                ScheduleReqsInfo(reqs=[]),
+                ScheduleReqsInfo(reqs=[req]),
+            ],
+            batch_size=lambda: 1,
+        )
+        result = SimpleNamespace(
+            bid=3,
+            next_token_ids=[0, 0, 42, 0],
+            cache_miss_count=0,
+            logits_output=SimpleNamespace(
+                next_token_logprobs=jnp.array([0.1, 0.0, 0.7, 0.0], dtype=jnp.float32),
+                next_token_top_logprobs_val=np.array(
+                    [[1.0], [0.0], [7.0], [0.0]], dtype=np.float32
+                ),
+                next_token_top_logprobs_idx=np.array([[10], [0], [70], [0]], dtype=np.int32),
+                next_token_token_ids_logprobs_val=np.array(
+                    [[1.1], [0.0], [7.7], [0.0]], dtype=np.float32
+                ),
+                next_token_token_ids_logprobs_idx=np.array([[11], [0], [77], [0]], dtype=np.int32),
+                hidden_states=None,
+            ),
+        )
+        scheduler = SimpleNamespace(
+            spec_algorithm=None,
+            num_generated_tokens=0,
+            enable_overlap=False,
+            token_to_kv_pool_allocator=MagicMock(),
+            tree_cache=MagicMock(),
+            forward_ct_decode=0,
+            server_args=SimpleNamespace(decode_log_interval=100),
+            set_next_batch_sampling_info_done=lambda batch: None,
+            stream_output=lambda *args, **kwargs: None,
+            log_decode_stats=lambda *args, **kwargs: None,
+        )
+
+        SchedulerOutputProcessorMixin.process_batch_result_decode(scheduler, batch, result)
+
+        np.testing.assert_allclose(req.output_token_logprobs_val, [0.7])
+        self.assertEqual(req.output_token_logprobs_idx, [42])
+        np.testing.assert_allclose(req.output_top_logprobs_val[0], np.array([7.0]))
+        np.testing.assert_array_equal(req.output_top_logprobs_idx[0], np.array([70]))
+        np.testing.assert_allclose(req.output_token_ids_logprobs_val[0], np.array([7.7]))
+        np.testing.assert_array_equal(req.output_token_ids_logprobs_idx[0], np.array([77]))
+
+    def test_prefill_logprob_uses_padded_dp_row_index(self):
+        class FakeReq:
+            def __init__(self):
+                self.is_retracted = False
+                self.is_chunked = 0
+                self.output_ids = []
+                self.origin_input_ids = [5]
+                self.logprob_start_len = 0
+                self.return_output_logprob_only = False
+                self.return_logprob = True
+                self.output_token_logprobs_val = []
+                self.output_token_logprobs_idx = []
+                self.output_top_logprobs_val = []
+                self.output_top_logprobs_idx = []
+                self.output_token_ids_logprobs_val = []
+                self.output_token_ids_logprobs_idx = []
+                self.input_token_logprobs = []
+                self.input_token_logprobs_val = None
+                self.input_token_logprobs_idx = None
+                self.input_top_logprobs_val = None
+                self.input_top_logprobs_idx = None
+                self.input_token_ids_logprobs_val = None
+                self.input_token_ids_logprobs_idx = None
+                self.temp_input_top_logprobs_val = None
+                self.temp_input_top_logprobs_idx = None
+                self.temp_input_token_ids_logprobs_val = None
+                self.temp_input_token_ids_logprobs_idx = None
+                self.top_logprobs_num = 1
+                self.token_ids_logprob = [1]
+                self.grammar = None
+                self.return_hidden_states = False
+
+            def check_finished(self, new_accepted_len=1):
+                return None
+
+            def finished(self):
+                return False
+
+        req = FakeReq()
+        batch = SimpleNamespace(
+            dp_size=2,
+            per_dp_bs_size=2,
+            return_logprob=True,
+            return_output_logprob_only=False,
+            spec_algorithm=None,
+            cache_miss_count=0,
+            reqs_info=[
+                ScheduleReqsInfo(reqs=[]),
+                ScheduleReqsInfo(reqs=[req], decoding_reqs=[]),
+            ],
+        )
+        result = SimpleNamespace(
+            bid=4,
+            next_token_ids=[0, 0, 42, 0],
+            extend_input_len_per_req=[1],
+            extend_logprob_start_len_per_req=[0],
+            cache_miss_count=0,
+            next_draft_input=None,
+            logits_output=SimpleNamespace(
+                next_token_logprobs=np.array([0.1, 0.0, 0.7, 0.0], dtype=np.float32),
+                next_token_top_logprobs_val=np.array(
+                    [[1.0], [0.0], [7.0], [0.0]], dtype=np.float32
+                ),
+                next_token_top_logprobs_idx=np.array([[10], [0], [70], [0]], dtype=np.int32),
+                next_token_token_ids_logprobs_val=np.array(
+                    [[1.1], [0.0], [7.7], [0.0]], dtype=np.float32
+                ),
+                next_token_token_ids_logprobs_idx=np.array([[11], [0], [77], [0]], dtype=np.int32),
+                input_token_logprobs=np.array([0.55], dtype=np.float32),
+                input_top_logprobs_val=np.array(
+                    [[["row0"]], [["pad1"]], [["row2"]], [["pad3"]]], dtype=object
+                ),
+                input_top_logprobs_idx=np.array([[[10]], [[0]], [[70]], [[0]]], dtype=object),
+                input_token_ids_logprobs_val=np.array(
+                    [[["tid0"]], [["pad1"]], [["tid2"]], [["pad3"]]], dtype=object
+                ),
+                input_token_ids_logprobs_idx=np.array([[[11]], [[0]], [[77]], [[0]]], dtype=object),
+                hidden_states=None,
+            ),
+        )
+
+        class FakeScheduler(SchedulerOutputProcessorMixin):
+            pass
+
+        scheduler = FakeScheduler()
+        scheduler.is_generation = True
+        scheduler.enable_overlap = False
+        scheduler.is_mixed_chunk = False
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.tree_cache = MagicMock()
+        scheduler.model_config = SimpleNamespace(vocab_size=100)
+        scheduler.set_next_batch_sampling_info_done = lambda batch: None
+        scheduler.stream_output = lambda *args, **kwargs: None
+
+        SchedulerOutputProcessorMixin.process_batch_result_prefill(scheduler, batch, result)
+
+        np.testing.assert_allclose(req.output_token_logprobs_val, [0.7])
+        self.assertEqual(req.output_token_logprobs_idx, [42])
+        np.testing.assert_array_equal(req.output_top_logprobs_val[0], np.array([7.0]))
+        np.testing.assert_array_equal(req.output_top_logprobs_idx[0], np.array([70]))
+        np.testing.assert_allclose(req.output_token_ids_logprobs_val[0], np.array([7.7]))
+        np.testing.assert_array_equal(req.output_token_ids_logprobs_idx[0], np.array([77]))
+        self.assertEqual(req.temp_input_top_logprobs_val, None)
+        self.assertEqual(req.input_top_logprobs_val, [None])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Preserve sampler metadata (logprobs, token IDs) across DP worker reduction so it survives the `scheduler_output_processor_mixin` path.
- Preserve the decode OOM abort signal so retract paths trigger consistently across DP workers.
- Add `python/sgl_jax/test/test_dp_sampler_regressions.py` with 10 regressions covering both fixes (logprob padding, abort propagation, sampling-info merge invariants).

## Test plan
- [x] `pytest python/sgl_jax/test/test_dp_sampler_regressions.py -v` on TPU v6e-4: **10 passed in 10.56s**

## Notes
First in a stack of 5 PRs decomposing `fix/dp-attn-jimoosciuc`. Subsequent PRs depend on the schedule_batch.py and test_dp_sampler_regressions.py changes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)