### PR TITLE
fix(mem_cache): eliminate KV cache double-free via release_kv_cache single entry point

### DIFF
--- a/docs/superpowers/plans/2026-04-27-kv-over-alloc-tracking.md
+++ b/docs/superpowers/plans/2026-04-27-kv-over-alloc-tracking.md
@@ -1,0 +1,712 @@
+# KV Cache Over-Allocation Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the structural KV double-free in sgl-jax that triggers `token_to_kv_pool_allocator memory leak detected!` on every plain `engine.async_generate` call. Port upstream sglang's `kv_committed_len` / `kv_allocated_len` tracking + single `release_kv_cache` entry point.
+
+**Architecture:** Each `Req` tracks how many KV slots are committed vs. allocated. All finished-req KV release goes through one `release_kv_cache(req, tree_cache)` function in `mem_cache/common.py`. The two ad-hoc `out_cache_loc[i:i+1]` frees in `scheduler_output_processor_mixin.py` (the actual double-free source) are deleted. EAGLE/abort/retract paths are out of scope.
+
+**Tech Stack:** Python, JAX, sgl-jax (worktree at `.claude/worktrees/fix-radix-cache`, branch `worktree-fix-radix-cache`).
+
+**Spec:** `docs/superpowers/specs/2026-04-27-kv-over-alloc-tracking-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Change type |
+|---|---|---|
+| `python/sgl_jax/srt/managers/schedule_batch.py` | `Req` data model + batch lifecycle (extend/decode/retract) | 5 new fields, 2 new methods, 4 maintenance hooks |
+| `python/sgl_jax/srt/mem_cache/common.py` | Allocator helpers | Add `release_kv_cache` function |
+| `python/sgl_jax/srt/mem_cache/radix_cache.py` | Radix tree KV cache | Refactor `cache_finished_req` to use new fields, fix page-tail double free, stop freeing `req_to_token_pool` slot |
+| `python/sgl_jax/srt/mem_cache/chunk_cache.py` | Disabled-radix KV cache | Refactor `cache_finished_req` to use new fields, stop freeing `req_to_token_pool` slot |
+| `python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py` | Per-step batch result handling | Delete 2 ad-hoc free blocks, replace 2 `cache_finished_req` calls with `release_kv_cache` |
+
+---
+
+## Task 1: Add 5 new fields and 2 pop methods to `Req`
+
+**Files:**
+- Modify: `python/sgl_jax/srt/managers/schedule_batch.py:251` (add fields after `last_matched_prefix_len`)
+- Modify: `python/sgl_jax/srt/managers/schedule_batch.py:~410` (add pop methods after `init_next_round_input` block, before `check_finished`)
+
+- [ ] **Step 1.1: Add 5 fields in `Req.__init__`**
+
+In `python/sgl_jax/srt/managers/schedule_batch.py`, find:
+
+```python
+        # The prefix length of the last prefix matching
+        self.last_matched_prefix_len: int = 0
+```
+
+Add immediately after:
+
+```python
+        # KV cache lifecycle tracking (matches upstream sglang Req fields).
+        # committed_len: number of tokens whose KV is safe to commit to radix evictable.
+        # allocated_len: number of token slots currently allocated for this req.
+        # cache_protected_len: prefix length locked into radix at prefill start; not freed by cache_finished_req.
+        # *_freed flags guard against double pop_*_kv_cache calls.
+        self.kv_committed_len: int = 0
+        self.kv_allocated_len: int = 0
+        self.cache_protected_len: int = 0
+        self.kv_committed_freed: bool = False
+        self.kv_overallocated_freed: bool = False
+```
+
+- [ ] **Step 1.2: Add `pop_committed_kv_cache` and `pop_overallocated_kv_cache`**
+
+Find the end of `init_next_round_input` (around line 387, ends with `self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)`). Insert these two methods before `def adjust_max_prefix_ids` (around line 389):
+
+```python
+    def pop_committed_kv_cache(self) -> int:
+        """Return committed KV length and mark as released. Single use per finished req."""
+        assert (
+            not self.kv_committed_freed
+        ), f"double pop_committed_kv_cache for req {self.rid}"
+        self.kv_committed_freed = True
+        return self.kv_committed_len
+
+    def pop_overallocated_kv_cache(self) -> tuple[int, int]:
+        """Return [committed_len, allocated_len) over-alloc range. Single use per finished req."""
+        assert (
+            not self.kv_overallocated_freed
+        ), f"double pop_overallocated_kv_cache for req {self.rid}"
+        self.kv_overallocated_freed = True
+        return self.kv_committed_len, self.kv_allocated_len
+```
+
+- [ ] **Step 1.3: Run a syntax / import sanity check**
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+python -c "from sgl_jax.srt.managers.schedule_batch import Req; r = Req('rid', 'p', [1,2,3], None); print(r.kv_committed_len, r.kv_allocated_len, r.cache_protected_len, r.kv_committed_freed, r.kv_overallocated_freed)"
+```
+
+Expected: `0 0 0 False False`
+
+- [ ] **Step 1.4: Verify pop methods**
+
+```bash
+python -c "
+from sgl_jax.srt.managers.schedule_batch import Req
+r = Req('rid', 'p', [1,2,3], None)
+r.kv_committed_len = 10
+r.kv_allocated_len = 12
+print('committed:', r.pop_committed_kv_cache())
+print('over:', r.pop_overallocated_kv_cache())
+try:
+    r.pop_committed_kv_cache()
+    print('FAIL: double-pop should have asserted')
+except AssertionError as e:
+    print('OK assertion:', e)
+"
+```
+
+Expected: `committed: 10`, `over: (10, 12)`, `OK assertion: double pop_committed_kv_cache for req rid`
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add python/sgl_jax/srt/managers/schedule_batch.py
+git commit -m "feat(req): add kv_committed_len/kv_allocated_len tracking fields and pop methods"
+```
+
+---
+
+## Task 2: Maintain new fields in extend / decode / retract / init_next_round_input
+
+**Files:**
+- Modify: `python/sgl_jax/srt/managers/schedule_batch.py:386-387` (init_next_round_input — set `cache_protected_len`)
+- Modify: `python/sgl_jax/srt/managers/schedule_batch.py:501-519` (`reset_for_retract` — reset 5 fields)
+- Modify: `python/sgl_jax/srt/managers/schedule_batch.py:851` (`prepare_for_extend` — set committed/allocated to seq_len)
+- Modify: `python/sgl_jax/srt/managers/schedule_batch.py:1151-1153` (`prepare_for_decode` — increment committed/allocated)
+
+- [ ] **Step 2.1: Set `cache_protected_len` in `init_next_round_input`**
+
+Find lines 385-387:
+
+```python
+            self.last_matched_prefix_len = len(self.prefix_indices)
+        self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
+```
+
+Change to:
+
+```python
+            self.last_matched_prefix_len = len(self.prefix_indices)
+        self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
+        # cache_protected_len is the prefix range already in radix (locked); cache_finished_req
+        # must NOT free this range, since dec_lock_ref handles that side.
+        self.cache_protected_len = len(self.prefix_indices)
+```
+
+- [ ] **Step 2.2: Reset 5 fields in `reset_for_retract`**
+
+Find lines 501-519. The current method ends with:
+
+```python
+        self.extend_batch_idx = 0
+        self.decode_batch_idx = 0
+```
+
+Add immediately after:
+
+```python
+        self.kv_committed_len = 0
+        self.kv_allocated_len = 0
+        self.cache_protected_len = 0
+        self.kv_committed_freed = False
+        self.kv_overallocated_freed = False
+```
+
+- [ ] **Step 2.3: Set committed/allocated in `prepare_for_extend`**
+
+Find line 851 (inside the `for i, (req, seq_len, pre_len) in enumerate(zip(...))` loop):
+
+```python
+            req.cached_tokens += pre_len - req.already_computed
+            req.already_computed = seq_len
+            req.is_retracted = False
+            req.extend_batch_idx += 1
+```
+
+Change to:
+
+```python
+            req.cached_tokens += pre_len - req.already_computed
+            req.already_computed = seq_len
+            req.is_retracted = False
+            req.extend_batch_idx += 1
+            # After prefill, all `seq_len` tokens have committed KV and are allocated.
+            req.kv_committed_len = seq_len
+            req.kv_allocated_len = seq_len
+```
+
+- [ ] **Step 2.4: Increment committed/allocated in `prepare_for_decode`**
+
+Find lines 1151-1153:
+
+```python
+        for req in self.reqs:
+            req.decode_batch_idx += 1
+```
+
+Change to:
+
+```python
+        for req in self.reqs:
+            req.decode_batch_idx += 1
+            req.kv_committed_len += 1
+            req.kv_allocated_len += 1
+```
+
+(Note: this loop is NOT reached for `spec_algorithm.is_eagle()` due to early return at line 1109. EAGLE keeps its own ad-hoc free path — out of scope.)
+
+- [ ] **Step 2.5: Sanity test — fields propagate through prefill+decode**
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+python -c "
+from sgl_jax.srt.managers.schedule_batch import Req
+r = Req('rid', 'p', [1,2,3], None)
+# simulate post-extend
+r.kv_committed_len = 13
+r.kv_allocated_len = 13
+# simulate 5 decode steps
+for _ in range(5):
+    r.kv_committed_len += 1
+    r.kv_allocated_len += 1
+assert r.kv_committed_len == 18 and r.kv_allocated_len == 18, (r.kv_committed_len, r.kv_allocated_len)
+# simulate retract
+r.reset_for_retract()
+assert r.kv_committed_len == 0 and r.kv_allocated_len == 0 and not r.kv_committed_freed
+print('OK')
+"
+```
+
+Expected: `OK`
+
+- [ ] **Step 2.6: Commit**
+
+```bash
+git add python/sgl_jax/srt/managers/schedule_batch.py
+git commit -m "feat(req): maintain kv_committed_len/kv_allocated_len across extend/decode/retract"
+```
+
+---
+
+## Task 3: Add `release_kv_cache` to `mem_cache/common.py`
+
+**Files:**
+- Modify: `python/sgl_jax/srt/mem_cache/common.py` (append at end)
+
+- [ ] **Step 3.1: Add the function**
+
+Open `python/sgl_jax/srt/mem_cache/common.py`. The file currently ends with `available_and_evictable_str` around line 102. Append at the end of the file:
+
+```python
+
+
+def release_kv_cache(req, tree_cache, is_insert: bool = True) -> None:
+    """Single entry point for releasing all KV cache held by a finished req.
+
+    Replaces scattered `tree_cache.cache_finished_req(req)` + ad-hoc
+    `out_cache_loc[i:i+1]` frees that previously caused double-frees.
+
+    Steps:
+      1. Delegate committed-range free to the tree cache's cache_finished_req.
+      2. Free over-allocated range [committed_len, allocated_len) (page-aligned).
+      3. Free the req_to_token_pool slot.
+
+    Args:
+        req: the finished Req.
+        tree_cache: a RadixCache, ChunkCache, or compatible BasePrefixCache.
+        is_insert: kept for upstream-API compatibility; unused in sgl-jax today.
+    """
+    from sgl_jax.srt.utils.common_utils import cdiv
+
+    if req.req_pool_idx is None:
+        # Already released (e.g., retract path, or streaming session early-free).
+        return
+
+    # Step 1: free committed KV via tree cache (radix evictable insert OR direct free).
+    tree_cache.cache_finished_req(req)
+    if req.req_pool_idx is None:
+        return
+
+    # Step 2: free over-allocated KV in [start_p, end_p).
+    start_p, end_p = req.pop_overallocated_kv_cache()
+    page_size = tree_cache.page_size
+    if page_size > 1:
+        # Align start_p UP to next page boundary; the partial page before start_p
+        # is part of the committed range and was handled by cache_finished_req.
+        start_p = cdiv(start_p, page_size) * page_size
+
+    if start_p < end_p:
+        indices = tree_cache.req_to_token_pool.req_to_token[
+            req.req_pool_idx, start_p:end_p
+        ]
+        # Filter zeros (uninitialized slots); same defensive pattern as cache_finished_req.
+        indices = indices[indices != 0]
+        if indices.size > 0:
+            tree_cache.token_to_kv_pool_allocator.free(indices)
+
+    # Step 3: release the req_to_token_pool slot.
+    tree_cache.req_to_token_pool.free(req.req_pool_idx)
+```
+
+- [ ] **Step 3.2: Sanity import check**
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+python -c "from sgl_jax.srt.mem_cache.common import release_kv_cache; print(release_kv_cache.__doc__.split(chr(10))[0])"
+```
+
+Expected: `Single entry point for releasing all KV cache held by a finished req.`
+
+- [ ] **Step 3.3: Commit**
+
+```bash
+git add python/sgl_jax/srt/mem_cache/common.py
+git commit -m "feat(mem_cache): add release_kv_cache as single KV release entry point"
+```
+
+---
+
+## Task 4: Refactor `RadixCache.cache_finished_req`
+
+**Files:**
+- Modify: `python/sgl_jax/srt/mem_cache/radix_cache.py:257-303`
+
+This task fixes 4 things at once:
+- Use `req.pop_committed_kv_cache()` (not the `len(input)+max(len(output)-1,0)` formula)
+- Use `req.cache_protected_len` (not `len(req.prefix_indices)`)
+- Stop calling `req_to_token_pool.free` (handed off to `release_kv_cache`)
+- Fix the existing page-tail double-free (line 280 + line 299 both freeing `kv_indices[page_aligned_len:]` when `page_size > 1`)
+
+- [ ] **Step 4.1: Replace the entire method**
+
+Find the current `cache_finished_req` at `python/sgl_jax/srt/mem_cache/radix_cache.py:257-303`:
+
+```python
+    def cache_finished_req(self, req: Req):
+        """Cache completed requests"""
+        all_token_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+        if self.disable:
+            kv_indices = self.req_to_token_pool.read(
+                req.req_pool_idx,
+                all_token_len,
+            )
+            kv_indices = kv_indices[kv_indices != 0]
+            self.token_to_kv_pool_allocator.free(kv_indices)
+            self.req_to_token_pool.free(req.req_pool_idx)
+            return
+
+        token_ids = (req.origin_input_ids + req.output_ids)[:all_token_len]
+        # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
+        # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
+        actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
+        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, all_token_len)
+        kv_indices = kv_indices[kv_indices != 0]
+
+        if self.page_size != 1:
+            page_aligned_len = actual_kv_len // self.page_size * self.page_size
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+            self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
+        else:
+            page_aligned_len = actual_kv_len
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+
+        page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
+        old_prefix_len = len(req.prefix_indices)
+        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
+            # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
+            # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
+            old_prefix_len -= 1
+
+        # Radix Cache takes over one reference from memory pool
+        new_prefix_len = self.insert(
+            RadixKey(token_ids[:page_aligned_token_len], req.extra_key), page_aligned_kv_indices
+        )
+
+        self.token_to_kv_pool_allocator.free(kv_indices[old_prefix_len:new_prefix_len])
+        # free the unaligned tail
+        self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
+
+        # Remove request slot and release cache lock
+        self.req_to_token_pool.free(req.req_pool_idx)
+        self.dec_lock_ref(req.last_node)
+```
+
+Replace with:
+
+```python
+    def cache_finished_req(self, req: Req):
+        """Cache completed requests.
+
+        Frees the committed KV range [cache_protected_len, committed_len). Does NOT
+        free the req_to_token_pool slot — that's owned by release_kv_cache.
+        """
+        committed_len = req.pop_committed_kv_cache()
+        if self.disable:
+            kv_indices = self.req_to_token_pool.read(
+                req.req_pool_idx,
+                committed_len,
+            )
+            kv_indices = kv_indices[kv_indices != 0]
+            self.token_to_kv_pool_allocator.free(kv_indices)
+            return
+
+        token_ids = (req.origin_input_ids + req.output_ids)[:committed_len]
+        # For EAGLE radix cache, the key is bigram, so kv length is -1.
+        actual_kv_len = committed_len - 1 if self.is_eagle else committed_len
+        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, committed_len)
+        kv_indices = kv_indices[kv_indices != 0]
+
+        if self.page_size != 1:
+            page_aligned_len = actual_kv_len // self.page_size * self.page_size
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+            # NOTE: the page-tail free for kv_indices[page_aligned_len:] is done
+            # unconditionally below (after radix insert). Do NOT free it here too —
+            # that was the historical double-free (page>1 + radix on amplifies x page_size).
+        else:
+            page_aligned_len = actual_kv_len
+            page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
+
+        page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
+        old_prefix_len = req.cache_protected_len
+        if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
+            # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
+            # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
+            old_prefix_len -= 1
+
+        # Radix Cache takes over one reference from memory pool
+        new_prefix_len = self.insert(
+            RadixKey(token_ids[:page_aligned_token_len], req.extra_key), page_aligned_kv_indices
+        )
+
+        self.token_to_kv_pool_allocator.free(kv_indices[old_prefix_len:new_prefix_len])
+        # free the unaligned tail (single source — see NOTE above)
+        self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
+
+        # Release cache lock. req_to_token_pool slot is freed by release_kv_cache.
+        self.dec_lock_ref(req.last_node)
+```
+
+- [ ] **Step 4.2: Sanity import**
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+python -c "from sgl_jax.srt.mem_cache.radix_cache import RadixCache; print('ok')"
+```
+
+Expected: `ok`
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add python/sgl_jax/srt/mem_cache/radix_cache.py
+git commit -m "fix(radix_cache): use pop_committed_kv_cache + cache_protected_len, fix page-tail double free
+
+- Replace indirect committed-length formula with req.pop_committed_kv_cache()
+- Replace len(req.prefix_indices) with req.cache_protected_len (stable)
+- Remove duplicate page-tail free (line 280 was duplicated by line 299)
+- Stop freeing req_to_token_pool slot (now owned by release_kv_cache)"
+```
+
+---
+
+## Task 5: Refactor `ChunkCache.cache_finished_req`
+
+**Files:**
+- Modify: `python/sgl_jax/srt/mem_cache/chunk_cache.py:36-43`
+
+- [ ] **Step 5.1: Replace the method**
+
+Find:
+
+```python
+    def cache_finished_req(self, req: Req):
+        kv_indices = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx,
+            : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
+        ]
+        self.req_to_token_pool.free(req.req_pool_idx)
+        self.token_to_kv_pool_allocator.free(kv_indices)
+```
+
+Replace with:
+
+```python
+    def cache_finished_req(self, req: Req):
+        committed_len = req.pop_committed_kv_cache()
+        kv_indices = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx,
+            :committed_len,
+        ]
+        # req_to_token_pool slot is freed by release_kv_cache.
+        self.token_to_kv_pool_allocator.free(kv_indices)
+```
+
+- [ ] **Step 5.2: Sanity import**
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+python -c "from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache; print('ok')"
+```
+
+Expected: `ok`
+
+- [ ] **Step 5.3: Commit**
+
+```bash
+git add python/sgl_jax/srt/mem_cache/chunk_cache.py
+git commit -m "fix(chunk_cache): use pop_committed_kv_cache, defer req_pool free to release_kv_cache"
+```
+
+---
+
+## Task 6: Replace mixin's scattered free calls with `release_kv_cache`
+
+**Files:**
+- Modify: `python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py` (4 changes + 1 import)
+
+- [ ] **Step 6.1: Add import**
+
+At the top of `python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py`, find the imports block. Add (alphabetically appropriate place near other `mem_cache` imports if any, otherwise near other `sgl_jax.srt` imports):
+
+```python
+from sgl_jax.srt.mem_cache.common import release_kv_cache
+```
+
+- [ ] **Step 6.2: Delete prefill overlap ad-hoc free (lines 98-101)**
+
+Find:
+
+```python
+            if self.is_mixed_chunk and self.enable_overlap and req.finished():
+                j = len(batch.out_cache_loc) - len(batch.reqs) + i
+                self.token_to_kv_pool_allocator.free(batch.out_cache_loc[j : j + 1])
+                continue
+```
+
+**Delete this entire 4-line block.** Reasoning: the over-alloc tracking now records that this 1 extra slot was allocated (via `kv_allocated_len += 1` at decode step before this finish was detected; for prefill mixed-chunk the slot is part of `out_cache_loc` which is implicit in `seq_len` allocated). The slot will be freed by `release_kv_cache`'s over-alloc step.
+
+- [ ] **Step 6.3: Replace prefill `cache_finished_req` call (line 125)**
+
+Find:
+
+```python
+                    self.tree_cache.cache_finished_req(req)
+```
+
+(Inside the `if req.finished():` branch at line 108-125.)
+
+Replace with:
+
+```python
+                    release_kv_cache(req, self.tree_cache)
+```
+
+- [ ] **Step 6.4: Delete decode overlap ad-hoc free (lines 284-293)**
+
+Find:
+
+```python
+            indices_to_free = None
+            if self.enable_overlap and req.finished():
+                if self.page_size == 1:
+                    indices_to_free = batch.out_cache_loc[i : i + 1]
+                else:
+                    if (len(req.origin_input_ids) + len(req.output_ids) - 1) % self.page_size == 0:
+                        indices_to_free = batch.out_cache_loc[i : i + 1]
+                if indices_to_free is not None:
+                    self.token_to_kv_pool_allocator.free(indices_to_free)
+                continue
+```
+
+**Delete this entire block.** Reasoning: same as 6.2 — over-alloc tracking + `release_kv_cache` handles the extra slot.
+
+- [ ] **Step 6.5: Replace decode `cache_finished_req` call (line 338)**
+
+Find:
+
+```python
+                self.tree_cache.cache_finished_req(req)
+```
+
+(Inside the decode `if req.finished():` branch, after the EAGLE block at lines 305-321.)
+
+Replace with:
+
+```python
+                release_kv_cache(req, self.tree_cache)
+```
+
+- [ ] **Step 6.6: Sanity import**
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+python -c "from sgl_jax.srt.managers.scheduler_output_processor_mixin import SchedulerOutputProcessorMixin; print('ok')" 2>&1 | tail -3
+```
+
+Expected: `ok` (or, if the class name differs, just no ImportError — `python -c "import sgl_jax.srt.managers.scheduler_output_processor_mixin"` is the fallback check).
+
+- [ ] **Step 6.7: Commit**
+
+```bash
+git add python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+git commit -m "fix(scheduler): route finished-req KV release through single release_kv_cache entry point
+
+Removes the two ad-hoc out_cache_loc[i:i+1] frees in overlap+finished branches
+that were the source of the structural double-free. Over-allocated slots are now
+tracked via Req.kv_allocated_len > kv_committed_len and freed inside release_kv_cache."
+```
+
+---
+
+## Task 7: End-to-end verification on brian-deepseek-test pod
+
+**Files:** none modified — verification only.
+
+The verification environment is the GKE TPU pod `brian-deepseek-test` (v6e 2x2). The 4-config matrix from the spec must all pass.
+
+- [ ] **Step 7.1: Sync code to the pod**
+
+Check if there is a sync script (likely `gke-tpu` skill helper or a project script):
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+ls gke.toml 2>/dev/null && echo "gke.toml present" || echo "no gke.toml"
+```
+
+If `gke.toml` is present, use the `gke-tpu` skill to sync; otherwise sync via whatever script the project uses (e.g. `scripts/sync.sh`, `rsync ...`). Defer the exact sync command to the operator.
+
+- [ ] **Step 7.2: Run config 1 — page_size=1, radix on (default)**
+
+On the pod (or via `gke-tpu` exec):
+
+```bash
+cd /path/to/sgl-jax/on/pod
+python -m pytest test/srt/test_engine_determine_generation.py::TestEngineDetermineGeneration::test_1 -v --tb=short 2>&1 | tee /tmp/leak-test-page1-radix-on.log
+```
+
+Pass criteria: test exits 0, no `token_to_kv_pool_allocator memory leak detected!` in the log.
+
+If the test does not accept page_size / radix as command-line args, run a minimal repro script (write a small `repro.py` that calls `sgl_jax.Engine(model_path=..., page_size=1)` then `engine.async_generate(prompt, sampling_params={"max_new_tokens": 200})` and checks `engine.tokenizer_manager.scheduler` for memory check assertions). The check that fires is `scheduler.py:1060-1089`.
+
+- [ ] **Step 7.3: Run config 2 — page_size=1, radix off**
+
+```bash
+python -m pytest test/srt/test_engine_determine_generation.py::TestEngineDetermineGeneration::test_1 -v --tb=short 2>&1 | tee /tmp/leak-test-page1-radix-off.log
+```
+
+(With `--disable-radix-cache` arg or env var; check the test's launcher to pass it through. If the test fixture doesn't expose it, write the minimal repro script and pass `disable_radix_cache=True` to `Engine(...)`.)
+
+Pass criteria: same as 7.2.
+
+- [ ] **Step 7.4: Run config 3 — page_size=4, radix on**
+
+```bash
+# (with page_size=4 set)
+python -m pytest test/srt/test_engine_determine_generation.py::TestEngineDetermineGeneration::test_1 -v --tb=short 2>&1 | tee /tmp/leak-test-page4-radix-on.log
+```
+
+Pass criteria: same. **This is the highest-value config — it had +4 leak before, hardest to fool.**
+
+- [ ] **Step 7.5: Run config 4 — page_size=4, radix off**
+
+```bash
+python -m pytest test/srt/test_engine_determine_generation.py::TestEngineDetermineGeneration::test_1 -v --tb=short 2>&1 | tee /tmp/leak-test-page4-radix-off.log
+```
+
+Pass criteria: same.
+
+- [ ] **Step 7.6: Spot-check no functional regression**
+
+Run one happy-path engine test with default settings:
+
+```bash
+python -m pytest test/srt/test_srt_engine.py -v --tb=short -k "smoke or basic" 2>&1 | tail -20
+```
+
+Pass criteria: any matching tests still pass. Record any unrelated failures separately (do not block merge on them unless caused by this change — diff against main if uncertain).
+
+- [ ] **Step 7.7: Final commit (only if any cleanup done) + push**
+
+If verification surfaced bugs, fix them in NEW commits (not amend) and re-run the failing config(s). When all 4 configs green:
+
+```bash
+git log --oneline merge/dp..HEAD   # confirm 6 clean commits
+git push prim worktree-fix-radix-cache   # respect the "only push to prim" rule
+```
+
+(Do not open PR yet — hand back to user for manual sanity / PR description draft.)
+
+---
+
+## Verification summary
+
+| Step | Config | Pre-fix | Post-fix expected |
+|---|---|---|---|
+| 7.2 | page=1, radix on  | LEAK +1 | NO_LEAK |
+| 7.3 | page=1, radix off | LEAK +1 | NO_LEAK |
+| 7.4 | page=4, radix on  | LEAK +4 | NO_LEAK |
+| 7.5 | page=4, radix off | NO_LEAK (masked) | NO_LEAK |
+| 7.6 | smoke tests       | pass | pass |
+
+If any of 7.2-7.5 still leaks, the most likely culprits in priority order:
+1. `cache_protected_len` set wrong (check `init_next_round_input` change in Task 2.1)
+2. Forgotten increment site (e.g., chunked prefill resumes prefill instead of decoding — check if there's a `prepare_for_continued_extend`)
+3. `release_kv_cache` over-alloc range zero-filtering hides a real slot (re-add a print of `start_p, end_p, indices` before the free in `common.py`)
+
+---
+
+## Out of scope (do NOT touch in this PR)
+
+- EAGLE finished free path (`scheduler_output_processor_mixin.py:305-321`)
+- Abort path bugs (handled in sibling worktree)
+- Retract path (`schedule_batch.py:1038-1071`) — already correct, just gets the new fields reset by Task 2.2
+- `cache_unfinished_req` — not on the leak path; same indirect formula but doesn't free `req_to_token_pool`
+- SWA radix cache — same family of issues but separate test surface; defer

--- a/docs/superpowers/specs/2026-04-27-kv-over-alloc-tracking-design.md
+++ b/docs/superpowers/specs/2026-04-27-kv-over-alloc-tracking-design.md
@@ -1,0 +1,211 @@
+# Design Spec: KV Cache Over-Allocation Tracking (sgl-jax)
+
+**Date:** 2026-04-27
+**Branch:** `worktree-fix-radix-cache` (worktree of `merge/dp`)
+**Final spec destination:** `docs/superpowers/specs/2026-04-27-kv-over-alloc-tracking-design.md` (move + commit after plan approval)
+
+---
+
+## Context
+
+`test/srt/test_engine_determine_generation.py` (introduced by PR #515) fails on `merge/dp` with `token_to_kv_pool_allocator memory leak detected!`. Root cause is **not** the abort/retract path — even a single `engine.async_generate` with no abort triggers the same hard assertion.
+
+**Diagnosis (verified via 4-config matrix on Qwen3-8B + tp=4 + chunked_prefill=4 + single 13-token prompt + max_new_tokens=200, brian-deepseek-test pod v6e 2x2):**
+
+| Config | Result | over-count |
+|---|---|---|
+| page=4 + radix on  | LEAK    | +4 |
+| page=4 + radix off | NO_LEAK | 0  |
+| page=1 + radix on  | LEAK    | +1 |
+| page=1 + radix off | LEAK    | +1 |
+
+A fixed 1-slot double-free; `PagedAllocator.setdiff1d` defense masks it for `page=4 + radix off`; `page=4 + radix on` amplifies to +4 because the page-granularity formula multiplies the leaked sub-page slot by `page_size`.
+
+**The double-free is structural:** sgl-jax has KV release scattered across multiple paths:
+1. `RadixCache.cache_finished_req` (`mem_cache/radix_cache.py:257-303`) infers committed length via `len(input) + max(len(output) - 1, 0)`, frees that range.
+2. `process_batch_result_decode` (`scheduler_output_processor_mixin.py:284-293`) ad-hoc frees `out_cache_loc[i:i+1]` in the overlap+finished branch, then `continue`s.
+
+The decode-step-N slot is included in BOTH paths → freed twice → allocator's `available + evict + protected` exceeds `max_total_num_tokens` → `scheduler.py:1060-1089` raises.
+
+**Upstream sglang fix pattern:** `kv_committed_len` / `kv_allocated_len` fields on `Req` + a single `release_kv_cache(req, tree_cache)` entry point that orchestrates `cache_finished_req` → over-alloc range free → `req_to_token_pool.free`. sgl-jax has none of this.
+
+**Intended outcome:** All 4 (page_size, radix on/off) baseline configurations of `test_engine_determine_generation.py::test_1` pass with no leak. PR #515's abort/retract path is a separate bug being fixed in another worktree; this spec covers only the baseline KV leak.
+
+---
+
+## Approach
+
+Port upstream's `kv_committed_len` / `kv_allocated_len` tracking model and `release_kv_cache` single entry point, adapted for sgl-jax. Scope: **minimal** — fix only the baseline 4-config leak. EAGLE finished free path (`mixin:305-321`) and abort/retract paths are out of scope.
+
+### Architecture changes
+
+```
+Before:                           After:
+─────────                         ──────
+mixin.prefill finished:           mixin.prefill finished:
+  cache_finished_req(req)           release_kv_cache(req, tree_cache)
+                                      ├─ tree_cache.cache_finished_req(req)
+mixin.decode finished:                │    └─ frees committed KV [protected, committed)
+  cache_finished_req(req)             ├─ pop_overallocated_kv_cache → (start_p, end_p)
+                                      ├─ frees over-alloc KV [start_p, end_p)
+mixin.prefill overlap:                └─ req_to_token_pool.free(req.req_pool_idx)
+  free out_cache_loc[j:j+1]
+  continue                          mixin.prefill overlap: REMOVED
+                                    mixin.decode overlap:  REMOVED
+mixin.decode overlap:               (over-alloc tracked by kv_allocated_len > kv_committed_len,
+  free out_cache_loc[i:i+1]          freed via release_kv_cache)
+  continue
+```
+
+### Components
+
+**1. `Req` class — 5 new fields** (`python/sgl_jax/srt/managers/schedule_batch.py`, ~line 312):
+```python
+self.kv_committed_len: int = 0
+self.kv_allocated_len: int = 0
+self.cache_protected_len: int = 0
+self.kv_committed_freed: bool = False
+self.kv_overallocated_freed: bool = False
+```
+
+**2. `Req` — 2 new pop methods** (after existing methods, ~line 500):
+```python
+def pop_committed_kv_cache(self) -> int:
+    assert not self.kv_committed_freed, "double pop_committed_kv_cache"
+    self.kv_committed_freed = True
+    return self.kv_committed_len
+
+def pop_overallocated_kv_cache(self) -> Tuple[int, int]:
+    assert not self.kv_overallocated_freed, "double pop_overallocated_kv_cache"
+    self.kv_overallocated_freed = True
+    return self.kv_committed_len, self.kv_allocated_len
+```
+
+**3. Field maintenance** (4 hook points):
+- `prepare_for_extend` (~`schedule_batch.py:851`): `req.kv_committed_len = seq_len; req.kv_allocated_len = seq_len` after the existing `req.already_computed = seq_len`
+- `prepare_for_decode` (~`schedule_batch.py:1152`): in the `for req in self.reqs` loop, `req.kv_committed_len += 1; req.kv_allocated_len += 1`
+- `reset_for_retract` (`schedule_batch.py:501-519`): reset all 5 fields to `0` / `False`
+- `init_next_round_input` equivalent — see §Open question below
+
+**4. New `release_kv_cache` function** (`python/sgl_jax/srt/mem_cache/common.py`, append after `available_and_evictable_str`):
+```python
+def release_kv_cache(req: Req, tree_cache, is_insert: bool = True) -> None:
+    """Single entry point for releasing all KV cache held by a finished req."""
+    if req.req_pool_idx is None:
+        return  # already freed (e.g., retract path)
+
+    # Step 1: commit + free committed KV via tree cache
+    tree_cache.cache_finished_req(req)
+    if req.req_pool_idx is None:
+        return
+
+    # Step 2: free over-allocated KV range [start_p, end_p)
+    start_p, end_p = req.pop_overallocated_kv_cache()
+    page_size = tree_cache.page_size
+    if page_size > 1:
+        start_p = ceil_align(start_p, page_size)
+    if start_p < end_p:
+        indices = tree_cache.req_to_token_pool.req_to_token[
+            req.req_pool_idx, start_p:end_p
+        ]
+        indices = indices[indices != 0]
+        tree_cache.token_to_kv_pool_allocator.free(indices)
+
+    # Step 3: release req_to_token slot
+    tree_cache.req_to_token_pool.free(req.req_pool_idx)
+```
+
+(`is_insert` accepted for upstream-compat; threaded through to `cache_finished_req` if/when needed — currently sgl-jax `cache_finished_req` doesn't take it; leave as no-op param for now.)
+
+**5. `RadixCache.cache_finished_req`** (`python/sgl_jax/srt/mem_cache/radix_cache.py:257-303`) — 4 changes:
+- Replace line 259 (`all_token_len = ...`) with `committed_len = req.pop_committed_kv_cache()`; use `committed_len` everywhere `all_token_len` appears
+- Replace `old_prefix_len = len(req.prefix_indices)` (line 286) with `old_prefix_len = req.cache_protected_len`
+- Remove `self.req_to_token_pool.free(req.req_pool_idx)` (line 302) — handed off to `release_kv_cache`
+- **Fix existing page-tail double-free bug:** lines 280 + 299 both free `kv_indices[page_aligned_len:]` when `page_size > 1`. Remove the line-280 free; keep line-299 (which runs unconditionally). Sanity-check: when `page_size == 1`, `page_aligned_len == actual_kv_len == len(kv_indices)`, so line-299 frees an empty slice — fine.
+
+**6. `ChunkCache.cache_finished_req`** (`python/sgl_jax/srt/mem_cache/chunk_cache.py:36-43`) — 2 changes:
+- Replace `len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)` with `req.pop_committed_kv_cache()`
+- Remove `self.req_to_token_pool.free(req.req_pool_idx)` — handed off to `release_kv_cache`
+
+**7. `scheduler_output_processor_mixin.py`** — 4 changes:
+- Line 125: `self.tree_cache.cache_finished_req(req)` → `release_kv_cache(req, self.tree_cache)`
+- Line 338: same substitution
+- Lines 98-101: **delete** entire prefill-overlap-finished ad-hoc free block (over-alloc now tracked & freed via `release_kv_cache`)
+- Lines 284-293: **delete** entire decode-overlap-finished ad-hoc free block (same reason)
+- Add `from sgl_jax.srt.mem_cache.common import release_kv_cache` import
+
+**8. EAGLE finished free** (`scheduler_output_processor_mixin.py:305-321`) — **NOT touched** in this spec. EAGLE allocates `cur_allocate_len > all_token_len` and frees the diff inline before `cache_finished_req`. Once `release_kv_cache` is in, this path will free the EAGLE over-alloc, then `release_kv_cache` will free committed + (now-zero) over-alloc + req_pool. As long as EAGLE doesn't update `kv_allocated_len`, `pop_overallocated_kv_cache` returns `(committed_len, committed_len)` → empty range → no-op. This is correct but means EAGLE keeps its ad-hoc pattern; migrating it is a future PR.
+
+### Critical files to modify
+
+| File | Lines (approx) | Change |
+|---|---|---|
+| `python/sgl_jax/srt/managers/schedule_batch.py` | 312, 501-519, ~840-851, ~1140-1153, +new methods | 5 fields, reset, set in extend, increment in decode, 2 pop methods, `cache_protected_len` set point |
+| `python/sgl_jax/srt/mem_cache/common.py` | append at end | new `release_kv_cache` |
+| `python/sgl_jax/srt/mem_cache/radix_cache.py` | 257-303 | use `pop_committed_kv_cache`, use `cache_protected_len`, remove `req_to_token_pool.free`, fix page-tail double free |
+| `python/sgl_jax/srt/mem_cache/chunk_cache.py` | 36-43 | use `pop_committed_kv_cache`, remove `req_to_token_pool.free` |
+| `python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py` | 98-101 (delete), 125, 284-293 (delete), 338, +import | 2 delete blocks, 2 call replacements |
+
+### Reused existing utilities
+
+- `ReqToTokenPool.free` (`memory_pool.py:133-138`) — accepts `int` or `list[int]`; we pass `req.req_pool_idx` (int).
+- `TokenToKVPoolAllocator.free` / `PagedTokenToKVPoolAllocator.free` (`allocator.py:116-123`, `316-332`) — already handle empty slice and grouped frees correctly.
+- `free_group_begin`/`free_group_end` (`mixin:274/386`) — `release_kv_cache` runs inside this group; all internal `free` calls go to the group buffer. **Do not** add nested `free_group_begin/end` in `release_kv_cache`.
+- `ceil_align` — needs to exist somewhere in sgl-jax; if not, write inline as `((x + page_size - 1) // page_size) * page_size`.
+
+---
+
+## Open question (must resolve before coding)
+
+**Where to set `req.cache_protected_len`?**
+
+Upstream sets it in `Req.init_next_round_input` (`schedule_batch.py:1038-1041`) after prefix matching. sgl-jax does prefix matching in `Scheduler.add_request` and possibly in `cache_unfinished_req`. The protected length is `len(req.prefix_indices)` at the moment prefill begins.
+
+Resolution plan (during writing-plans phase):
+1. `grep -rn "prefix_indices = " python/sgl_jax/srt/` to find all assignment sites.
+2. Identify the LAST assignment before `prepare_for_extend` runs.
+3. Add `req.cache_protected_len = len(req.prefix_indices)` immediately after that assignment.
+
+**Risk if mis-placed:** prefix tokens get double-freed (placed too early, before lock is taken) or under-freed (placed too late, after some prefix already released). The 4-config test will catch both.
+
+---
+
+## Risks
+
+1. **`cache_protected_len` placement** (above) — highest-risk single decision. Resolve via grep + verification before writing the change.
+2. **Existing page-tail double-free** (radix_cache.py:280 + 299) — must be fixed in this PR, otherwise page>1 + radix on still leaks even with new tracking.
+3. **DP grouping in `prepare_for_decode`** — confirm the `for req in self.reqs` loop iterates ALL reqs across DP ranks (not just one rank's slice). If sgl-jax splits decode by DP, the increment must run for every rank's reqs.
+4. **`free_group` nesting** — `release_kv_cache` is called inside `free_group_begin/end`. Do not call `free_group_begin/end` inside `release_kv_cache`.
+5. **EAGLE path correctness** — left untouched but verify by inspection: `release_kv_cache` running after EAGLE's inline free should be a no-op for the over-alloc range (EAGLE doesn't touch `kv_allocated_len`, so `kv_committed_len == kv_allocated_len` → empty range).
+
+---
+
+## Verification
+
+End-to-end test on TPU pod (e.g., `brian-deepseek-test`, v6e 2x2):
+
+```bash
+cd /Users/ramezes/job/sgl-project/sgl-jax/.claude/worktrees/fix-radix-cache
+
+# 4-config matrix — single prompt baseline must NOT trigger memory leak detection
+for page in 1 4; do
+  for radix_flag in "" "--disable-radix-cache"; do
+    echo "=== page=${page} radix_flag='${radix_flag}' ==="
+    python -m pytest test/srt/test_engine_determine_generation.py::TestEngineDetermineGeneration::test_1 \
+      -v --tb=short
+    # (test launches engine internally; pass page/radix via test fixture or env if test supports it,
+    # otherwise run minimal repro script directly with engine.async_generate + 13-token prompt + max_new_tokens=200)
+  done
+done
+```
+
+**Pass criteria:**
+- All 4 configs: `scheduler.py:1060-1089` `check_memory` invariant `available + evictable + protected == max_total_num_tokens` holds throughout the run; no `ValueError: token_to_kv_pool_allocator memory leak detected!`.
+- `test_1` (single retract baseline) passes — confirms baseline generation is unaffected.
+
+**Optional regression spot-check:**
+- `test/srt/test_srt_engine.py::test_smoke` — 1 run on default config to confirm no functional regression in the happy path.
+
+**Out of scope:**
+- `test_2/test_3/test_4` (abort/multi-req retract) — those require the abort path fix from the sibling worktree.
+- EAGLE / speculative decode tests.

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -396,6 +396,9 @@ class Req:
             )
             self.last_matched_prefix_len = len(self.prefix_indices)
         self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
+        # cache_protected_len is the prefix range already in radix (locked); cache_finished_req
+        # must NOT free this range, since dec_lock_ref handles that side.
+        self.cache_protected_len = len(self.prefix_indices)
 
     def pop_committed_kv_cache(self) -> int:
         """Return committed KV length and mark as released. Single use per finished req."""
@@ -542,6 +545,13 @@ class Req:
         self.swa_evicted_seqlen = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
+
+        # Reset KV lifecycle tracking fields.
+        self.kv_committed_len = 0
+        self.kv_allocated_len = 0
+        self.cache_protected_len = 0
+        self.kv_committed_freed = False
+        self.kv_overallocated_freed = False
 
     def set_finish_with_abort(self, error_msg: str):
         # set it to one token to skip the long prefill
@@ -874,6 +884,9 @@ class ScheduleBatch:
             req.already_computed = seq_len
             req.is_retracted = False
             req.extend_batch_idx += 1
+            # After prefill, all `seq_len` tokens have committed KV and are allocated.
+            req.kv_committed_len = seq_len
+            req.kv_allocated_len = seq_len
 
             # Compute the relative logprob_start_len in an extend batch
             if req.logprob_start_len >= pre_len:
@@ -1175,6 +1188,8 @@ class ScheduleBatch:
 
         for req in self.reqs:
             req.decode_batch_idx += 1
+            req.kv_committed_len += 1
+            req.kv_allocated_len += 1
 
     def filter_batch(
         self,

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -250,6 +250,17 @@ class Req:
         # The prefix length of the last prefix matching
         self.last_matched_prefix_len: int = 0
 
+        # KV cache lifecycle tracking (matches upstream sglang Req fields).
+        # committed_len: number of tokens whose KV is safe to commit to radix evictable.
+        # allocated_len: number of token slots currently allocated for this req.
+        # cache_protected_len: prefix length locked into radix at prefill start; not freed by cache_finished_req.
+        # *_freed flags guard against double pop_*_kv_cache calls.
+        self.kv_committed_len: int = 0
+        self.kv_allocated_len: int = 0
+        self.cache_protected_len: int = 0
+        self.kv_committed_freed: bool = False
+        self.kv_overallocated_freed: bool = False
+
         # Whether or not if it is chunked. It increments whenever
         # it is chunked, and decrement whenever chunked request is
         # processed.
@@ -385,6 +396,20 @@ class Req:
             )
             self.last_matched_prefix_len = len(self.prefix_indices)
         self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
+
+    def pop_committed_kv_cache(self) -> int:
+        """Return committed KV length and mark as released. Single use per finished req."""
+        assert not self.kv_committed_freed, f"double pop_committed_kv_cache for req {self.rid}"
+        self.kv_committed_freed = True
+        return self.kv_committed_len
+
+    def pop_overallocated_kv_cache(self) -> tuple[int, int]:
+        """Return [committed_len, allocated_len) over-alloc range. Single use per finished req."""
+        assert (
+            not self.kv_overallocated_freed
+        ), f"double pop_overallocated_kv_cache for req {self.rid}"
+        self.kv_overallocated_freed = True
+        return self.kv_committed_len, self.kv_allocated_len
 
     def adjust_max_prefix_ids(self):
         self.fill_ids = self.origin_input_ids + self.output_ids

--- a/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_output_processor_mixin.py
@@ -11,6 +11,7 @@ from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 from sgl_jax.srt.layers.routed_experts_capturer import get_global_experts_capturer
 from sgl_jax.srt.managers.io_struct import AbortReq, BatchTokenIDOut
 from sgl_jax.srt.managers.schedule_batch import BaseFinishReason, Req, ScheduleBatch
+from sgl_jax.srt.mem_cache.common import release_kv_cache
 from sgl_jax.srt.precision_tracer import precision_tracer
 from sgl_jax.srt.utils.common_utils import cdiv
 
@@ -95,11 +96,6 @@ class SchedulerOutputProcessorMixin:
 
             req.latest_bid = batch.bid
 
-            if self.is_mixed_chunk and self.enable_overlap and req.finished():
-                j = len(batch.out_cache_loc) - len(batch.reqs) + i
-                self.token_to_kv_pool_allocator.free(batch.out_cache_loc[j : j + 1])
-                continue
-
             if req.is_chunked <= 0:
                 # req output_ids are set here
                 req.output_ids.append(next_token_id)
@@ -122,7 +118,7 @@ class SchedulerOutputProcessorMixin:
                             >= precision_tracer.get_max_requests()
                         ):
                             precision_tracer.stop_trace()
-                    self.tree_cache.cache_finished_req(req)
+                    release_kv_cache(req, self.tree_cache)
                 elif not batch.decoding_reqs or req not in batch.decoding_reqs:
                     # This updates radix so others can match
                     self.tree_cache.cache_unfinished_req(req)
@@ -281,17 +277,6 @@ class SchedulerOutputProcessorMixin:
 
             req.latest_bid = batch.bid
 
-            indices_to_free = None
-            if self.enable_overlap and req.finished():
-                if self.page_size == 1:
-                    indices_to_free = batch.out_cache_loc[i : i + 1]
-                else:
-                    if (len(req.origin_input_ids) + len(req.output_ids) - 1) % self.page_size == 0:
-                        indices_to_free = batch.out_cache_loc[i : i + 1]
-                if indices_to_free is not None:
-                    self.token_to_kv_pool_allocator.free(indices_to_free)
-                continue
-
             new_accepted_len = 1
             if batch.spec_algorithm is None or batch.spec_algorithm.is_none():
                 req.output_ids.append(next_token_id)
@@ -335,7 +320,7 @@ class SchedulerOutputProcessorMixin:
                         >= precision_tracer.get_max_requests()
                     ):
                         precision_tracer.stop_trace()
-                self.tree_cache.cache_finished_req(req)
+                release_kv_cache(req, self.tree_cache)
 
             if req.return_output_logprob_only:
                 req.output_token_logprobs_val.append(next_token_logprobs[i])

--- a/python/sgl_jax/srt/mem_cache/chunk_cache.py
+++ b/python/sgl_jax/srt/mem_cache/chunk_cache.py
@@ -34,12 +34,12 @@ class ChunkCache(BasePrefixCache):
         )
 
     def cache_finished_req(self, req: Req):
+        committed_len = req.pop_committed_kv_cache()
         kv_indices = self.req_to_token_pool.req_to_token[
             req.req_pool_idx,
-            # For decode server: if req.output_ids is empty, we want to free all req.origin_input_ids
-            : len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0),
+            :committed_len,
         ]
-        self.req_to_token_pool.free(req.req_pool_idx)
+        # req_to_token_pool slot is freed by release_kv_cache.
         self.token_to_kv_pool_allocator.free(kv_indices)
 
     def cache_unfinished_req(self, req: Req):

--- a/python/sgl_jax/srt/mem_cache/common.py
+++ b/python/sgl_jax/srt/mem_cache/common.py
@@ -100,3 +100,49 @@ def available_and_evictable_str(tree_cache) -> str:
         available_size = token_to_kv_pool_allocator.available_size()
         evictable_size = tree_cache.evictable_size()
         return f"Available tokens: {available_size + evictable_size} ({available_size=} + {evictable_size=})\n"
+
+
+def release_kv_cache(req, tree_cache, is_insert: bool = True) -> None:
+    """Single entry point for releasing all KV cache held by a finished req.
+
+    Replaces scattered ``tree_cache.cache_finished_req(req)`` plus ad-hoc
+    ``out_cache_loc[i:i+1]`` frees that previously caused double-frees.
+
+    Steps:
+      1. Delegate committed-range free to the tree cache's cache_finished_req.
+      2. Free over-allocated range [committed_len, allocated_len) (page-aligned).
+      3. Free the req_to_token_pool slot.
+
+    Args:
+        req: the finished Req.
+        tree_cache: a RadixCache, ChunkCache, or compatible BasePrefixCache.
+        is_insert: kept for upstream-API compatibility; unused in sgl-jax today.
+    """
+    from sgl_jax.srt.utils.common_utils import cdiv
+
+    if req.req_pool_idx is None:
+        # Already released (e.g., retract path, or streaming session early-free).
+        return
+
+    # Step 1: free committed KV via tree cache (radix evictable insert OR direct free).
+    tree_cache.cache_finished_req(req)
+    if req.req_pool_idx is None:
+        return
+
+    # Step 2: free over-allocated KV in [start_p, end_p).
+    start_p, end_p = req.pop_overallocated_kv_cache()
+    page_size = tree_cache.page_size
+    if page_size > 1:
+        # Align start_p UP to next page boundary; the partial page before start_p
+        # is part of the committed range and was handled by cache_finished_req.
+        start_p = cdiv(start_p, page_size) * page_size
+
+    if start_p < end_p:
+        indices = tree_cache.req_to_token_pool.req_to_token[req.req_pool_idx, start_p:end_p]
+        # Filter zeros (uninitialized slots); same defensive pattern as cache_finished_req.
+        indices = indices[indices != 0]
+        if indices.size > 0:
+            tree_cache.token_to_kv_pool_allocator.free(indices)
+
+    # Step 3: release the req_to_token_pool slot.
+    tree_cache.req_to_token_pool.free(req.req_pool_idx)

--- a/python/sgl_jax/srt/mem_cache/radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/radix_cache.py
@@ -255,35 +255,39 @@ class RadixCache(BasePrefixCache):
         return self._insert_helper(self.root_node, converted_key, value)
 
     def cache_finished_req(self, req: Req):
-        """Cache completed requests"""
-        all_token_len = len(req.origin_input_ids) + max(len(req.output_ids) - 1, 0)
+        """Cache completed requests.
+
+        Frees the committed KV range [cache_protected_len, committed_len). Does NOT
+        free the req_to_token_pool slot — that's owned by release_kv_cache.
+        """
+        committed_len = req.pop_committed_kv_cache()
         if self.disable:
             kv_indices = self.req_to_token_pool.read(
                 req.req_pool_idx,
-                all_token_len,
+                committed_len,
             )
             kv_indices = kv_indices[kv_indices != 0]
             self.token_to_kv_pool_allocator.free(kv_indices)
-            self.req_to_token_pool.free(req.req_pool_idx)
             return
 
-        token_ids = (req.origin_input_ids + req.output_ids)[:all_token_len]
-        # For EAGLE radix cache, we will convert the key to bigram key, e.g. [1,2,3,4] -> [(1,2), (2,3), (3,4)], the length will -1. ((len([(1,2), (2,3), (3,4)]) = len([1,2,3,4]) - 1))
-        # So for the corresponding kv length should also -1. Then we get the actual_kv_len, and use it to do later calculation and slicing.
-        actual_kv_len = all_token_len - 1 if self.is_eagle else all_token_len
-        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, all_token_len)
+        token_ids = (req.origin_input_ids + req.output_ids)[:committed_len]
+        # For EAGLE radix cache, the key is bigram, so kv length is -1.
+        actual_kv_len = committed_len - 1 if self.is_eagle else committed_len
+        kv_indices = self.req_to_token_pool.read(req.req_pool_idx, committed_len)
         kv_indices = kv_indices[kv_indices != 0]
 
         if self.page_size != 1:
             page_aligned_len = actual_kv_len // self.page_size * self.page_size
             page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
-            self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
+            # NOTE: the page-tail free for kv_indices[page_aligned_len:] is done
+            # unconditionally below (after radix insert). Do NOT free it here too —
+            # that was the historical double-free (page>1 + radix on amplifies x page_size).
         else:
             page_aligned_len = actual_kv_len
             page_aligned_kv_indices = kv_indices[:page_aligned_len].copy()
 
         page_aligned_token_len = page_aligned_len + 1 if self.is_eagle else page_aligned_len
-        old_prefix_len = len(req.prefix_indices)
+        old_prefix_len = req.cache_protected_len
         if self.is_eagle and old_prefix_len > req.last_matched_prefix_len:
             # In EAGLE chunked prefill case, the prefix_indices included one unmatched token (kv_indices[actual_kv_len:])
             # Here we -1 to make sure the kv of the unmatched token can be freed correctly to avoid memory leak
@@ -295,11 +299,10 @@ class RadixCache(BasePrefixCache):
         )
 
         self.token_to_kv_pool_allocator.free(kv_indices[old_prefix_len:new_prefix_len])
-        # free the unaligned tail
+        # free the unaligned tail (single source — see NOTE above)
         self.token_to_kv_pool_allocator.free(kv_indices[page_aligned_len:])
 
-        # Remove request slot and release cache lock
-        self.req_to_token_pool.free(req.req_pool_idx)
+        # Release cache lock. req_to_token_pool slot is freed by release_kv_cache.
         self.dec_lock_ref(req.last_node)
 
     def cache_unfinished_req(self, req: Req):

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -19,16 +19,13 @@ from sgl_jax.srt.layers.moe import EPMoE, GateLogit, TopK, create_moe_weights_ma
 from sgl_jax.srt.layers.radix_attention import RadixAttention
 from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
-from sgl_jax.srt.utils.weight_utils import (
-    WeightLoader,
-    WeightMapping,
-    replicate_kv_heads,
-)
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
 
 
 class MiMoV2MLP(nnx.Module):
+
     def __init__(
         self,
         hidden_size: int,
@@ -73,6 +70,7 @@ class MiMoV2MLP(nnx.Module):
 
 
 class MiMoV2Moe(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -148,6 +146,7 @@ class MiMoV2Moe(nnx.Module):
 
 
 class MiMoV2Attention(nnx.Module):
+
     def __init__(
         self,
         hidden_size: int,
@@ -292,6 +291,7 @@ class MiMoV2Attention(nnx.Module):
 
 
 class MiMoV2DecoderLayer(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -425,6 +425,7 @@ class MiMoV2DecoderLayer(nnx.Module):
 
 
 class MiMoV2Model(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -482,6 +483,7 @@ class MiMoV2Model(nnx.Module):
 
 
 class MiMoV2FlashForCausalLM(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -493,7 +495,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self.dtype = dtype
         self.model = MiMoV2Model(config, dtype=self.dtype, mesh=mesh)
         # Buffer to hold raw FP8 K/V weights+scales for per-head fused dequant.
-        # Populated during weight loading, consumed by _dequant_fused_kv_heads.
+        # Populated during weight loading, consumed by WeightLoader.dequant_fused_kv().
         self._kv_buffers: dict[int, dict] = {}
 
         if not getattr(self.config, "tie_word_embeddings", True):
@@ -508,7 +510,11 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
 
     def load_weights(self, model_config: ModelConfig):
-        loader = WeightLoader(
+        # Pre-warm GCSFuse cache: sequential read of large safetensors files
+        # dramatically speeds up subsequent random-access MoE expert loading.
+        self._warmup_safetensors_cache(model_config)
+
+        self.loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
@@ -516,386 +522,78 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         )
         self._quant_config = model_config.quantization_config
         weight_mappings = self._create_weight_mappings()
-        loader.load_weights_from_safetensors(weight_mappings)
+        self.loader.load_weights_from_safetensors(weight_mappings)
         logger.info("MiMoV2Flash weights loaded successfully!")
 
         # Post-load: dequantize FP8 attention + layer-0 MLP to bf16.
-        # Q/K head_dim padding (192→256) is handled by the kernel internally.
-        if self._is_static_quant:
-            self._dequantize_fp8_to_bf16()
-            # K+V: fused per-head dequant (cross K/V boundary blocks)
-            self._dequant_fused_kv_heads()
-            # KV head replication for TP alignment (after K/V are bf16 LinearBase)
-            self._ensure_kv_head_replication()
+        if self.loader.is_static_quant:
+            head_dim = self.config.head_dim
+            v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+            # 1. Dequant Q only (K/V go through fused KV path via _kv_buffers)
+            self.loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[("self_attn.q_proj", head_dim)],
+            )
+            # 2. Fused KV per-head dequant (cross K/V boundary blocks)
+            self.loader.dequant_fused_kv(self._kv_buffers, self.model.layers, self.config)
+            # 3. Layer-0 dense MLP
+            self.loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+                layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
+            )
+            # 4. KV head replication for TP alignment
+            self.loader.replicate_kv_heads(
+                self.model.layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
 
-    def _is_quant_ignored(self, hf_path: str) -> bool:
-        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
-        quant_cfg = getattr(self, "_quant_config", None)
-        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
-            return True  # not quantized at all
-        ignored = quant_cfg.ignored_layers or []
-        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+    @staticmethod
+    def _warmup_safetensors_cache(model_config: ModelConfig):
+        """Pre-read safetensors files to warm GCSFuse cache.
 
-    @property
-    def _is_static_quant(self) -> bool:
-        quant_cfg = getattr(self, "_quant_config", None)
-        return quant_cfg is not None and quant_cfg.is_static_checkpoint
-
-    # ------------------------------------------------------------------
-    # Post-load transforms: dequantize FP8 → BF16, pad head dims
-    # ------------------------------------------------------------------
-
-    def _dequantize_quantized_linear(self, ql, head_dim=None) -> LinearBase:
-        """Dequantize a single QuantizedLinear to bf16 LinearBase.
-
-        weight_q may be in HF layout [out, in] or model layout [in, out]
-        depending on the transpose flag used during loading.
-        weight_scale is in kernel-ready 3D layout [in_blocks, 1, out_dim].
-
-        Handles kv_head_padding: when weight_q has been replicated along the
-        output axis (e.g. 4 kv_heads → 16 for TP), the scale only covers the
-        original (unreplicated) output dimension.  We extract one copy of the
-        original heads, dequantize, then re-replicate in bf16.
-
-        Args:
-            head_dim: If set, enables per-head block quant handling. Required
-                when head_dim % block_size != 0 (e.g., head_dim=192 with
-                block_size=128), as the HF checkpoint uses per-head block
-                boundaries instead of uniform blocks.
+        GCSFuse random reads are ~400ms per tensor (cold) vs ~1ms (warm).
+        Sequential bulk read fills the cache so MoE loading uses warm reads.
         """
-        weight_q = ql.weight_q.value
-        weight_scale = ql.weight_scale.value
-        logger.info(
-            "Dequant debug: weight_q.shape=%s weight_scale.shape=%s kernel_axes=%s head_dim=%s",
-            weight_q.shape,
-            weight_scale.shape,
-            ql.kernel_axes,
-            head_dim,
-        )
+        import glob
+        import os
+        from concurrent.futures import ThreadPoolExecutor
 
-        if weight_scale.ndim == 3:
-            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
-        elif weight_scale.ndim == 2:
-            # 2D block-quant scale: (out_blocks, in_blocks) in HF layout.
-            # Expand to 3D kernel-ready (in_blocks, 1, out_dim) then reuse _block_dequant.
-            from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
-                expand_block_scale,
-            )
-
-            # Determine out_dim: weight_q is (in, out) model layout or (out, in) HF layout.
-            _, in_blocks = weight_scale.shape
-            out_dim = weight_q.shape[1] if weight_q.shape[0] % in_blocks == 0 else weight_q.shape[0]
-            block_size_out = 128
-            scale_3d = expand_block_scale(weight_scale, out_dim, block_size_out)
-            weight_bf16 = self._block_dequant(weight_q, scale_3d, head_dim=head_dim)
-        elif weight_scale.ndim == 1:
-            out_dim = weight_scale.shape[0]
-            if weight_q.shape[1] == out_dim:
-                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
-                    jnp.bfloat16
-                )
-            else:
-                weight_bf16 = (
-                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
-                ).astype(jnp.bfloat16)
-        else:
-            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
-
-        # weight_bf16 is now in model layout [in, out]
-        in_features, out_features = weight_bf16.shape
-
-        with jax.set_mesh(ql.mesh):
-            new_linear = LinearBase(
-                input_size=in_features,
-                output_size=out_features,
-                kernel_axes=ql.kernel_axes,
-                use_bias=ql.bias is not None,
-                params_dtype=jnp.bfloat16,
-                mesh=ql.mesh,
-            )
-            new_linear.weight = nnx.Param(weight_bf16)
-            if ql.bias is not None:
-                new_linear.bias = nnx.Param(ql.bias.value.astype(jnp.bfloat16))
-        return new_linear
-
-    def _block_dequant(
-        self, weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
-    ) -> jax.Array:
-        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
-
-        Returns bf16 weight in model layout [in_dim, out_dim].
-        Handles kv_head_padding where weight_q is larger than scale coverage
-        by tiling the scale to match.
-
-        Args:
-            head_dim: If set, enables per-head block quant handling when scale
-                out_dim doesn't match weight dims. The scale is re-indexed using
-                per-head block boundaries instead of uniform block mapping.
-        """
-        import math
-
-        in_blocks = weight_scale.shape[0]
-        out_dim = weight_scale.shape[2]
-
-        # Detect layout and kv-padding
-        dim0, dim1 = weight_q.shape
-
-        if dim1 == out_dim:
-            # Model layout [in, out], no kv-padding
-            pass
-        elif dim0 == out_dim:
-            # HF layout [out, in] — transpose to model layout
-            weight_q = jnp.transpose(weight_q)
-        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
-            # Per-head block quant: scale was expanded for wrong n_out.
-            # Determine layout: in_dim must be divisible by in_blocks.
-            if dim0 % in_blocks == 0:
-                actual_out = dim1  # model layout [in, out]
-            else:
-                weight_q = jnp.transpose(weight_q)
-                actual_out = dim0  # was HF layout [out, in]
-
-            # Re-index scale using per-head block boundaries.
-            # The wrongly-expanded scale has uniform block mapping (ch // 128),
-            # but we need per-head mapping where each head's blocks are independent.
-            block_size = out_dim // (out_dim // 128) if out_dim >= 128 else 128
-            block_size = 128  # from weight_block_size config
-            blocks_per_head = math.ceil(head_dim / block_size)
-            num_heads = actual_out // head_dim
-
-            # Build gather index: for each output channel, find the corresponding
-            # channel in the uniformly-expanded scale that has the correct block's value.
-            gather_idx = jnp.array(
-                [
-                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
-                    for j in range(actual_out)
-                ]
-            )
-            weight_scale = weight_scale[:, :, gather_idx]  # (in_blocks, 1, actual_out)
-            out_dim = actual_out
-
-            logger.info(
-                "Per-head block dequant: %d heads × head_dim=%d, %d blocks/head, "
-                "remapped scale to (%s)",
-                num_heads,
-                head_dim,
-                blocks_per_head,
-                weight_scale.shape,
-            )
-        elif dim1 > out_dim and dim1 % out_dim == 0:
-            # Model layout [in, kv_padded_out] — tile scale to match
-            kv_replicas = dim1 // out_dim
-            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
-            out_dim = dim1
-            logger.info(
-                "Detected kv_head_padding: tiling scale %dx to match %d out channels",
-                kv_replicas,
-                out_dim,
-            )
-        elif dim0 > out_dim and dim0 % out_dim == 0:
-            # HF layout [kv_padded_out, in] — transpose and tile scale
-            kv_replicas = dim0 // out_dim
-            weight_q = jnp.transpose(weight_q)
-            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
-            out_dim = weight_q.shape[1]
-            logger.info(
-                "Detected kv_head_padding (HF layout): tiling scale %dx to match %d out channels",
-                kv_replicas,
-                out_dim,
-            )
-        else:
-            raise ValueError(
-                f"Cannot match weight_q shape {weight_q.shape} with scale out_dim={out_dim}"
-            )
-
-        # weight_q is now [in_dim, out_dim] in model layout
-        in_dim = weight_q.shape[0]
-        block_k = in_dim // in_blocks
-        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
-        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
-
-        return weight_bf16
-
-    def _dequantize_fp8_to_bf16(self):
-        """Dequantize FP8 QuantizedLinear → bf16 LinearBase.
-
-        Targets:
-        - All layers: self_attn.q_proj, k_proj, v_proj
-        - Layer 0: mlp.gate_proj, up_proj, down_proj (dense MLP only)
-        """
-        from sgl_jax.srt.layers.linear import QuantizedLinear
-
-        for layer_idx, layer in enumerate(self.model.layers):
-            attn = layer.self_attn
-            # Only Q and o_proj go through QuantizedLinear path.
-            # K/V are handled by _dequant_fused_kv_heads (per-head fused dequant).
-            for proj_name in ("q_proj",):
-                proj = getattr(attn, proj_name)
-                if isinstance(proj, QuantizedLinear):
-                    hd = attn.head_dim
-                    setattr(attn, proj_name, self._dequantize_quantized_linear(proj, head_dim=hd))
-                    logger.info("Dequantized layer %d %s → bf16", layer_idx, proj_name)
-
-            # Layer 0 dense MLP
-            if layer_idx == 0 and not layer.is_layer_sparse:
-                for proj_name in ("gate_proj", "up_proj", "down_proj"):
-                    proj = getattr(layer.mlp, proj_name)
-                    if isinstance(proj, QuantizedLinear):
-                        setattr(layer.mlp, proj_name, self._dequantize_quantized_linear(proj))
-                        logger.info("Dequantized layer 0 MLP %s → bf16", proj_name)
-
-        logger.info("FP8 → BF16 dequantization complete.")
-
-    def _ensure_kv_head_replication(self):
-        """Replicate KV heads for TP alignment when the weight loader missed them."""
-        attn = self.model.layers[0].self_attn
-        replicate_kv_heads(
-            layers=self.model.layers,
-            mesh=self.mesh,
-            head_dim=attn.head_dim,
-            v_head_dim=attn.v_head_dim,
-            target_kv_heads=attn.k_head_num,
-        )
-
-    def _uniform_block_dequant(self, weight, scale, block_size):
-        """Simple uniform block dequant for weight[out_dim, in_dim] * scale[out_blocks, in_blocks].
-
-        Used for layers where K/V are quantized uniformly across all heads
-        (no cross-boundary scale sharing between K and V).
-        """
-        out_dim, in_dim = weight.shape
-        out_blocks = scale.shape[0]
-        padded_out = out_blocks * block_size
-        in_blocks = scale.shape[1]
-        if padded_out > out_dim:
-            weight = jnp.pad(weight, ((0, padded_out - out_dim), (0, 0)))
-        w_4d = weight.astype(jnp.float32).reshape(out_blocks, block_size, in_blocks, block_size)
-        s_4d = scale[:, None, :, None]
-        result = (w_4d * s_4d).reshape(padded_out, in_dim)[:out_dim, :].astype(jnp.bfloat16)
-        return result
-
-    def _dequant_fused_kv_heads(self):
-        """Dequantize FP8 K+V weights with per-layer quantization scheme detection.
-
-        Different layers may use different quantization schemes:
-        - Per-head fused: K+V quantized as fused [K(head_dim), V(v_head_dim)] per KV head.
-          Block boundaries cross K/V boundary, so they must be fused for correct dequant.
-          Signature: k_scale_blocks == num_kv_heads * ceil(head_dim/block_size)
-        - Uniform: K and V quantized independently across the whole tensor.
-          No cross-boundary issue, can dequant K and V separately.
-          Signature: k_scale_blocks == ceil(num_kv_heads * head_dim / block_size)
-        """
-        import math
-
-        from jax.sharding import NamedSharding
-
-        kv_buffers = self._kv_buffers
-        if not kv_buffers:
+        model_path = model_config.model_path
+        st_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+        if not st_files:
             return
 
-        head_dim = self.config.head_dim
-        v_head_dim = getattr(self.config, "v_head_dim", head_dim)
-        quant_cfg = getattr(self, "_quant_config", None)
-        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+        total_size = sum(os.path.getsize(f) for f in st_files)
+        logger.info(
+            "Warming up GCSFuse cache: %d files, %.1f GB",
+            len(st_files),
+            total_size / 1024**3,
+        )
 
-        fused_dim = head_dim + v_head_dim
-        blocks_per_head = math.ceil(fused_dim / block_size)
-        padded_dim = blocks_per_head * block_size
-        k_blocks_per_head = math.ceil(head_dim / block_size)
-        v_blocks_per_head = blocks_per_head - k_blocks_per_head
+        def _read_file(path):
+            """Read file sequentially to populate GCSFuse cache."""
+            buf = bytearray(4 * 1024 * 1024)  # 4MB buffer
+            with open(path, "rb") as f:
+                while f.readinto(buf):
+                    pass
 
-        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+        import time
 
-        for layer_idx in sorted(kv_buffers.keys()):
-            buf = kv_buffers[layer_idx]
-            k_weight = buf["k_weight"]
-            k_scale = buf["k_scale"]
-            v_weight = buf["v_weight"]
-            v_scale = buf["v_scale"]
-
-            in_dim = k_weight.shape[1]
-            in_blocks = in_dim // block_size
-
-            # Per-layer num_kv_heads from actual weight shape
-            num_kv_heads = k_weight.shape[0] // head_dim
-            k_scale_blocks = k_scale.shape[0]
-
-            # Detect quantization scheme for this layer
-            expected_per_head = num_kv_heads * k_blocks_per_head
-            expected_uniform = math.ceil(num_kv_heads * head_dim / block_size)
-            is_per_head = (
-                k_scale_blocks == expected_per_head and expected_per_head != expected_uniform
-            )
-
-            if is_per_head:
-                # Per-head fused: K+V must be fused because scale blocks cross K/V boundary
-                k_w = k_weight.reshape(num_kv_heads, head_dim, in_dim)
-                v_w = v_weight.reshape(num_kv_heads, v_head_dim, in_dim)
-                k_s = k_scale.reshape(num_kv_heads, k_blocks_per_head, in_blocks)
-                v_s = v_scale.reshape(num_kv_heads, v_blocks_per_head, in_blocks)
-                fused_w = jnp.concatenate([k_w, v_w], axis=1)
-                fused_s = jnp.concatenate([k_s, v_s], axis=1)
-                if fused_dim < padded_dim:
-                    fused_w = jnp.pad(fused_w, ((0, 0), (0, padded_dim - fused_dim), (0, 0)))
-                fused_5d = fused_w.astype(jnp.float32).reshape(
-                    num_kv_heads, blocks_per_head, block_size, in_blocks, block_size
-                )
-                scale_5d = fused_s[:, :, None, :, None]
-                dequanted = (
-                    (fused_5d * scale_5d)
-                    .reshape(num_kv_heads, padded_dim, in_dim)[:, :fused_dim, :]
-                    .astype(jnp.bfloat16)
-                )
-                k_bf16 = dequanted[:, :head_dim, :].reshape(num_kv_heads * head_dim, in_dim)
-                v_bf16 = dequanted[:, head_dim:, :].reshape(num_kv_heads * v_head_dim, in_dim)
-            else:
-                # Uniform: K and V can be dequanted independently
-                k_bf16 = self._uniform_block_dequant(k_weight, k_scale, block_size)
-                v_bf16 = self._uniform_block_dequant(v_weight, v_scale, block_size)
-
-            # Transpose [out, in] → [in, out], shard, replace
-            k_bf16 = jax.device_put(jnp.transpose(k_bf16), tp_sharding)
-            v_bf16 = jax.device_put(jnp.transpose(v_bf16), tp_sharding)
-
-            attn = self.model.layers[layer_idx].self_attn
-            in_k, out_k = k_bf16.shape
-            in_v, out_v = v_bf16.shape
-
-            with jax.set_mesh(self.mesh):
-                k_linear = LinearBase(
-                    input_size=in_k,
-                    output_size=out_k,
-                    kernel_axes=(None, "tensor"),
-                    use_bias=False,
-                    params_dtype=jnp.bfloat16,
-                    mesh=self.mesh,
-                )
-                k_linear.weight = nnx.Param(k_bf16)
-                attn.k_proj = k_linear
-
-                v_linear = LinearBase(
-                    input_size=in_v,
-                    output_size=out_v,
-                    kernel_axes=(None, "tensor"),
-                    use_bias=False,
-                    params_dtype=jnp.bfloat16,
-                    mesh=self.mesh,
-                )
-                v_linear.weight = nnx.Param(v_bf16)
-                attn.v_proj = v_linear
-
-            if layer_idx % 10 == 0 or layer_idx == 0:
-                logger.info(
-                    "Layer %d KV dequant: %s, heads=%d, K=%s V=%s",
-                    layer_idx,
-                    "per-head" if is_per_head else "uniform",
-                    num_kv_heads,
-                    k_bf16.shape,
-                    v_bf16.shape,
-                )
-
-        kv_buffers.clear()
-        logger.info("FP8 KV dequantization complete for all layers.")
+        t0 = time.time()
+        with ThreadPoolExecutor(max_workers=min(8, len(st_files))) as executor:
+            list(executor.map(_read_file, st_files))
+        t1 = time.time()
+        logger.info(
+            "GCSFuse cache warm-up done: %.1fs (%.0f MB/s)",
+            t1 - t0,
+            total_size / 1024**2 / (t1 - t0) if t1 > t0 else 0,
+        )
 
     def _create_weight_mappings(self) -> dict:
         mappings = {
@@ -928,7 +626,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         target = prefix
 
         mappings = {}
-        is_fp8 = self._is_static_quant
+        is_fp8 = self.loader.is_static_quant
 
         # Attention projections
         for proj, sharding, kv_pad, hd_pad in [
@@ -938,7 +636,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
             ("o_proj", ("tensor", None), False, True),
         ]:
             hf_key = f"{prefix}.self_attn.{proj}"
-            ignored = self._is_quant_ignored(hf_key)
+            ignored = self.loader.is_quant_ignored(hf_key)
 
             # FP8 K/V: bypass QuantizedLinear, store raw FP8 data for fused
             # per-head dequant (cross K/V boundary blocks).
@@ -1044,6 +742,9 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
             if is_fp8:
                 augmented = {}
+                # FusedEPMoE scales must live on the model mesh (data, tensor)
+                # to avoid expert-mesh NamedSharding conflicts in shard_map.
+                # EPMoE scales stay on the expert mesh.
                 use_model_mesh_for_scale = moe_backend == "fused"
                 for key, mapping in moe_mappings.items():
                     augmented[key] = mapping

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -1,0 +1,243 @@
+"""MiMo-V2-Pro model implementation for SGLang-JAX.
+
+Inherits from MiMoV2FlashForCausalLM. The main difference is the weight format:
+Pro uses a fused qkv_proj instead of separate q/k/v_proj weights. The FP8
+checkpoint was quantized per-TP-shard and concatenated, so the fused QKV has
+a per-shard-interleaved layout that requires special dequantization handling.
+"""
+
+import logging
+
+import jax
+import jax.numpy as jnp
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.layers.moe import create_moe_weights_mapping
+from sgl_jax.srt.models.mimo_v2_flash import MiMoV2FlashForCausalLM
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh | None = None,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        super().__init__(config, mesh, dtype)
+        # Buffer to hold fused QKV FP8 weights/scales before per-shard dequant.
+        # Populated during weight loading, consumed by WeightLoader.dequant_fused_qkv.
+        self._fused_qkv_buffers: dict[int, dict] = {}
+
+    def load_weights(self, model_config):
+        """Load weights with special handling for per-shard-quantized fused QKV."""
+        self.loader = WeightLoader(
+            model=self,
+            model_config=model_config,
+            mesh=self.mesh,
+            dtype=self.dtype,
+        )
+        self._quant_config = model_config.quantization_config
+        weight_mappings = self._create_weight_mappings()
+        self.loader.load_weights_from_safetensors(weight_mappings)
+        logger.info("MiMoV2Pro weights loaded successfully!")
+
+        if self.loader.is_static_quant:
+            head_dim = self.config.head_dim
+            v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+            # Dequantize fused QKV per-shard, then split into Q/K/V bf16.
+            self.loader.dequant_fused_qkv(self._fused_qkv_buffers, self.model.layers, self.config)
+            # Dequantize remaining FP8 weights (layer 0 MLP, etc).
+            self.loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+                layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
+            )
+            self.loader.replicate_kv_heads(
+                self.model.layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
+
+    def _create_layer_mappings(self, layer_idx: int) -> dict:
+        """Override to handle fused qkv_proj weights in MiMo-V2-Pro checkpoints."""
+        prefix = f"model.layers.{layer_idx}"
+        target = prefix
+
+        mappings = {}
+        is_fp8 = self.loader.is_static_quant
+
+        # --- Fused QKV projection ---
+        hf_qkv_key = f"{prefix}.self_attn.qkv_proj"
+        qkv_ignored = self.loader.is_quant_ignored(hf_qkv_key)
+
+        if is_fp8 and not qkv_ignored:
+            # FP8 fused QKV: store raw weight+scale in buffer, dequant post-load.
+            # Use a callback mapping that stores into _fused_qkv_buffers instead of
+            # trying to split the per-shard-interleaved data.
+            mappings[f"{hf_qkv_key}.weight"] = WeightMapping(
+                target_path=f"__FUSED_QKV_WEIGHT__{layer_idx}",
+                sharding=(None, None),
+                transpose=False,
+            )
+            mappings[f"{hf_qkv_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"__FUSED_QKV_SCALE__{layer_idx}",
+                sharding=(None, None),
+                transpose=False,
+            )
+        else:
+            # BF16 or ignored: split normally (contiguous Q/K/V layout is fine)
+            qkv_weight_suffix = "weight"
+            mappings[f"{hf_qkv_key}.weight"] = WeightMapping(
+                target_path=[
+                    f"{target}.self_attn.q_proj.{qkv_weight_suffix}",
+                    f"{target}.self_attn.k_proj.{qkv_weight_suffix}",
+                    f"{target}.self_attn.v_proj.{qkv_weight_suffix}",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=False,
+                kv_head_padding=True,
+            )
+
+        # --- o_proj (separate, same as Flash) ---
+        hf_o_key = f"{prefix}.self_attn.o_proj"
+        o_ignored = self.loader.is_quant_ignored(hf_o_key)
+        o_weight_suffix = "weight" if (not is_fp8 or o_ignored) else "weight_q"
+
+        mappings[f"{hf_o_key}.weight"] = WeightMapping(
+            target_path=f"{target}.self_attn.o_proj.{o_weight_suffix}",
+            sharding=("tensor", None),
+            transpose=True,
+            head_dim_padding=True,
+        )
+
+        if is_fp8 and not o_ignored:
+            mappings[f"{hf_o_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"{target}.self_attn.o_proj.weight_scale",
+                sharding=(None, None),
+                transpose=False,
+            )
+
+        # --- Attention sink bias (same as Flash) ---
+        is_swa = (
+            hasattr(self.config, "hybrid_layer_pattern")
+            and 0 <= layer_idx < len(self.config.hybrid_layer_pattern)
+            and self.config.hybrid_layer_pattern[layer_idx] == 1
+        )
+        has_sink_bias = (is_swa and getattr(self.config, "add_swa_attention_sink_bias", False)) or (
+            not is_swa and getattr(self.config, "add_full_attention_sink_bias", False)
+        )
+        if has_sink_bias:
+            mappings[f"{prefix}.self_attn.attention_sink_bias"] = WeightMapping(
+                target_path=f"{target}.self_attn.attention_sink_bias",
+                sharding=("tensor",),
+                transpose=False,
+            )
+
+        # --- Layernorms (same as Flash) ---
+        mappings[f"{prefix}.input_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.input_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+        mappings[f"{prefix}.post_attention_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.post_attention_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+
+        # --- MLP / MoE (same as Flash) ---
+        is_sparse = (
+            hasattr(self.config, "moe_layer_freq")
+            and 0 <= layer_idx < len(self.config.moe_layer_freq)
+            and not isinstance(self.config.moe_layer_freq, int)
+            and self.config.moe_layer_freq[layer_idx]
+        )
+
+        if is_sparse:
+            mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
+                target_path=f"{target}.mlp.moe_gate.kernel",
+                sharding=(None, None),
+                transpose=True,
+            )
+
+            if getattr(self.config, "topk_method", "greedy") == "noaux_tc":
+                mappings[f"{prefix}.mlp.gate.e_score_correction_bias"] = WeightMapping(
+                    target_path=f"{target}.mlp.correction_bias",
+                    sharding=(None,),
+                    transpose=False,
+                )
+
+            num_experts = getattr(
+                self.config,
+                "n_routed_experts",
+                getattr(self.config, "num_experts", 8),
+            )
+            moe_backend = getattr(self.config, "moe_backend", "epmoe")
+
+            moe_mappings = create_moe_weights_mapping(
+                prefix=prefix,
+                target_prefix=target,
+                num_experts=num_experts,
+                moe_backend=moe_backend,
+                moe_path="mlp.experts",
+                source_expert_pattern="{i}",
+            )
+
+            if is_fp8:
+                augmented = {}
+                use_model_mesh_for_scale = moe_backend == "fused"
+                for key, mapping in moe_mappings.items():
+                    augmented[key] = mapping
+                    target_param = mapping.target_path[0]
+                    src_paths = mapping.target_path[1:]
+                    scale_key = key + "_scale"
+                    scale_target = target_param + "_scale"
+                    scale_srcs = [p.replace(".weight", ".weight_scale_inv") for p in src_paths]
+                    scale_sharding = (
+                        (("data", "tensor"), None, None)
+                        if use_model_mesh_for_scale
+                        else ("expert", None, None)
+                    )
+                    augmented[scale_key] = WeightMapping(
+                        target_path=[scale_target] + scale_srcs,
+                        sharding=scale_sharding,
+                        transpose=use_model_mesh_for_scale,
+                        concat_axis=mapping.concat_axis,
+                        physical_to_logical_map=mapping.physical_to_logical_map,
+                    )
+                moe_mappings = augmented
+
+            mappings.update(moe_mappings)
+        else:
+            for proj, sharding in [
+                ("gate_proj", (None, "tensor")),
+                ("up_proj", (None, "tensor")),
+                ("down_proj", ("tensor", None)),
+            ]:
+                hf_key = f"{prefix}.mlp.{proj}"
+                weight_suffix = "weight_q" if is_fp8 else "weight"
+                mappings[f"{hf_key}.weight"] = WeightMapping(
+                    target_path=f"{target}.mlp.{proj}.{weight_suffix}",
+                    sharding=sharding,
+                    transpose=True,
+                )
+                if is_fp8:
+                    mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                        target_path=f"{target}.mlp.{proj}.weight_scale",
+                        sharding=(None, None),
+                        transpose=False,
+                    )
+
+        return mappings
+
+
+EntryClass = MiMoV2ProForCausalLM

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1,12 +1,17 @@
 import copy
 import glob
+import json
 import logging
+import math
 import os
 import pickle
 import re
+import struct
+import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
@@ -14,6 +19,9 @@ import ml_dtypes
 import numpy as np
 from flax import nnx
 from jax.experimental import multihost_utils
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.layers.linear import LinearBase
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 from safetensors import safe_open
@@ -137,6 +145,7 @@ class WeightLoader:
 
             self.head_dim_pad = (self.head_dim_original + 127) // 128 * 128 - self.head_dim_original
             self.head_dim = self.head_dim_original
+            self.v_head_dim = getattr(model_config, "v_head_dim", self.head_dim_original)
         if hasattr(self.mesh, "shape") and "tensor" in self.mesh.shape:
             self.sharding_size = self.mesh.shape["tensor"]
         else:
@@ -152,6 +161,570 @@ class WeightLoader:
             )
         else:
             self.moe_abstract_mesh = None
+
+    # ------------------------------------------------------------------
+    # Quant config helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def is_static_quant(self) -> bool:
+        """Check if the model uses a static FP8 checkpoint."""
+        quant_cfg = getattr(self.model_config, "quantization_config", None)
+        return quant_cfg is not None and quant_cfg.is_static_checkpoint
+
+    def is_quant_ignored(self, hf_path: str) -> bool:
+        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
+        quant_cfg = getattr(self.model_config, "quantization_config", None)
+        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
+            return True
+        ignored = quant_cfg.ignored_layers or []
+        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+
+    # ------------------------------------------------------------------
+    # Post-load hooks: dequant FP8 → BF16, KV head replication
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_bf16_linear(
+        weight: jax.Array, kernel_axes, mesh, use_bias=False, bias=None
+    ) -> "LinearBase":
+        """Create a bf16 LinearBase from a weight array [in, out]."""
+        from sgl_jax.srt.layers.linear import LinearBase
+
+        in_features, out_features = weight.shape
+        with jax.set_mesh(mesh):
+            new_linear = LinearBase(
+                input_size=in_features,
+                output_size=out_features,
+                kernel_axes=kernel_axes,
+                use_bias=use_bias,
+                params_dtype=jnp.bfloat16,
+                mesh=mesh,
+            )
+            new_linear.weight = nnx.Param(weight)
+            if bias is not None:
+                new_linear.bias = nnx.Param(bias.astype(jnp.bfloat16))
+        return new_linear
+
+    def dequant_fp8_linear(self, ql, head_dim: int | None = None) -> "LinearBase":
+        """Dequantize a single QuantizedLinear → bf16 LinearBase.
+
+        Handles 3D block-quant scales, 1D per-channel scales, kv_head_padding,
+        and per-head block quant (when head_dim % block_size != 0).
+
+        Args:
+            ql: QuantizedLinear module with weight_q and weight_scale.
+            head_dim: If set, enables per-head block quant handling.
+        """
+        weight_q = ql.weight_q.value
+        weight_scale = ql.weight_scale.value
+
+        if weight_scale.ndim == 3:
+            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
+        elif weight_scale.ndim == 1:
+            out_dim = weight_scale.shape[0]
+            if weight_q.shape[1] == out_dim:
+                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
+                    jnp.bfloat16
+                )
+            else:
+                weight_bf16 = (
+                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
+                ).astype(jnp.bfloat16)
+        else:
+            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
+
+        bias = ql.bias.value if ql.bias is not None else None
+        return self.create_bf16_linear(
+            weight_bf16, ql.kernel_axes, ql.mesh, ql.bias is not None, bias
+        )
+
+    @staticmethod
+    def _block_dequant(
+        weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
+    ) -> jax.Array:
+        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
+
+        Returns bf16 weight in model layout [in_dim, out_dim].
+        Handles kv_head_padding (scale tiling) and per-head block quant.
+        """
+        import math
+
+        in_blocks = weight_scale.shape[0]
+        out_dim = weight_scale.shape[2]
+        dim0, dim1 = weight_q.shape
+
+        if dim1 == out_dim:
+            pass  # Model layout [in, out], no kv-padding
+        elif dim0 == out_dim:
+            weight_q = jnp.transpose(weight_q)  # HF layout [out, in]
+        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
+            # Per-head block quant: scale was expanded for wrong n_out.
+            if dim0 % in_blocks == 0:
+                actual_out = dim1  # model layout [in, out]
+            else:
+                weight_q = jnp.transpose(weight_q)
+                actual_out = dim0  # was HF layout [out, in]
+
+            block_size = 128
+            blocks_per_head = math.ceil(head_dim / block_size)
+            num_heads = actual_out // head_dim
+
+            gather_idx = jnp.array(
+                [
+                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
+                    for j in range(actual_out)
+                ]
+            )
+            weight_scale = weight_scale[:, :, gather_idx]
+            out_dim = actual_out
+
+            logger.info(
+                "Per-head block dequant: %d heads x head_dim=%d, %d blocks/head, "
+                "remapped scale to (%s)",
+                num_heads,
+                head_dim,
+                blocks_per_head,
+                weight_scale.shape,
+            )
+        elif dim1 > out_dim and dim1 % out_dim == 0:
+            # Model layout [in, kv_padded_out] — tile scale
+            kv_replicas = dim1 // out_dim
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = dim1
+        elif dim0 > out_dim and dim0 % out_dim == 0:
+            # HF layout [kv_padded_out, in] — transpose and tile scale
+            kv_replicas = dim0 // out_dim
+            weight_q = jnp.transpose(weight_q)
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = weight_q.shape[1]
+        else:
+            raise ValueError(
+                f"Cannot match weight_q shape {weight_q.shape} with scale out_dim={out_dim}"
+            )
+
+        in_dim = weight_q.shape[0]
+        block_k = in_dim // in_blocks
+        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
+        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
+        return weight_bf16
+
+    def dequant_fp8_layers(
+        self,
+        layers: list,
+        specs: list[tuple[str, int | None]],
+        *,
+        layer_filter=None,
+    ):
+        """Dequantize specified QuantizedLinear projections → bf16 LinearBase.
+
+        Args:
+            layers: model.layers list.
+            specs: list of (dotted_path, head_dim) tuples, e.g.
+                [("self_attn.q_proj", 192), ("self_attn.v_proj", 128)].
+            layer_filter: optional callable(layer_idx, layer) -> bool.
+        """
+        from sgl_jax.srt.layers.linear import QuantizedLinear
+
+        for layer_idx, layer in enumerate(layers):
+            if layer_filter is not None and not layer_filter(layer_idx, layer):
+                continue
+            for proj_path, hd in specs:
+                parts = proj_path.split(".")
+                parent = layer
+                for p in parts[:-1]:
+                    parent = getattr(parent, p)
+                attr_name = parts[-1]
+                proj = getattr(parent, attr_name)
+                if isinstance(proj, QuantizedLinear):
+                    setattr(parent, attr_name, self.dequant_fp8_linear(proj, head_dim=hd))
+                    logger.info("Dequantized layer %d %s -> bf16", layer_idx, proj_path)
+
+        logger.info("FP8 -> BF16 dequantization complete.")
+
+    def replicate_kv_heads(
+        self,
+        layers: list,
+        specs: list[tuple[str, int]],
+        target_kv_heads_fn,
+    ):
+        """Replicate KV heads for TP alignment.
+
+        Args:
+            layers: model.layers list.
+            specs: list of (dotted_path, head_dim) tuples, e.g.
+                [("self_attn.k_proj", 192), ("self_attn.v_proj", 128)].
+            target_kv_heads_fn: callable(attn_module) -> int, returns expected
+                TP-aligned KV head count.
+        """
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
+        for layer_idx, layer in enumerate(layers):
+            attn = layer.self_attn
+            target_kv_heads = target_kv_heads_fn(attn)
+
+            for proj_path, hd in specs:
+                parts = proj_path.split(".")
+                parent = layer
+                for p in parts[:-1]:
+                    parent = getattr(parent, p)
+                attr_name = parts[-1]
+                proj = getattr(parent, attr_name)
+                w = proj.weight.value
+                expected_size = target_kv_heads * hd
+                actual_size = w.shape[1]
+
+                if actual_size == expected_size:
+                    continue
+
+                if actual_size > 0 and expected_size % actual_size == 0:
+                    num_replicas = expected_size // actual_size
+                    orig_kv = actual_size // hd
+
+                    logger.info(
+                        "KV head replication: layer %d %s %d->%d heads (%d->%d)",
+                        layer_idx,
+                        proj_path,
+                        orig_kv,
+                        target_kv_heads,
+                        actual_size,
+                        expected_size,
+                    )
+
+                    w_full = jax.device_put(w, NamedSharding(self.mesh, P()))
+                    w_3d = w_full.reshape(w.shape[0], orig_kv, hd)
+                    w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
+                    w_new = w_rep.reshape(w.shape[0], expected_size)
+                    w_new = jax.device_put(w_new, NamedSharding(self.mesh, P(None, "tensor")))
+
+                    setattr(
+                        parent,
+                        attr_name,
+                        self.create_bf16_linear(w_new, proj.kernel_axes, self.mesh),
+                    )
+
+    @staticmethod
+    def _uniform_block_dequant(weight, scale, block_size):
+        """Uniform block dequant for weight[out_dim, in_dim] * scale[out_blocks, in_blocks]."""
+        out_dim, in_dim = weight.shape
+        out_blocks = scale.shape[0]
+        padded_out = out_blocks * block_size
+        in_blocks = scale.shape[1]
+        if padded_out > out_dim:
+            weight = jnp.pad(weight, ((0, padded_out - out_dim), (0, 0)))
+        w_4d = weight.astype(jnp.float32).reshape(out_blocks, block_size, in_blocks, block_size)
+        s_4d = scale[:, None, :, None]
+        result = (w_4d * s_4d).reshape(padded_out, in_dim)[:out_dim, :].astype(jnp.bfloat16)
+        return result
+
+    def dequant_fused_kv(
+        self,
+        kv_buffers: dict[int, dict],
+        layers: list,
+        config,
+    ):
+        """Dequantize FP8 K+V weights with per-layer quantization scheme detection.
+
+        Handles two schemes:
+        - Per-head fused: K+V quantized as fused [K(head_dim), V(v_head_dim)] per head.
+          Block boundaries cross K/V boundary, so they must be fused for correct dequant.
+        - Uniform: K and V quantized independently across the whole tensor.
+
+        Args:
+            kv_buffers: dict mapping layer_idx -> {k_weight, k_scale, v_weight, v_scale}
+            layers: model.layers list
+            config: model config with head_dim, v_head_dim
+        """
+        import math
+
+        from jax.sharding import NamedSharding
+
+        if not kv_buffers:
+            return
+
+        head_dim = config.head_dim
+        v_head_dim = getattr(config, "v_head_dim", head_dim)
+        quant_cfg = getattr(config, "quantization_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        fused_dim = head_dim + v_head_dim
+        blocks_per_head = math.ceil(fused_dim / block_size)
+        padded_dim = blocks_per_head * block_size
+        k_blocks_per_head = math.ceil(head_dim / block_size)
+        v_blocks_per_head = blocks_per_head - k_blocks_per_head
+
+        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+
+        for layer_idx in sorted(kv_buffers.keys()):
+            buf = kv_buffers[layer_idx]
+            k_weight = buf["k_weight"]
+            k_scale = buf["k_scale"]
+            v_weight = buf["v_weight"]
+            v_scale = buf["v_scale"]
+
+            in_dim = k_weight.shape[1]
+            in_blocks = in_dim // block_size
+
+            num_kv_heads = k_weight.shape[0] // head_dim
+            k_scale_blocks = k_scale.shape[0]
+
+            expected_per_head = num_kv_heads * k_blocks_per_head
+            expected_uniform = math.ceil(num_kv_heads * head_dim / block_size)
+            is_per_head = (
+                k_scale_blocks == expected_per_head and expected_per_head != expected_uniform
+            )
+
+            if is_per_head:
+                k_w = k_weight.reshape(num_kv_heads, head_dim, in_dim)
+                v_w = v_weight.reshape(num_kv_heads, v_head_dim, in_dim)
+                k_s = k_scale.reshape(num_kv_heads, k_blocks_per_head, in_blocks)
+                v_s = v_scale.reshape(num_kv_heads, v_blocks_per_head, in_blocks)
+                fused_w = jnp.concatenate([k_w, v_w], axis=1)
+                fused_s = jnp.concatenate([k_s, v_s], axis=1)
+                if fused_dim < padded_dim:
+                    fused_w = jnp.pad(fused_w, ((0, 0), (0, padded_dim - fused_dim), (0, 0)))
+                fused_5d = fused_w.astype(jnp.float32).reshape(
+                    num_kv_heads, blocks_per_head, block_size, in_blocks, block_size
+                )
+                scale_5d = fused_s[:, :, None, :, None]
+                dequanted = (
+                    (fused_5d * scale_5d)
+                    .reshape(num_kv_heads, padded_dim, in_dim)[:, :fused_dim, :]
+                    .astype(jnp.bfloat16)
+                )
+                k_bf16 = dequanted[:, :head_dim, :].reshape(num_kv_heads * head_dim, in_dim)
+                v_bf16 = dequanted[:, head_dim:, :].reshape(num_kv_heads * v_head_dim, in_dim)
+            else:
+                k_bf16 = self._uniform_block_dequant(k_weight, k_scale, block_size)
+                v_bf16 = self._uniform_block_dequant(v_weight, v_scale, block_size)
+
+            k_bf16 = jax.device_put(jnp.transpose(k_bf16), tp_sharding)
+            v_bf16 = jax.device_put(jnp.transpose(v_bf16), tp_sharding)
+
+            attn = layers[layer_idx].self_attn
+            attn.k_proj = self.create_bf16_linear(k_bf16, (None, "tensor"), self.mesh)
+            attn.v_proj = self.create_bf16_linear(v_bf16, (None, "tensor"), self.mesh)
+
+            if layer_idx % 10 == 0 or layer_idx == 0:
+                logger.info(
+                    "Layer %d KV dequant: %s, heads=%d, K=%s V=%s",
+                    layer_idx,
+                    "per-head" if is_per_head else "uniform",
+                    num_kv_heads,
+                    k_bf16.shape,
+                    v_bf16.shape,
+                )
+
+        kv_buffers.clear()
+        logger.info("FP8 KV dequantization complete for all layers.")
+
+    def dequant_fused_qkv(
+        self,
+        fused_qkv_buffers: dict[int, dict],
+        layers: list,
+        config,
+    ):
+        """Dequantize per-shard-interleaved fused QKV FP8 weights.
+
+        The FP8 checkpoint was quantized per-TP-shard and concatenated:
+          weight: [shard0_QKV | shard1_QKV | ... | shardN_QKV], shape [total_qkv, hidden]
+          scale:  [shard0_scale | shard1_scale | ... | shardN_scale], shape [total_blocks, in_blocks]
+
+        Each shard's QKV dim may not be a multiple of block_size, so scale blocks
+        within a shard can span K/V boundaries. We must dequantize per-shard first,
+        then extract Q/K/V from each shard.
+
+        All dequant math runs on CPU (numpy) to avoid TPU OOM.  Only the final
+        bf16 result is ``device_put`` to TPU with TP sharding.
+
+        Args:
+            fused_qkv_buffers: dict mapping layer_idx -> {"weight": np.ndarray, "scale": np.ndarray}
+            layers: model.layers list
+            config: model config with head_dim, v_head_dim, num_attention_heads, etc.
+        """
+        if not fused_qkv_buffers:
+            return
+
+        from jax.sharding import NamedSharding
+
+        head_dim = config.head_dim
+        v_head_dim = getattr(config, "v_head_dim", head_dim)
+        num_heads = config.num_attention_heads
+        num_kv_heads = config.num_key_value_heads
+
+        quant_cfg = getattr(config, "quantization_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+
+        for layer_idx in sorted(fused_qkv_buffers.keys()):
+            buf = fused_qkv_buffers[layer_idx]
+            fused_weight = buf["weight"]  # numpy, [total_qkv, hidden], FP8
+            fused_scale = buf["scale"]  # numpy, [total_blocks, in_blocks], f32
+
+            in_dim = fused_weight.shape[1]  # hidden_size
+
+            # Infer n_shards: find TP size where per-shard blocking matches scale shape
+            n_shards, orig_kv_heads = self._infer_qkv_shards(
+                fused_weight.shape[0],
+                fused_scale.shape[0],
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                v_head_dim,
+                block_size,
+            )
+
+            per_shard_q = (num_heads // n_shards) * head_dim
+            per_shard_k = (orig_kv_heads // n_shards) * head_dim
+            per_shard_v = (orig_kv_heads // n_shards) * v_head_dim
+            per_shard_total = per_shard_q + per_shard_k + per_shard_v
+            per_shard_blocks = math.ceil(per_shard_total / block_size)
+            padded_rows = per_shard_blocks * block_size
+            in_blocks = in_dim // block_size
+
+            if layer_idx % 10 == 0:
+                logger.info(
+                    "Layer %d: dequant fused QKV FP8 (CPU), n_shards=%d, "
+                    "per_shard=%d (Q=%d K=%d V=%d), blocks=%d",
+                    layer_idx,
+                    n_shards,
+                    per_shard_total,
+                    per_shard_q,
+                    per_shard_k,
+                    per_shard_v,
+                    per_shard_blocks,
+                )
+
+            q_parts, k_parts, v_parts = [], [], []
+
+            for shard_idx in range(n_shards):
+                # Extract this shard's weight and scale (numpy slicing)
+                w_start = shard_idx * per_shard_total
+                shard_w = fused_weight[w_start : w_start + per_shard_total, :]
+
+                s_start = shard_idx * per_shard_blocks
+                shard_s = fused_scale[s_start : s_start + per_shard_blocks, :]
+
+                # Pad weight rows to block boundary for dequant
+                if per_shard_total < padded_rows:
+                    shard_w = np.pad(shard_w, ((0, padded_rows - per_shard_total), (0, 0)))
+
+                # Block dequantize on CPU: [padded_rows, in_dim] × [blocks, in_blocks]
+                shard_f = shard_w.astype(np.float32).reshape(
+                    per_shard_blocks, block_size, in_blocks, block_size
+                )
+                shard_s_4d = shard_s[:, None, :, None]
+                shard_dequant = (shard_f * shard_s_4d).reshape(padded_rows, in_dim)[
+                    :per_shard_total, :
+                ]
+
+                # Split into Q, K, V and transpose to model layout [in, out_shard].
+                # .T is O(1) numpy view; .copy() releases the shard_dequant reference.
+                q_parts.append(shard_dequant[:per_shard_q, :].T.copy())
+                k_parts.append(shard_dequant[per_shard_q : per_shard_q + per_shard_k, :].T.copy())
+                v_parts.append(shard_dequant[per_shard_q + per_shard_k :, :].T.copy())
+
+            # Free CPU buffers for this layer
+            del buf["weight"], buf["scale"]
+
+            # Concat on CPU, convert to bf16, shard to TPU via callback.
+            # Uses make_array_from_callback to avoid the allgather that
+            # device_put triggers in multi-host (assert_equal OOM).
+            # Process Q/K/V sequentially to limit peak CPU memory.
+            attn = layers[layer_idx].self_attn
+            for proj_name, parts in [
+                ("q_proj", q_parts),
+                ("k_proj", k_parts),
+                ("v_proj", v_parts),
+            ]:
+                merged = np.ascontiguousarray(
+                    np.concatenate(parts, axis=1).astype(ml_dtypes.bfloat16)
+                )
+                del parts[:]
+                # Bind merged via default arg to avoid late-binding closure issue.
+                weight = jax.make_array_from_callback(
+                    merged.shape,
+                    tp_sharding,
+                    lambda idx, m=merged: jnp.array(m[idx]),
+                )
+                del merged
+                setattr(
+                    attn,
+                    proj_name,
+                    self.create_bf16_linear(weight, (None, "tensor"), self.mesh),
+                )
+
+            if layer_idx == 0:
+                q_w = attn.q_proj.weight.value
+                k_w = attn.k_proj.weight.value
+                v_w = attn.v_proj.weight.value
+                logger.info(
+                    "Layer 0 dequant result: Q=%s K=%s V=%s",
+                    q_w.shape,
+                    k_w.shape,
+                    v_w.shape,
+                )
+
+        # Clean up buffers
+        fused_qkv_buffers.clear()
+        logger.info("Fused QKV FP8 dequantization complete (CPU numpy path).")
+
+    @staticmethod
+    def _infer_qkv_shards(
+        total_out_dim: int,
+        total_scale_blocks: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        v_head_dim: int,
+        block_size: int,
+    ) -> tuple[int, int]:
+        """Infer the number of TP shards used during FP8 quantization.
+
+        The config's num_kv_heads may be GQA-replicated (e.g. 32 instead of
+        the original 8), so we also try divisors of num_kv_heads to find the
+        original value used during per-shard quantization.
+
+        Returns (tp_shards, original_num_kv_heads).
+        """
+        # Collect candidate kv_heads values: config value and its divisors
+        kv_candidates = []
+        for d in range(1, num_kv_heads + 1):
+            if num_kv_heads % d == 0:
+                kv_candidates.append(d)
+        # Try config value first, then smaller divisors (descending)
+        kv_candidates = sorted(set(kv_candidates), reverse=True)
+
+        # TP candidates: all divisors of num_heads (covers any quantization-time TP)
+        tp_candidates = sorted(d for d in range(1, num_heads + 1) if num_heads % d == 0)
+
+        for orig_kv in kv_candidates:
+            for tp in tp_candidates:
+                if orig_kv % tp != 0:
+                    continue
+                per_shard = (
+                    (num_heads // tp) * head_dim
+                    + (orig_kv // tp) * head_dim
+                    + (orig_kv // tp) * v_head_dim
+                )
+                per_shard_blocks = math.ceil(per_shard / block_size)
+                if per_shard_blocks * tp == total_scale_blocks and per_shard * tp == total_out_dim:
+                    if orig_kv != num_kv_heads:
+                        logger.info(
+                            "Inferred original num_kv_heads=%d (config has %d), tp=%d",
+                            orig_kv,
+                            num_kv_heads,
+                            tp,
+                        )
+                    return tp, orig_kv
+        raise ValueError(
+            f"Cannot infer QKV shard count: out_dim={total_out_dim}, "
+            f"scale_blocks={total_scale_blocks}, num_heads={num_heads}, "
+            f"num_kv_heads={num_kv_heads}, head_dim={head_dim}, "
+            f"v_head_dim={v_head_dim}, block_size={block_size}"
+        )
 
     def _normalize_physical_to_logical_map(
         self,
@@ -389,6 +962,12 @@ class WeightLoader:
             iterator = tqdm(weights_files, desc="Scanning Metadata", unit="file")
 
             for st_file in iterator:
+                # Parse safetensors header for byte offsets (for bulk MoE reads)
+                with open(st_file, "rb") as raw_f:
+                    header_size = struct.unpack("<Q", raw_f.read(8))[0]
+                    raw_header = json.loads(raw_f.read(header_size))
+                data_section_offset = 8 + header_size
+
                 with safe_open(st_file, framework="flax", device="cpu") as f:
                     for key in f.keys():  # noqa: SIM118
                         slice_info = f.get_slice(key)
@@ -397,6 +976,12 @@ class WeightLoader:
                             "shape": tuple(slice_info.get_shape()),
                             "dtype": slice_info.get_dtype(),
                         }
+                        # Add byte offset info for direct reads
+                        if key in raw_header:
+                            offsets = raw_header[key].get("data_offsets")
+                            if offsets:
+                                info["byte_offset"] = data_section_offset + offsets[0]
+                                info["byte_size"] = offsets[1] - offsets[0]
                         if key not in weight_info:
                             weight_info[key] = []
                         weight_info[key].append(info)
@@ -702,7 +1287,7 @@ class WeightLoader:
                     sample_map = {
                         p: logical_indices[i] for i, p in enumerate(physical_indices[:sample_size])
                     }
-                    logger.info("Cloning split-experts map (sample): %s", sample_map)
+                    logger.debug("Cloning split-experts map (sample): %s", sample_map)
             else:
                 logical_indices = physical_indices
 
@@ -737,9 +1322,9 @@ class WeightLoader:
 
             return out_array
 
-        result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice).astype(
-            target_dtype
-        )
+        result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice)
+        if result.dtype != target_dtype:
+            result = result.astype(target_dtype)
         if do_transpose and result.ndim >= 3:
             result = jnp.transpose(result, (0, 2, 1))
         return result
@@ -781,7 +1366,62 @@ class WeightLoader:
         else:
             num_physical_experts = num_logical_experts
 
-        if do_transpose and len(single_expert_shape) >= 2:
+        # Detect whether we can defer transpose to TPU instead of doing it
+        # on CPU during loading. This is possible when do_transpose=True but
+        # the weight dimensions (all dims after expert dim) are unsharded,
+        # meaning each callback loads the full tensor. Deferring avoids the
+        # costly strided memcpy from np.transpose on non-contiguous views.
+        defer_transpose = False
+        if do_transpose and len(single_expert_shape) >= 2 and target_sharding is not None:
+            spec = target_sharding.spec
+            # spec[0] is expert dim sharding, spec[1:] are weight dims
+            weight_dims_unsharded = all(s is None for s in spec[1:])
+            if weight_dims_unsharded:
+                defer_transpose = True
+                logger.info(
+                    "MoE defer_transpose=True: will load in HF layout and "
+                    "transpose on TPU (shape=%s)",
+                    single_expert_shape,
+                )
+
+        # Check if bulk raw byte reading is possible (byte offsets available
+        # from scan phase). This eliminates per-expert safetensors API calls
+        # and reduces GCSFuse round-trips by reading contiguous byte ranges.
+        # Skip bulk_read for small tensors (e.g. scales) — safetensors API
+        # with cached handles is faster than raw open/seek/read on GCSFuse.
+        _expert_elems = 1
+        for d in single_expert_shape:
+            _expert_elems *= d
+        _expert_bytes_est = _expert_elems * (1 if st_dtype.startswith("F8_") else 4)
+        _BULK_READ_MIN_BYTES = 1024 * 1024  # 1 MB per expert
+        bulk_read = (
+            defer_transpose
+            and _expert_bytes_est >= _BULK_READ_MIN_BYTES
+            and all(
+                "byte_offset" in weight_info[expected_hf_keys[i]][0]
+                for i in range(min(2, num_logical_experts))
+            )
+        )
+        if bulk_read:
+            logger.info(
+                "MoE bulk_read=True: using raw byte reads for %d experts",
+                num_logical_experts,
+            )
+
+        # Map safetensors dtype strings to numpy dtypes for raw reads
+        _st_to_np_dtype = {
+            "F32": np.float32,
+            "F16": np.float16,
+            "BF16": np.dtype("V2"),  # 2-byte view, reinterpret later
+            "I64": np.int64,
+            "I32": np.int32,
+            "BOOL": np.bool_,
+            "F8_E4M3": np.uint8,
+            "F8_E5M2": np.uint8,
+        }
+        np_read_dtype = _st_to_np_dtype.get(st_dtype, np.uint8)
+
+        if do_transpose and not defer_transpose and len(single_expert_shape) >= 2:
             final_single_shape = list(single_expert_shape)
             final_single_shape[-1], final_single_shape[-2] = (
                 final_single_shape[-2],
@@ -794,9 +1434,14 @@ class WeightLoader:
         stacked_shape = (num_physical_experts, *final_single_shape)
         sharding = target_sharding or jax.sharding.NamedSharding(self.mesh, P())
 
-        LOAD_WORKERS = 16
+        LOAD_WORKERS = int(os.environ.get("SGLANG_MOE_LOAD_WORKERS", "16"))
+
+        _callback_times = []
+        _detailed_logged = False
 
         def _load_stacked_slice(index):
+            nonlocal _detailed_logged
+            _cb_start = time.monotonic()
             expert_slice = index[0]
             inner_slice = index[1:]
 
@@ -817,22 +1462,54 @@ class WeightLoader:
                         p: logical_indices_to_load[i]
                         for i, p in enumerate(physical_indices[:sample_size])
                     }
-                    logger.info("Cloning experts map (sample): %s", sample_map)
+                    logger.debug("Cloning experts map (sample): %s", sample_map)
             else:
                 logical_indices_to_load = physical_indices
 
+            # --- Load first expert with detailed timing ---
             first_log_idx = logical_indices_to_load[0]
             first_hf_key = expected_hf_keys[first_log_idx]
             first_fname = weight_info[first_hf_key][0]["file"]
-            first_f = file_manager.get_handle(first_fname)
 
-            if not do_transpose:
+            _t0 = time.monotonic()
+            first_f = file_manager.get_handle(first_fname)
+            _t_handle = time.monotonic() - _t0
+
+            if not do_transpose or defer_transpose:
+                _t1 = time.monotonic()
                 first_chunk = first_f.get_slice(first_hf_key)[inner_slice]
+                _t_getslice = time.monotonic() - _t1
+                _t2 = time.monotonic()
                 first_chunk = _view_as_fp8_if_needed(first_chunk, target_dtype)
+                _t_fp8 = time.monotonic() - _t2
+                _t_transpose = 0.0
             else:
+                _t1 = time.monotonic()
                 data = first_f.get_slice(first_hf_key)[:]
+                _t_getslice = time.monotonic() - _t1
+                _t2 = time.monotonic()
                 data = _view_as_fp8_if_needed(data, target_dtype)
+                _t_fp8 = time.monotonic() - _t2
+                _t3 = time.monotonic()
                 first_chunk = np.transpose(data)[inner_slice]
+                _t_transpose = time.monotonic() - _t3
+
+            # Log detailed timing for first callback only
+            if not _detailed_logged:
+                _detailed_logged = True
+                expert_bytes = first_chunk.nbytes
+                logger.debug(
+                    "MoE callback[0] detail: experts_in_shard=%d "
+                    "get_handle=%.4fs get_slice=%.4fs fp8_view=%.4fs "
+                    "transpose=%.4fs expert_bytes=%d file=%s",
+                    sliced_num_physical,
+                    _t_handle,
+                    _t_getslice,
+                    _t_fp8,
+                    _t_transpose,
+                    expert_bytes,
+                    os.path.basename(first_fname),
+                )
 
             out_shape = (sliced_num_physical, *first_chunk.shape)
             out_array = np.empty(out_shape, dtype=first_chunk.dtype)
@@ -846,33 +1523,273 @@ class WeightLoader:
                 else:
                     logical_to_positions.setdefault(log_idx, []).append(phys_pos)
 
+            # Per-thread timing accumulators
+            _thread_stats = {
+                "get_handle": [],
+                "get_slice": [],
+                "fp8": [],
+                "transpose": [],
+                "copy": [],
+            }
+            _thread_files = []
+
             def load_and_fill_expert(args):
                 l_idx, positions = args
                 hf_k = expected_hf_keys[l_idx]
                 fname = weight_info[hf_k][0]["file"]
-                f = file_manager.get_handle(fname)
 
-                if not do_transpose:
+                t_a = time.monotonic()
+                f = file_manager.get_handle(fname)
+                t_b = time.monotonic()
+                _thread_stats["get_handle"].append(t_b - t_a)
+
+                if not do_transpose or defer_transpose:
                     chunk = f.get_slice(hf_k)[inner_slice]
+                    t_c = time.monotonic()
+                    _thread_stats["get_slice"].append(t_c - t_b)
                     chunk = _view_as_fp8_if_needed(chunk, target_dtype)
+                    t_d = time.monotonic()
+                    _thread_stats["fp8"].append(t_d - t_c)
+                    _thread_stats["transpose"].append(0.0)
                 else:
                     data = f.get_slice(hf_k)[:]
+                    t_c = time.monotonic()
+                    _thread_stats["get_slice"].append(t_c - t_b)
                     data = _view_as_fp8_if_needed(data, target_dtype)
+                    t_d = time.monotonic()
+                    _thread_stats["fp8"].append(t_d - t_c)
                     chunk = np.transpose(data)[inner_slice]
+                    t_e = time.monotonic()
+                    _thread_stats["transpose"].append(t_e - t_d)
 
+                t_copy_start = time.monotonic()
                 for pos in positions:
                     out_array[pos] = chunk
+                _thread_stats["copy"].append(time.monotonic() - t_copy_start)
+                _thread_files.append(os.path.basename(fname))
 
             if logical_to_positions:
                 tasks = list(logical_to_positions.items())
                 with ThreadPoolExecutor(max_workers=LOAD_WORKERS) as executor:
                     list(executor.map(load_and_fill_expert, tasks))
 
+            _callback_times.append(time.monotonic() - _cb_start)
+
+            # Log aggregated thread stats for first callback
+            if len(_callback_times) == 1 and _thread_stats["get_slice"]:
+                n = len(_thread_stats["get_slice"])
+                unique_files = len(set(_thread_files))
+                logger.debug(
+                    "MoE callback[0] threads: n=%d unique_files=%d "
+                    "get_handle=%.4fs get_slice(sum=%.2fs avg=%.4fs max=%.4fs) "
+                    "fp8=%.4fs transpose(sum=%.2fs avg=%.4fs) copy=%.4fs",
+                    n,
+                    unique_files,
+                    sum(_thread_stats["get_handle"]),
+                    sum(_thread_stats["get_slice"]),
+                    sum(_thread_stats["get_slice"]) / n,
+                    max(_thread_stats["get_slice"]),
+                    sum(_thread_stats["fp8"]),
+                    sum(_thread_stats["transpose"]),
+                    sum(_thread_stats["transpose"]) / n,
+                    sum(_thread_stats["copy"]),
+                )
+
             return out_array
 
-        return jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice).astype(
-            target_dtype
-        )
+        t0 = time.monotonic()
+        if bulk_read:
+            # Host-level bulk loading: read all experts for local devices at
+            # once, then device_put in parallel. This replaces serial
+            # make_array_from_callback with a single bulk I/O + parallel
+            # device transfers.
+            local_devices = sharding.mesh.local_devices
+            n_local = len(local_devices)
+
+            # Determine which physical experts each local device needs
+            device_assignments = sharding.devices_indices_map(stacked_shape)
+            local_assignments = []
+            for dev in local_devices:
+                idx = device_assignments[dev]
+                expert_slice = idx[0]
+                s, e, st = expert_slice.indices(num_physical_experts)
+                local_assignments.append(list(range(s, e, st)))
+
+            # Collect ALL unique logical expert indices needed by this host
+            all_logical = set()
+            for phys_indices in local_assignments:
+                for p in phys_indices:
+                    if physical_to_logical_map is not None:
+                        all_logical.add(int(physical_to_logical_map[p]))
+                    else:
+                        all_logical.add(p)
+
+            # Group by file for bulk reading
+            file_groups = {}
+            for log_idx in all_logical:
+                hf_key = expected_hf_keys[log_idx]
+                info = weight_info[hf_key][0]
+                fname = info["file"]
+                byte_offset = info["byte_offset"]
+                file_groups.setdefault(fname, []).append((log_idx, byte_offset, hf_key))
+
+            # Compute per-expert byte size
+            expert_nbytes = 1
+            for d in single_expert_shape:
+                expert_nbytes *= d
+            elem_size = 1 if np_read_dtype == np.uint8 else np.dtype(np_read_dtype).itemsize
+            expert_nbytes *= elem_size
+
+            # Read all expert data from files (parallel across files)
+            expert_data_map = {}  # log_idx -> np.ndarray
+
+            def _bulk_read_file(fname, entries):
+                entries.sort(key=lambda e: e[1])
+                min_off = entries[0][1]
+                max_end = entries[-1][1] + expert_nbytes
+                rng = max_end - min_off
+                actual = len(entries) * expert_nbytes
+                result = {}
+                if rng <= actual * 2 and len(entries) > 1:
+                    with open(fname, "rb") as f:
+                        f.seek(min_off)
+                        bulk = f.read(rng)
+                    for log_idx, byte_off, hf_key in entries:
+                        local_off = byte_off - min_off
+                        arr = np.frombuffer(
+                            bulk,
+                            dtype=np_read_dtype,
+                            count=expert_nbytes // elem_size,
+                            offset=local_off,
+                        ).reshape(single_expert_shape)
+                        result[log_idx] = arr.copy()
+                else:
+                    with open(fname, "rb") as f:
+                        for log_idx, byte_off, hf_key in entries:
+                            f.seek(byte_off)
+                            raw = f.read(expert_nbytes)
+                            arr = np.frombuffer(
+                                raw,
+                                dtype=np_read_dtype,
+                            ).reshape(single_expert_shape)
+                            result[log_idx] = arr
+                return result
+
+            t_io_start = time.monotonic()
+            if len(file_groups) > 1:
+                with ThreadPoolExecutor(max_workers=len(file_groups)) as ex:
+                    futs = {
+                        ex.submit(_bulk_read_file, fn, ents): fn for fn, ents in file_groups.items()
+                    }
+                    for fut in futs:
+                        expert_data_map.update(fut.result())
+            else:
+                for fn, ents in file_groups.items():
+                    expert_data_map.update(_bulk_read_file(fn, ents))
+            t_io = time.monotonic() - t_io_start
+            total_read_mb = sum(v.nbytes for v in expert_data_map.values()) / 1e6
+
+            # Assemble per-device arrays and device_put (parallel)
+            t_assemble_start = time.monotonic()
+            n_experts_per_shard = len(local_assignments[0])
+
+            def _build_and_put(dev_idx):
+                dev = local_devices[dev_idx]
+                phys_indices = local_assignments[dev_idx]
+                shard = np.empty(
+                    (n_experts_per_shard, *single_expert_shape),
+                    dtype=np_read_dtype,
+                )
+                for pos, p in enumerate(phys_indices):
+                    log_idx = (
+                        int(physical_to_logical_map[p])
+                        if physical_to_logical_map is not None
+                        else p
+                    )
+                    shard[pos] = expert_data_map[log_idx]
+                shard = _view_as_fp8_if_needed(shard, target_dtype)
+                return jax.device_put(shard, dev)
+
+            with ThreadPoolExecutor(max_workers=n_local) as ex:
+                per_device_arrays = list(ex.map(_build_and_put, range(n_local)))
+            t_assemble = time.monotonic() - t_assemble_start
+
+            result = jax.make_array_from_single_device_arrays(
+                stacked_shape,
+                sharding,
+                per_device_arrays,
+            )
+            t_callback = time.monotonic() - t0
+
+            logger.debug(
+                "MoE host-bulk load: shape=%s dtype=%s "
+                "io=%.2fs (%.1f MB, %.1f MB/s) "
+                "assemble+put=%.2fs total=%.2fs "
+                "experts_read=%d files=%d devices=%d",
+                stacked_shape,
+                target_dtype,
+                t_io,
+                total_read_mb,
+                total_read_mb / t_io if t_io > 0 else 0,
+                t_assemble,
+                t_callback,
+                len(expert_data_map),
+                len(file_groups),
+                n_local,
+            )
+        else:
+            # Pre-warm safetensors file handles to avoid cold-start latency
+            # during serial callbacks. This is especially important for small
+            # tensors (scales) where GCSFuse file-open latency dominates.
+            unique_files = set()
+            for i in range(num_logical_experts):
+                hf_key = expected_hf_keys[i]
+                unique_files.add(weight_info[hf_key][0]["file"])
+            uncached = [fn for fn in unique_files if fn not in file_manager.handles]
+            if uncached:
+
+                def _prewarm(fn):
+                    return fn, safe_open(fn, framework="np", device="cpu")
+
+                with ThreadPoolExecutor(max_workers=min(len(uncached), 16)) as ex:
+                    for fn, handle in ex.map(_prewarm, uncached):
+                        file_manager.handles[fn] = handle
+
+            callback_fn = _load_stacked_slice
+            result = jax.make_array_from_callback(
+                stacked_shape,
+                sharding,
+                callback_fn,
+            )
+            t_callback = time.monotonic() - t0
+        t1 = time.monotonic()
+        if result.dtype != target_dtype:
+            result = result.astype(target_dtype)
+        t_astype = time.monotonic() - t1
+        # Deferred transpose: data was loaded in HF layout [experts, out, in],
+        # now transpose to kernel layout [experts, in, out] on TPU.
+        t2 = time.monotonic()
+        if defer_transpose and result.ndim >= 3:
+            result = jnp.transpose(result, (0, 2, 1))
+        t_defer = time.monotonic() - t2
+        if _callback_times:
+            defer_msg = f" defer_transpose={t_defer:.3f}s" if defer_transpose else ""
+            logger.debug(
+                "MoE tensor load: shape=%s dtype=%s callbacks=%d "
+                "callback_total=%.2fs (min=%.3fs max=%.3fs) "
+                "make_array=%.2fs astype=%.2fs workers=%d%s",
+                stacked_shape,
+                target_dtype,
+                len(_callback_times),
+                sum(_callback_times),
+                min(_callback_times),
+                max(_callback_times),
+                t_callback,
+                t_astype,
+                LOAD_WORKERS,
+                defer_msg,
+            )
+        return result
 
     def load_weights_from_safetensors(
         self,
@@ -957,6 +1874,8 @@ class WeightLoader:
 
                 can_optimize = (
                     isinstance(mapping.target_path, str)
+                    and not mapping.target_path.startswith("__FUSED_QKV_")
+                    and not mapping.target_path.startswith("__KV_")
                     and mapping.reshape is None
                     and mapping.repeat is None  # Check repeat here too!
                     and not mapping.kv_head_padding
@@ -1122,6 +2041,7 @@ class WeightLoader:
                         final_sharding = jax.sharding.NamedSharding(self.mesh, P(*mapping.sharding))
 
                     # 2. Call creator
+                    _t_load_start = time.monotonic()
                     stacked_weight = self._create_stacked_moe_lazy_tensor(
                         expected_hf_keys,
                         weight_info,
@@ -1130,6 +2050,7 @@ class WeightLoader:
                         target_sharding=final_sharding,  # Global loading
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )
+                    _t_load = time.monotonic() - _t_load_start
                     loaded_shape = stacked_weight.shape
 
                     if mapping.reshape is not None:
@@ -1149,7 +2070,7 @@ class WeightLoader:
                     )
 
                     if is_static_quant and moe_key.endswith("_scale"):
-                        logger.info(
+                        logger.debug(
                             "MoE scale debug group=%s target=%s loaded_shape=%s final_shape=%s "
                             "param_shape=%s reshape=%s repeat=%s sharding=%s",
                             moe_key,
@@ -1163,10 +2084,22 @@ class WeightLoader:
                         )
 
                     try:
+                        _t_assign_start = time.monotonic()
                         if stacked_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                             model_param.value = stacked_weight
                         else:
                             model_param.value = stacked_weight.astype(model_param.value.dtype)
+                        _t_assign = time.monotonic() - _t_assign_start
+                        logger.debug(
+                            "MoE group %s: load=%.2fs assign=%.2fs total=%.2fs "
+                            "shape=%s sharding=%s",
+                            moe_key,
+                            _t_load,
+                            _t_assign,
+                            _t_load + _t_assign,
+                            loaded_shape,
+                            mapping.sharding,
+                        )
                     except Exception as e:
                         logger.error(
                             "Failed MoE assign group=%s target=%s loaded_shape=%s final_shape=%s "
@@ -1247,7 +2180,7 @@ class WeightLoader:
                     )
 
                     if is_static_quant and moe_key.endswith("_scale"):
-                        logger.info(
+                        logger.debug(
                             "Split-MoE scale debug group=%s target=%s loaded_shape=%s final_shape=%s "
                             "param_shape=%s reshape=%s repeat=%s sharding=%s",
                             moe_key,
@@ -1500,6 +2433,23 @@ class WeightLoader:
                 )
             return
 
+        # Handle fused QKV buffer storage (used by MiMo-V2-Pro per-shard dequant).
+        # target_path like "__FUSED_QKV_WEIGHT__42" stores into model._fused_qkv_buffers.
+        if jax_path.startswith("__FUSED_QKV_"):
+            if hasattr(self.model, "_fused_qkv_buffers"):
+                is_scale = "SCALE" in jax_path
+                layer_idx = int(jax_path.rsplit("__", 1)[-1])
+                buf = self.model._fused_qkv_buffers.setdefault(layer_idx, {})
+                np_weight = np.asarray(processed_weight)
+                buf["scale" if is_scale else "weight"] = np_weight
+                logger.info(
+                    "Stored fused QKV %s for layer %d, shape=%s (CPU numpy)",
+                    "scale" if is_scale else "weight",
+                    layer_idx,
+                    np_weight.shape,
+                )
+            return
+
         # Apply output_multiplier_scale to lm_head weights (matching PyTorch implementation)
         if "lm_head" in hf_key and hasattr(self.model_config.hf_config, "output_multiplier_scale"):
             logger.info(
@@ -1555,13 +2505,18 @@ class WeightLoader:
     ):
         jax_paths = mapping.target_path
 
+        v_head_dim = getattr(self, "v_head_dim", self.head_dim_original)
+        v_head_dim_pad = (v_head_dim + 127) // 128 * 128 - v_head_dim
+        v_head_dim_padded = v_head_dim + v_head_dim_pad
+
         if hf_key.endswith(".bias"):
             q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
 
             q_bias = weight[:q_dim]
-            k_bias = weight[q_dim : q_dim + kv_dim]
-            v_bias = weight[q_dim + kv_dim : q_dim + 2 * kv_dim]
+            k_bias = weight[q_dim : q_dim + k_dim]
+            v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 q_bias = jnp.reshape(q_bias, (self.num_heads, self.head_dim_original))
@@ -1572,23 +2527,56 @@ class WeightLoader:
                 k_bias = jnp.pad(k_bias, ((0, 0), (0, self.head_dim_pad)))
                 k_bias = jnp.reshape(k_bias, (self.num_kv_heads * self.head_dim,))
 
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, self.head_dim_original))
-                v_bias = jnp.pad(v_bias, ((0, 0), (0, self.head_dim_pad)))
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * self.head_dim,))
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, v_head_dim))
+                v_bias = jnp.pad(v_bias, ((0, 0), (0, v_head_dim_pad)))
+                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * v_head_dim_padded,))
 
             splits = [q_bias, k_bias, v_bias]
+        elif "scale" in hf_key and weight.ndim == 2:
+            # Block-quant scale: split along block dimension, not element dimension.
+            # The fused QKV scale has shape [total_blocks, in_blocks] where blocks
+            # are computed per Q/K/V segment independently.
+            import math
+
+            quant_cfg = getattr(self.model_config, "quantization_config", None)
+            block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+            q_dim = self.num_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+
+            q_blocks = math.ceil(q_dim / block_size)
+            k_blocks = math.ceil(k_dim / block_size)
+            # V gets remaining blocks (may include padding to head_dim_original)
+            v_blocks = weight.shape[0] - q_blocks - k_blocks
+
+            logger.info(
+                "Splitting QKV scale %s shape=%s into Q=%d K=%d V=%d blocks",
+                hf_key,
+                weight.shape,
+                q_blocks,
+                k_blocks,
+                v_blocks,
+            )
+
+            q_scale = weight[:q_blocks, :]
+            k_scale = weight[q_blocks : q_blocks + k_blocks, :]
+            v_scale = weight[q_blocks + k_blocks :, :]
+
+            splits = [q_scale, k_scale, v_scale]
         else:
             q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
 
             if mapping.transpose:
                 q_weight = weight[:, :q_dim]
-                k_weight = weight[:, q_dim : q_dim + kv_dim]
-                v_weight = weight[:, q_dim + kv_dim : q_dim + 2 * kv_dim]
+                k_weight = weight[:, q_dim : q_dim + k_dim]
+                v_weight = weight[:, q_dim + k_dim : q_dim + k_dim + v_dim]
             else:
                 q_weight = weight[:q_dim, :]
-                k_weight = weight[q_dim : q_dim + kv_dim, :]
-                v_weight = weight[q_dim + kv_dim : q_dim + 2 * kv_dim, :]
+                k_weight = weight[q_dim : q_dim + k_dim, :]
+                v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 if mapping.transpose:
@@ -1609,15 +2597,6 @@ class WeightLoader:
                     k_weight = jnp.reshape(
                         k_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
                     )
-
-                    v_weight = jnp.reshape(
-                        v_weight,
-                        (self.hidden_size, self.num_kv_heads, self.head_dim_original),
-                    )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, self.head_dim_pad)))
-                    v_weight = jnp.reshape(
-                        v_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
-                    )
                 else:
                     q_weight = jnp.reshape(
                         q_weight,
@@ -1637,13 +2616,24 @@ class WeightLoader:
                         k_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
                     )
 
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                if mapping.transpose:
                     v_weight = jnp.reshape(
                         v_weight,
-                        (self.num_kv_heads, self.head_dim_original, self.hidden_size),
+                        (self.hidden_size, self.num_kv_heads, v_head_dim),
                     )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, v_head_dim_pad)))
                     v_weight = jnp.reshape(
-                        v_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
+                        v_weight, (self.hidden_size, self.num_kv_heads * v_head_dim_padded)
+                    )
+                else:
+                    v_weight = jnp.reshape(
+                        v_weight,
+                        (self.num_kv_heads, v_head_dim, self.hidden_size),
+                    )
+                    v_weight = jnp.pad(v_weight, ((0, 0), (0, v_head_dim_pad), (0, 0)))
+                    v_weight = jnp.reshape(
+                        v_weight, (self.num_kv_heads * v_head_dim_padded, self.hidden_size)
                     )
 
             splits = [q_weight, k_weight, v_weight]
@@ -1657,6 +2647,11 @@ class WeightLoader:
             sharded_weight = self._shard_weight(processed_weight, mapping.sharding)
 
             model_param = self._get_param(params, jax_path)
+
+            # Expand 2D block-quant scale to 3D kernel-ready layout.
+            sharded_weight = self._maybe_expand_linear_block_scale(
+                sharded_weight, model_param, jax_path
+            )
 
             if sharded_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                 model_param.value = sharded_weight
@@ -1776,76 +2771,3 @@ class WeightLoader:
 
         layer_num = int(parts[2])
         return layer_num >= self.model_config.num_hidden_layers
-
-
-def replicate_kv_heads(
-    layers,
-    mesh: jax.sharding.Mesh,
-    head_dim: int,
-    v_head_dim: int,
-    target_kv_heads: int,
-):
-    """Replicate KV heads for TP alignment when the weight loader missed them.
-
-    When v_head_dim != head_dim, the weight loader's _apply_kv_head_padding
-    can't pattern-match v_proj shapes. This function fixes that by checking
-    actual weight dims against expected (tp-aligned) dims and replicating.
-
-    Args:
-        layers: List of decoder layers, each with self_attn containing k_proj/v_proj.
-        mesh: JAX mesh for sharding.
-        head_dim: K/Q head dimension.
-        v_head_dim: V head dimension (may differ from head_dim).
-        target_kv_heads: Target number of KV heads after TP alignment.
-    """
-    from jax.sharding import NamedSharding
-    from jax.sharding import PartitionSpec as P
-
-    from sgl_jax.srt.layers.linear import LinearBase
-
-    for layer_idx, layer in enumerate(layers):
-        attn = layer.self_attn
-
-        for proj_name, hd in [
-            ("k_proj", head_dim),
-            ("v_proj", v_head_dim),
-        ]:
-            proj = getattr(attn, proj_name)
-            w = proj.weight.value
-            expected_size = target_kv_heads * hd
-            actual_size = w.shape[1]
-
-            if actual_size == expected_size:
-                continue
-
-            if actual_size > 0 and expected_size % actual_size == 0:
-                num_replicas = expected_size // actual_size
-                orig_kv = actual_size // hd
-
-                logger.info(
-                    "KV head replication: layer %d %s %d→%d heads (%d→%d)",
-                    layer_idx,
-                    proj_name,
-                    orig_kv,
-                    target_kv_heads,
-                    actual_size,
-                    expected_size,
-                )
-
-                w_full = jax.device_put(w, NamedSharding(mesh, P()))
-                w_3d = w_full.reshape(w.shape[0], orig_kv, hd)
-                w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
-                w_new = w_rep.reshape(w.shape[0], expected_size)
-                w_new = jax.device_put(w_new, NamedSharding(mesh, P(None, "tensor")))
-
-                with jax.set_mesh(mesh):
-                    new_linear = LinearBase(
-                        input_size=w.shape[0],
-                        output_size=expected_size,
-                        kernel_axes=proj.kernel_axes,
-                        use_bias=False,
-                        params_dtype=jnp.bfloat16,
-                        mesh=mesh,
-                    )
-                    new_linear.weight = nnx.Param(w_new)
-                setattr(attn, proj_name, new_linear)

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -517,6 +517,7 @@ suites = {
         TestFile("test/srt/openai_server/features/test_structural_tag.py", 2),
         TestFile("test/srt/test_srt_engine.py", 1),
         TestFile("test/srt/test_logprobs.py", 3),
+        TestFile("test/srt/test_penalty.py", 12),
         TestFile("test/srt/test_qwen1_5_models_dummy.py", 3),
         TestFile("test/srt/lora/test_bgmv_backend.py", 6),
         TestFile("test/srt/lora/test_dynamic_lora.py", 10),

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -1,0 +1,227 @@
+"""
+Functional tests for penalty parameters (frequency / presence / combined).
+
+Ports sglang PR #11931 to sgl-jax (aligned with the evolved upstream form
+that uses vocabulary diversity + fixed seeds for stability). Validates that
+penalty params actually shape token output distribution, not merely that
+the server accepts them.
+
+Note: sgl-jax does not currently implement repetition_penalty
+(no BatchedRepetitionPenalizer in penaltylib/), so no test here passes
+repetition_penalty.
+
+Usage:
+    python3 -m unittest test_penalty.TestPenalty -v
+"""
+
+import re
+import unittest
+
+import requests
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestPenalty(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            device="tpu",
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--random-seed",
+                "3",
+                "--mem-fraction-static",
+                "0.65",
+                "--max-prefill-tokens",
+                "8192",
+                "--download-dir",
+                "/dev/shm/",
+                "--dtype",
+                "bfloat16",
+                "--attention-backend",
+                "fa",
+                "--page-size",
+                "64",
+                "--max-running-requests",
+                "64",
+            ],
+            env={
+                "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def run_generate_with_prompt(self, prompt, sampling_params, max_tokens=100, seed=None):
+        """POST to /v1/chat/completions with the given prompt and params."""
+        sampling_params = sampling_params.copy()
+        sampling_params.setdefault("temperature", 0.05)
+        sampling_params.setdefault("top_p", 1.0)
+        if seed is not None:
+            sampling_params["seed"] = seed
+
+        response = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+                **sampling_params,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        content = result["choices"][0]["message"]["content"]
+        return content
+
+    def _get_vocab_diversity(self, text):
+        """Calculate vocabulary diversity as unique_words / total_words.
+
+        Higher values mean more diverse (less repetitive) text.
+        """
+        words = re.findall(r"\b\w+\b", text.lower())
+        if not words:
+            return 1.0
+        return len(set(words)) / len(words)
+
+    def _test_penalty_effect(
+        self,
+        prompt,
+        baseline_params,
+        penalty_params,
+        expected_reduction=True,
+        max_tokens=150,
+    ):
+        """Generic test for penalty effects using vocabulary diversity.
+
+        Measures unique_words/total_words ratio instead of counting a specific
+        word, because penalties affect ALL token probabilities -- the model may
+        avoid some repeated tokens while using others more.
+        """
+        # Use higher temperature so penalties can actually affect token selection.
+        # The default temperature (0.05) is near-greedy, making penalty adjustments
+        # to logits ineffective since the top token still dominates.
+        baseline_params = baseline_params.copy()
+        penalty_params = penalty_params.copy()
+        baseline_params.setdefault("temperature", 0.8)
+        penalty_params.setdefault("temperature", 0.8)
+
+        base_seed = 42
+        baseline_diversities = []
+        penalty_diversities = []
+
+        for i in range(5):
+            seed = base_seed + i
+            baseline_output = self.run_generate_with_prompt(
+                prompt, baseline_params, max_tokens, seed=seed
+            )
+            penalty_output = self.run_generate_with_prompt(
+                prompt, penalty_params, max_tokens, seed=seed
+            )
+
+            baseline_diversities.append(self._get_vocab_diversity(baseline_output))
+            penalty_diversities.append(self._get_vocab_diversity(penalty_output))
+
+        avg_baseline = sum(baseline_diversities) / len(baseline_diversities)
+        avg_penalty = sum(penalty_diversities) / len(penalty_diversities)
+
+        if expected_reduction:
+            self.assertGreater(
+                avg_penalty,
+                avg_baseline,
+                f"Penalty should increase vocab diversity: "
+                f"{avg_baseline:.3f} -> {avg_penalty:.3f}",
+            )
+        else:
+            self.assertLess(
+                avg_penalty,
+                avg_baseline,
+                f"Negative penalty should decrease vocab diversity: "
+                f"{avg_baseline:.3f} -> {avg_penalty:.3f}",
+            )
+
+    def test_frequency_penalty_reduces_word_repetition(self):
+        """frequency_penalty should increase vocabulary diversity."""
+        prompt = (
+            "Write exactly 10 very small sentences, each containing the word "
+            "'data'. Use the word 'data' as much as possible."
+        )
+        baseline_params = {"frequency_penalty": 0.0}
+        penalty_params = {"frequency_penalty": 1.99}
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
+
+    def test_presence_penalty_reduces_topic_repetition(self):
+        """presence_penalty should increase vocabulary diversity."""
+        prompt = (
+            "Write the word 'machine learning' exactly 20 times in a row, " "separated by spaces."
+        )
+        baseline_params = {"presence_penalty": 0.0}
+        penalty_params = {"presence_penalty": 1.99}
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
+
+    def test_combined_penalties_reduce_repetition(self):
+        """Combined frequency + presence penalties should increase vocab diversity."""
+        prompt = (
+            "Write exactly 10 short sentences, each containing the word 'data'. "
+            "Use the word 'data' as much as possible."
+        )
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        penalty_params = {
+            "frequency_penalty": 1.99,
+            "presence_penalty": 1.99,
+        }
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
+
+    def test_penalty_edge_cases_negative_penalty_values(self):
+        """Negative penalty values should decrease vocabulary diversity."""
+        prompt = "Write the word 'test' exactly 15 times in a row, separated by spaces."
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        negative_penalty_params = {
+            "frequency_penalty": -0.5,
+            "presence_penalty": -0.25,
+        }
+        self._test_penalty_effect(
+            prompt,
+            baseline_params,
+            negative_penalty_params,
+            expected_reduction=False,
+        )
+
+    def test_penalty_edge_cases_extreme_penalty_values(self):
+        """Extreme penalty values should strongly increase vocabulary diversity."""
+        prompt = "Write the word 'extreme' exactly 20 times in a row, separated by spaces."
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        extreme_penalty_params = {
+            "frequency_penalty": 2.0,
+            "presence_penalty": 2.0,
+        }
+        self._test_penalty_effect(prompt, baseline_params, extreme_penalty_params)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
## Summary

Fixes the structural KV double-free in sgl-jax that triggers `token_to_kv_pool_allocator memory leak detected!` on every plain `engine.async_generate` call (no abort/retract needed to reproduce).

Ports upstream sglang's `kv_committed_len` / `kv_allocated_len` tracking model + single `release_kv_cache(req, tree_cache)` entry point. Also fixes a separate but related page-tail double-free in `RadixCache.cache_finished_req`.

**Diagnosis (4-config matrix on Qwen3-8B, single 13-token prompt, `max_new_tokens=200`):**

| page_size | radix | before | over-count |
|---|---|---|---|
| 1 | on  | LEAK +1 | direct exposure |
| 1 | off | LEAK +1 | direct exposure |
| 4 | on  | LEAK +4 | page-granularity amplifies sub-page slot |
| 4 | off | NO_LEAK | masked by `PagedAllocator.setdiff1d` defense |

A fixed 1-slot double-free: the decode-step-N slot was freed by both `RadixCache.cache_finished_req` (via the indirect `len(input)+max(len(output)-1,0)` formula) **and** the ad-hoc `out_cache_loc[i:i+1]` free in `process_batch_result_decode`'s overlap branch.

**Changes:**
- `Req` now carries `kv_committed_len` / `kv_allocated_len` / `cache_protected_len` (+ 2 freed-flag guards)
- New `release_kv_cache(req, tree_cache)` in `mem_cache/common.py` orchestrates: `cache_finished_req` → free over-allocated `[committed, allocated)` range → `req_to_token_pool.free`
- `RadixCache.cache_finished_req` and `ChunkCache.cache_finished_req` use `pop_committed_kv_cache()` (not the indirect formula) and stop calling `req_to_token_pool.free` (handed off to `release_kv_cache`)
- Two ad-hoc `out_cache_loc[i:i+1]` free blocks in `scheduler_output_processor_mixin.py` (the structural source of the double-free) are deleted
- Page-tail double-free in `RadixCache.cache_finished_req` (line 280 + 299 both freed `kv_indices[page_aligned_len:]` when `page_size > 1`) is fixed by removing the line-280 free
- EAGLE finished free path (`mixin:305-321`) and abort/retract paths are out of scope

**Spec & plan included:**
- `docs/superpowers/specs/2026-04-27-kv-over-alloc-tracking-design.md`
- `docs/superpowers/plans/2026-04-27-kv-over-alloc-tracking.md`

## Test plan

- [ ] `test/srt/test_engine_determine_generation.py::TestEngineDeterministicGeneration::test_1` passes with `(page_size, disable_radix_cache)` ∈ {(1, False), (1, True), (4, False), (4, True)} on TPU v6e 2x2 (in-flight on `brian-deepseek-test`)
- [ ] `scheduler.check_memory()` invariant `available + evictable + protected == max_total_num_tokens` holds throughout
- [ ] No regression on default-config smoke run

🤖 Generated with [Claude Code](https://claude.com/claude-code)