### PR TITLE
fix: support SWA radix cache

### DIFF
--- a/docs/basic_usage/mimo_v2.5_pro.md
+++ b/docs/basic_usage/mimo_v2.5_pro.md
@@ -1,0 +1,275 @@
+# MiMo-V2.5-Pro on SGL-JAX
+
+MiMo-V2.5-Pro is Xiaomi's large-scale MoE model with hybrid attention (full attention + sliding window attention) and FP8-quantized weights, optimized for long-context reasoning. SGL-JAX supports it on TPU v6e and v7x with FP8 dequantization, tensor parallelism, and expert parallelism.
+
+This cookbook walks through setting up a multi-node TPU slice and serving MiMo-V2.5-Pro end-to-end. The primary reference configuration is **TPU v7x-16** (`2x2x4`, 4 nodes); a TPU v6e-64 (`4x4x4`, 16 nodes) launch command is also provided.
+
+## Hardware Requirements
+
+| TPU Type | Topology | Chips per node | Nodes | Total chips |
+|----------|----------|----------------|-------|-------------|
+| v7x      | 2x2x4    | 4              | 4     | 16          |
+| v6e      | 4x4x4    | 4              | 16    | 64          |
+
+All nodes must be in the same TPU slice and able to reach each other on the JAX init port (`5000` by default below) and the TPU process port (`8471`).
+
+## Environment Setup
+
+### 1. Start a JAX TPU container on each node
+
+Use the official JAX 0.8.1 TPU image:
+
+```bash
+docker run -it --privileged \
+  --shm-size=32g \
+  --ipc=host \
+  --network=host \
+  -v /dev:/dev \
+  us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.8.1-rev1 bash
+```
+
+> The same image is used by SGL-JAX's GKE / SkyPilot launchers; pinning to `jax0.8.1-rev1` keeps the JAX runtime in lockstep with the SGL-JAX `[tpu]` extras.
+
+### 2. Clone and install SGL-JAX
+
+```bash
+git clone https://github.com/sgl-project/sglang-jax.git
+cd sglang-jax
+git fetch origin
+pip install -e "python[tpu]"
+```
+
+This installs `sgl-jax` together with its TPU-specific dependencies (matching `jax==0.8.1`).
+
+### 3. (Optional) Install evalscope for accuracy evaluation
+
+```bash
+pip install evalscope==0.17.1
+```
+
+## Launching the Server
+
+Run the **same** command on every node, only varying `${NODE_RANK}` and pointing all nodes at the rank-0 host via `${MASTER_ADDR}` (e.g. `node0.cluster.local:5000`).
+
+### TPU v7x (16 chips, 4 nodes, `2x2x4`)
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+    --model-path XiaomiMiMo/MiMo-V2.5-Pro \
+    --trust-remote-code \
+    --tp-size 32 --ep-size 32 \
+    --moe-backend fused \
+    --host 0.0.0.0 --port 30271 \
+    --disable-radix-cache \
+    --page-size 256 --context-length 262144 \
+    --chunked-prefill-size 4096 \
+    --dtype bfloat16 --mem-fraction-static 0.95 \
+    --swa-full-tokens-ratio 0.25 \
+    --log-level info --max-running-requests 512 \
+    --nnodes 4 --node-rank ${NODE_RANK} \
+    --dist-init-addr ${MASTER_ADDR}
+```
+
+`${NODE_RANK}` ranges from `0` to `3`.
+
+### TPU v6e (64 chips, 16 nodes, `4x4x4`)
+
+```bash
+JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+    --model-path XiaomiMiMo/MiMo-V2.5-Pro \
+    --trust-remote-code \
+    --port 30271 \
+    --tp-size 64 --ep-size 64 \
+    --context-length 262144 --max-seq-len 4096 \
+    --chunked-prefill-size 4096 --max-prefill-tokens 16384 \
+    --page-size 256 \
+    --mem-fraction-static 0.92 \
+    --max-running-requests 512 \
+    --swa-full-tokens-ratio 0.15 \
+    --attention-backend fa --moe-backend fused \
+    --disable-radix-cache \
+    --nnodes 16 --node-rank ${NODE_RANK} \
+    --dist-init-addr ${MASTER_ADDR}
+```
+
+`${NODE_RANK}` ranges from `0` to `15`. Compared to the v7x recipe, the v6e command lowers `mem-fraction-static` to `0.92` and tightens `swa-full-tokens-ratio` to `0.15` because v6e has less HBM per chip.
+
+### Key flags
+
+- `--tp-size / --ep-size`: Match the total JAX device count across all nodes. v7x exposes 2 logical devices per chip (32 = 16 chips × 2); v6e exposes 1 (64 = 64 chips × 1).
+- `--moe-backend fused`: Uses the fused Pallas MoE kernel (recommended). `epmoe` is also supported but slower at this scale.
+- `--page-size 256`: Required page size for the SWA pool's eviction logic. Smaller page sizes are not supported with MiMo-V2.5-Pro.
+- `--context-length 262144`: 256K context. Match this to your workload's max prompt + output length.
+- `--chunked-prefill-size 4096`: Splits long prefills into 4K-token chunks to bound peak HBM during prefill.
+- `--swa-full-tokens-ratio`: Fraction of the KV cache pool reserved for full-attention layers. `0.25` for v7x, `0.15` for v6e.
+- `--mem-fraction-static`: Fraction of HBM reserved for weights + KV cache. Lower if the host shares the TPU.
+- `--max-running-requests 512`: Upper bound on concurrent decoding requests.
+- `--disable-radix-cache`: Required for now — radix cache is not yet supported.
+- `JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache`: Persists XLA / Pallas compilation cache so subsequent restarts skip the ~4-minute precompile step.
+
+## Running on GKE (Indexed Job)
+
+For Kubernetes / GKE deployments, the four nodes are launched as an Indexed Job + headless Service so that pod `${index}` resolves to a stable DNS name. Below is a minimal manifest for a TPU v7x `2x2x4` slice. Adjust `nodeSelector`, `claimName`, and `image` for your cluster.
+
+```yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mimo-v2-5-pro-headless-svc
+spec:
+  clusterIP: None
+  selector:
+    job-name: mimo-v2-5-pro
+  ports:
+  - name: dist-init
+    port: 5000
+  - name: tpu-process
+    port: 8471
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mimo-v2-5-pro
+spec:
+  backoffLimit: 0
+  completionMode: Indexed
+  parallelism: 4
+  completions: 4
+  template:
+    metadata:
+      annotations:
+        gke-gcsfuse/volumes: "true"
+    spec:
+      subdomain: mimo-v2-5-pro-headless-svc
+      restartPolicy: Never
+      serviceAccountName: gcs-account
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: tpu7x
+        cloud.google.com/gke-tpu-topology: 2x2x4
+      containers:
+      - name: mimo-v2-5-pro
+        image: us-docker.pkg.dev/cloud-tpu-images/jax-ai-image/tpu:jax0.8.1-rev1
+        command: ["bash", "-lc"]
+        args:
+        - |
+          set -euxo pipefail
+
+          # --- 1. Clone & install ---
+          REPO_DIR=/tmp/sglang-jax
+          if [ ! -d "$REPO_DIR/.git" ]; then
+            git clone https://github.com/sgl-project/sglang-jax.git "$REPO_DIR"
+          fi
+          cd "$REPO_DIR" && git fetch origin && pip install -e "python[tpu]"
+
+          # --- 2. Launch the server ---
+          export NODE_RANK=${JOB_COMPLETION_INDEX}
+          export MASTER_ADDR=mimo-v2-5-pro-0.mimo-v2-5-pro-headless-svc:5000
+          JAX_COMPILATION_CACHE_DIR=/tmp/jit_cache python -m sgl_jax.launch_server \
+              --model-path /models/MiMo-V2.5-Pro \
+              --trust-remote-code \
+              --tp-size 32 --ep-size 32 \
+              --moe-backend fused \
+              --host 0.0.0.0 --port 30271 \
+              --disable-radix-cache \
+              --page-size 256 --context-length 262144 \
+              --chunked-prefill-size 4096 \
+              --dtype bfloat16 --mem-fraction-static 0.95 \
+              --swa-full-tokens-ratio 0.25 \
+              --log-level info --max-running-requests 512 \
+              --nnodes 4 --node-rank ${NODE_RANK} \
+              --dist-init-addr ${MASTER_ADDR}
+        env:
+        - name: TPU_PROCESS_ADDRESSES
+          value: mimo-v2-5-pro-0.mimo-v2-5-pro-headless-svc:8471,mimo-v2-5-pro-1.mimo-v2-5-pro-headless-svc:8471,mimo-v2-5-pro-2.mimo-v2-5-pro-headless-svc:8471,mimo-v2-5-pro-3.mimo-v2-5-pro-headless-svc:8471
+        - name: TPU_WORKER_HOSTNAMES
+          value: mimo-v2-5-pro-0.mimo-v2-5-pro-headless-svc,mimo-v2-5-pro-1.mimo-v2-5-pro-headless-svc,mimo-v2-5-pro-2.mimo-v2-5-pro-headless-svc,mimo-v2-5-pro-3.mimo-v2-5-pro-headless-svc
+        - name: TPU_PROCESS_PORT
+          value: "8471"
+        - name: JOB_COMPLETION_INDEX
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['batch.kubernetes.io/job-completion-index']
+        - name: TPU_WORKER_ID
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['batch.kubernetes.io/job-completion-index']
+        ports:
+        - containerPort: 30271
+          name: http
+        - containerPort: 5000
+          name: dist-init
+        resources:
+          requests:
+            google.com/tpu: "4"
+          limits:
+            google.com/tpu: "4"
+        volumeMounts:
+        - mountPath: /models
+          name: model-storage
+        - mountPath: /dev/shm
+          name: dev-shm
+      volumes:
+      - name: dev-shm
+        emptyDir:
+          medium: Memory
+      - name: gke-gcsfuse-cache
+        emptyDir:
+          medium: Memory
+      - name: model-storage
+        persistentVolumeClaim:
+          claimName: <your-model-pvc>
+```
+
+Apply with:
+
+```bash
+kubectl apply -f mimo-v2-5-pro.yaml
+kubectl wait --for=condition=Ready pod -l job-name=mimo-v2-5-pro --timeout=600s
+```
+
+The server is ready once `mimo-v2-5-pro-0` logs `Uvicorn running on http://0.0.0.0:30271`.
+
+## Sending a Request
+
+```bash
+curl -X POST http://<rank0-ip>:30271/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "XiaomiMiMo/MiMo-V2.5-Pro",
+    "messages": [{"role": "user", "content": "Prove that sqrt(2) is irrational."}],
+    "temperature": 1, "top_p": 0.95, "max_tokens": 4096
+  }'
+```
+
+## Accuracy Evaluation
+
+### AIME 2025 (with thinking enabled)
+
+```bash
+evalscope eval \
+    --model XiaomiMiMo/MiMo-V2.5-Pro \
+    --api-url http://127.0.0.1:30271/v1/chat/completions \
+    --api-key EMPTY \
+    --eval-type service \
+    --datasets aime25 \
+    --eval-batch-size 16 \
+    --timeout 6000000 \
+    --generation-config '{"temperature":1,"top_p":0.95,"max_tokens":131072,"chat_template_kwargs":{"enable_thinking":true}}'
+```
+
+Reference numbers measured on TPU v7x-16 (`2x2x4`, `tp=32 ep=32`):
+
+| Model         | Dataset | Metric        | Subset      | Num | Score   |
+|:--------------|:--------|:--------------|:------------|:----|:--------|
+| MiMo-V2.5-Pro   | aime25  | AveragePass@1 | AIME2025-I  | 15  | 0.8667  |
+| MiMo-V2.5-Pro   | aime25  | AveragePass@1 | AIME2025-II | 15  | 1.0000  |
+| MiMo-V2.5-Pro   | aime25  | AveragePass@1 | OVERALL     | 30  | 0.9334  |
+
+## Known Issues
+
+- Radix cache cannot be enabled yet — always pass `--disable-radix-cache`.
+
+## Additional Resources
+
+- [MiMo-V2.5-Pro Model Card](https://huggingface.co/XiaomiMiMo/MiMo-V2.5-Pro)

--- a/docs/design/swa_eviction_and_lru_strategy.md
+++ b/docs/design/swa_eviction_and_lru_strategy.md
@@ -1,0 +1,325 @@
+# SWA Eviction and LRU Strategy
+
+## 1. Dual-Pool Architecture
+
+```
++-----------------------------------------------------------+
+|                      KV Cache Memory                      |
+|                                                           |
+|  +-------------------------+  +-------------------------+ |
+|  |       Full Pool         |  |        SWA Pool         | |
+|  |   (Full Attention lys)  |  |   (Sliding Window lys)  | |
+|  |                         |  |                         | |
+|  |   Grows with seqlen     |  |   Bounded by window     | |
+|  |   Never evicted per-req |  |   Evicted outside window| |
+|  +-------------------------+  +-------------------------+ |
+|                                                           |
+|  Linked by full_to_swa_index_mapping:                     |
+|    full_idx --> swa_idx  (or 0 if SWA freed)              |
++-----------------------------------------------------------+
+```
+
+### Key Terms
+
+| Term | Meaning |
+|------|---------|
+| `swa_evicted_seqlen` | SWA slots `[0, swa_evicted_seqlen)` have been freed |
+| `protected prefix` | Prefix `[0, protected_prefix_len)` owned by the radix tree, derived from the request's locked `last_node` path; per-request eviction cannot touch it |
+| `last_matched_prefix_len` | Page-aligned cached prefix length kept on the request for writeback / retract bookkeeping |
+| `tombstone` | Tree node: full KV retained, SWA KV freed |
+
+## 2. Two Cache Modes at a Glance
+
+```
+ChunkCache (--disable-radix-cache)       SWARadixCache (radix cache enabled)
++-------------------------------+        +-------------------------------+
+| No tree. Request owns all     |        | Radix tree caches KV for     |
+| slots. Freed on completion.   |        | prefix reuse across reqs.    |
+| No prefix sharing.            |        | Tree outlives requests.      |
++-------------------------------+        +-------------------------------+
+```
+
+## 3. Per-Request SWA Eviction
+
+Frees SWA slots outside the sliding window from a request's `req_to_token` buffer.
+
+Two code paths, depending on cache mode:
+
+**ChunkCache path** (`ScheduleBatch._evict_swa`):
+```
+_evict_swa(req, pre_len, sliding_window_size, page_size):
+
+  # If tree_cache is SWARadixCache, delegate to evict_req_swa (see below)
+  1. Target: new_evicted = max(swa_evicted_seqlen, pre_len - sliding_window - page_size)
+  2. Align:  new_evicted = page_floor(new_evicted)   [only if page_size > 1]
+  3. Free:   free_swa( slots[swa_evicted_seqlen : new_evicted] )
+```
+
+**SWARadixCache path** (`SWARadixCache.evict_req_swa`):
+```
+evict_req_swa(req, pre_len):
+
+  1. Derive: protected_prefix_len = _node_prefix_len(req.last_node)
+  2. Clamp:  swa_evicted_seqlen = max(swa_evicted_seqlen, protected_prefix_len)
+  3. Target: new_evicted = max(swa_evicted_seqlen, pre_len - sliding_window - page_size)
+  4. Align:  new_evicted = page_floor(new_evicted)   [only if page_size > 1]
+  5. Free:   free_swa( slots[swa_evicted_seqlen : new_evicted] )
+```
+
+Steps 1-2 are unique to the SWARadixCache path — they protect the tree-owned
+prefix from being evicted. The `- page_size` safety margin in step 3 prevents
+`swa_evicted_seqlen` from reaching the live leaf boundary, ensuring
+`_insert_helper` can always create a non-tombstone leaf.
+
+```
+Example (sliding_window=128, page_size=256, seqlen=2049, decode pre_len=2048):
+
+  ChunkCache path: new_evicted = 2048 - 128 - 256 = 1664
+                   page_floor(1664, 256) = 1536
+
+  0         1536         2048
+  |..........|############|
+   freed SWA   retained
+               (window + page)
+  ^                        ^
+  swa_evicted=1536    seqlen=2049
+```
+
+### When does it run?
+
+| Phase  | ChunkCache | SWARadixCache                             |
+|--------|------------|-------------------------------------------|
+| Extend | Yes        | **No** (skipped; `isinstance(tree_cache, ChunkCache)` gate) |
+| Decode | Yes        | Yes (delegates to `evict_req_swa` with tree-derived protected prefix) |
+
+## 4. Extend Phase Behavior
+
+### 4.1 ChunkCache -- Proactive Eviction
+
+With overlap scheduling, `pre_len` is shifted back by `chunked_prefill_size`
+when `enable_overlap=True` and `req.is_chunked > 0`.
+There is no explicit `extend_batch_idx` gate — the first two chunks naturally
+produce no eviction because `pre_len - chunked_prefill_size` is too small to
+exceed `sliding_window + page_size`.
+
+```
+8K tokens, chunk_size=2048, sliding_window=128, page_size=256, overlap=True
+
+       0       2048      4096      6144      8192
+       |        |         |         |         |
+Chk 1: |########|                              pre_len=0-2048<0, no eviction
+       alloc [0,2048)
+
+Chk 2: |################|                     pre_len=2048-2048=0, no eviction
+       alloc [0,4096)
+
+Chk 3: |.........|################|           pre_len=4096-2048=2048
+       freed     retained                     new_evicted=2048-128-256=1664
+       [0,1536)                                page_floor(1664,256)=1536
+
+Chk 4: |..................|################|  pre_len=6144-2048=4096
+       freed              retained            new_evicted=4096-128-256=3712
+       [0,3584)                                page_floor(3712,256)=3584
+
+  . = freed SWA    # = retained SWA
+```
+
+Without overlap (`enable_overlap=False`), `pre_len` is not adjusted.
+Each chunk directly evicts based on the full `len(req.prefix_indices)`:
+
+```
+Chk 1: |########|                              pre_len=0, nothing
+Chk 2: |........|################|             pre_len=2048, evict [0,1536)
+Chk 3: |.................|################|    pre_len=4096, evict [1536,3584)
+```
+
+### 4.2 SWARadixCache -- Deferred to Tree
+
+```
+8K tokens, chunk_size=2048, sliding_window=128, page_size=256
+
+       0       2048      4096      6144      8192
+       |        |         |         |         |
+Chk 1: |########|
+       _evict_swa: SKIPPED
+       cache_unfinished_req --> tree owns [0,2048), all non-tombstone
+       protected prefix = 2048 (derived from last_node)
+
+Chk 2: |################|
+       _evict_swa: SKIPPED
+       cache_unfinished_req --> tree owns [0,4096), all non-tombstone
+       protected prefix = 4096 (derived from last_node)
+
+       ... chunks 3, 4 ...  protected prefix = 8192
+
+First decode step:
+  protected_prefix_len = prefix_len(last_node) = 8192
+  swa_evicted = max(0, 8192) = 8192
+  new_evicted = max(8192, 8192-128-256) = 8192
+  --> NO EVICTION (all tree-protected)
+
+  # = SWA in tree (non-tombstone, only freed by tree Phase 2)
+```
+
+**Trade-off**: Prefill SWA slots stay in tree until pool pressure triggers
+tree-level eviction. The ownership boundary now lives inside the cache layer
+instead of a request field, but prefill is still less SWA-efficient than ChunkCache.
+
+## 5. Tree-Level Eviction (SWARadixCache)
+
+Triggered by allocation pressure (`evict_from_tree_cache` when pool space < needed).
+
+### Phase 1 -- Full Eviction (delete leaf nodes)
+
+Frees **both** full + SWA KV. Removes node from tree entirely.
+
+```
+Before:                             After evicting leaf B:
+
+root --> [A 0..2048] --> [B] leaf   root --> [A 0..2048] --> [C] leaf
+                     --> [C] leaf
+                                    B: full+SWA freed, node deleted
+
+If parent becomes childless tombstone --> cascade delete:
+
+root --> [A tombstone] --> [B] leaf       root (empty)
+         only child                       A, B both deleted
+```
+
+### Phase 2 -- SWA-Only Eviction (tombstone internal nodes)
+
+Uses `swa_lru_list` to find LRU nodes. Two sub-cases:
+
+**Internal node** (has children): frees **only SWA** KV via `free_swa()`.
+Full KV kept for prefix matching. Node becomes a tombstone, removed from
+`swa_lru_list` but stays in `full_lru_list`.
+
+**Leaf node** (no children): cannot become tombstone (leaf-must-not-be-tombstone
+invariant), so it is fully deleted — frees **both** full + SWA via `free()`,
+removed from both LRU lists, then cascade delete fires on parent.
+
+```
+Internal node case:
+
+Before:                                After Phase 2 on node A:
+
+root --> [A 0..2048] --> [B] leaf      root --> [A 0..2048] --> [B] leaf
+          full+SWA   --> [C] leaf               TOMBSTONE   --> [C] leaf
+                                                 full only
+```
+
+### Gradual Tombstone Progression (LRU order, head --> tail)
+
+```
+          [0..2048]    [2048..4096]   [4096..6144]   [6144..8192]
+
+Initial:  full+SWA --> full+SWA  --> full+SWA  --> full+SWA
+
+Round 1:  TOMBSTONE--> full+SWA  --> full+SWA  --> full+SWA
+          full only
+
+Round 2:  TOMBSTONE--> TOMBSTONE --> full+SWA  --> full+SWA
+          full only    full only
+
+Round 3:  TOMBSTONE--> TOMBSTONE --> TOMBSTONE --> full+SWA
+          full only    full only     full only     ^ only tail
+                                                     retains SWA
+```
+
+## 6. Tombstone Insert Logic
+
+`_insert_helper` has two sets of tombstone branch logic:
+
+- **Inside the while loop**: healing of **existing** tombstone nodes
+- **After the while loop**: tombstone split when creating **new** nodes
+
+### 6.1 Existing Tombstone Healing (while loop)
+
+When insert walks through an existing tombstone node beyond
+`update_kv_after_len`, it checks `swa_evicted_seqlen` against
+`[node_start, node_end)`:
+
+```
+  BRANCH 1: swa_evicted <= node_start  --> revive entire node
+  BRANCH 2: node_start < swa_evicted < node_end --> split, revive back half
+  BRANCH 3: swa_evicted >= node_end    --> keep tombstone, free incoming value
+```
+
+Branch 1 fires during `cache_unfinished_req` (`swa_evicted_seqlen = 0`)
+when `_match_prefix_helper` truncated the prefix due to tombstone safety.
+
+Branches 2/3 fire during `cache_finished_req` when a prior request's
+decode nodes have been tombstoned and the current request generated
+identical decode tokens (e.g. greedy decoding with the same prefix).
+
+### 6.2 New Node Tombstone Split (after while loop)
+
+When insert has remaining unmatched tokens (`len(key) > 0`), it creates
+new nodes.  Invariant: **leaf nodes must never be tombstone**.
+
+```
+  Case 1: swa_evicted <= total_prefix_length
+          --> create non-tombstone leaf (normal path for cache_unfinished_req)
+
+  Case 2: total_prefix_length < swa_evicted < total_prefix_length + len(key)
+          --> split into tombstone prefix + non-tombstone leaf
+              (normal path for cache_finished_req: decode suffix split)
+
+  Case 3: swa_evicted >= total_prefix_length + len(key)
+          --> all remaining SWA evicted, cannot create non-tombstone leaf
+              free incoming value and return (defensive guard, kept safe
+              by the extra `- page_size` in `_evict_swa` frontier)
+```
+
+### 6.3 Trigger Conditions
+
+| Call site | `swa_evicted_seqlen` | Existing tombstone | New nodes |
+|-----------|---------------------|--------------------|-----------|
+| `cache_unfinished_req` | Always 0 | Branch 1 only | Case 1 only |
+| `cache_finished_req` | >= protected prefix length | Prefill nodes: skip zone. Prior req's decode nodes: Branch 1/2/3 | Case 2 (normal), Case 3 (defensive) |
+
+## 7. LRU Policy
+
+```
++-----------------------------------------------------+
+|                   full_lru_list                     |
+|  Tracks: ALL non-root nodes                         |
+|  Used by: Phase 1 (find LRU leaf for full eviction) |
+|                                                     |
+|  LRU <--- old nodes --- recent nodes ---> MRU       |
++-----------------------------------------------------+
+
++-----------------------------------------------------+
+|                   swa_lru_list                      |
+|  Tracks: non-root, NON-TOMBSTONE nodes only         |
+|  Used by: Phase 2 (find LRU node for SWA eviction)  |
+|                                                     |
+|  Tombstone nodes REMOVED from this list.            |
+|  Revived nodes RE-INSERTED at MRU.                  |
++-----------------------------------------------------+
+```
+
+On prefix match, the **deepest matched node** and all ancestors are
+reset to MRU in both lists, keeping frequently accessed prefixes fresh.
+
+## 8. Summary
+
+```
++-------------------+-----------------+------------------------+
+|                   | ChunkCache      | SWARadixCache          |
++-------------------+-----------------+------------------------+
+| Extend SWA evict  | Proactive       | Skipped                |
+|                   | (per chunk)     | (tree handles)         |
++-------------------+-----------------+------------------------+
+| Decode SWA evict  | From pos 0      | From                   |
+|                   |                 | protected tree prefix  |
++-------------------+-----------------+------------------------+
+| Prefill SWA waste | Low (bounded)   | Higher (until          |
+|                   |                 | Phase 2 evicts)        |
++-------------------+-----------------+------------------------+
+| Prefix reuse      | None            | Yes (via tree)         |
++-------------------+-----------------+------------------------+
+| SWA reclamation   | Per-request     | Tree Phase 2           |
+|                   | _evict_swa      | (reactive, LRU)        |
++-------------------+-----------------+------------------------+
+```

--- a/python/sgl_jax/srt/managers/schedule_batch.py
+++ b/python/sgl_jax/srt/managers/schedule_batch.py
@@ -375,14 +375,13 @@ class Req:
     ):
         self.fill_ids = self.origin_input_ids + self.output_ids
         if tree_cache is not None:
-            (
-                self.prefix_indices,
-                self.last_node,
-                self.last_host_node,
-                self.host_hit_length,
-            ) = tree_cache.match_prefix(
+            match_result = tree_cache.match_prefix(
                 key=RadixKey(self.adjust_max_prefix_ids(), self.extra_key),
             )
+            self.prefix_indices = match_result.device_indices
+            self.last_node = match_result.last_device_node
+            self.last_host_node = match_result.last_host_node
+            self.host_hit_length = match_result.host_hit_length
             self.last_matched_prefix_len = len(self.prefix_indices)
         self.extend_input_len = len(self.fill_ids) - len(self.prefix_indices)
 
@@ -753,7 +752,11 @@ class ScheduleBatch:
 
     def _evict_swa(self, req: Req, pre_len: int, sliding_window_size: int, page_size: int):
         """Evict SWA pool tokens outside the sliding window for a single request."""
-        new_evicted = max(req.swa_evicted_seqlen, pre_len - sliding_window_size)
+        if isinstance(self.tree_cache, SWARadixCache):
+            self.tree_cache.evict_req_swa(req, pre_len)
+            return
+
+        new_evicted = max(req.swa_evicted_seqlen, pre_len - sliding_window_size - page_size)
         if page_size > 1:
             new_evicted = (new_evicted // page_size) * page_size
         if new_evicted <= req.swa_evicted_seqlen:
@@ -761,10 +764,7 @@ class ScheduleBatch:
         free_slots = self.req_to_token_pool.req_to_token[
             req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
         ]
-        num_swa_freed = self.token_to_kv_pool_allocator.count_swa_mapped(free_slots)
         self.token_to_kv_pool_allocator.free_swa(free_slots)
-        if num_swa_freed > 0 and isinstance(self.tree_cache, SWARadixCache):
-            self.tree_cache.adjust_swa_protected_size(-num_swa_freed)
         req.swa_evicted_seqlen = new_evicted
 
     def maybe_evict_swa(self, sliding_window_size=None):
@@ -782,17 +782,20 @@ class ScheduleBatch:
         )
 
         if self.forward_mode is not None and self.forward_mode.is_decode():
-            # Evict at the smaller of sliding_window_size and page_size to avoid
-            # stale SWA slot accumulation.
             evict_interval = max(min(sliding_window_size, page_size), 1)
+            evict_phase = 1 if evict_interval > 1 else 0
             for req in self.reqs:
-                if req.decode_batch_idx > 0 and (
-                    evict_interval <= 1 or req.decode_batch_idx % evict_interval == 1
+                if (
+                    req.decode_batch_idx > 0
+                    and req.decode_batch_idx % evict_interval == evict_phase
                 ):
                     self._evict_swa(req, req.seqlen - 1, sliding_window_size, page_size)
             return
 
         if self.forward_mode is None or not self.forward_mode.is_extend():
+            return
+
+        if not isinstance(self.tree_cache, ChunkCache):
             return
 
         for i, req in enumerate(self.reqs):
@@ -813,8 +816,7 @@ class ScheduleBatch:
         self.forward_mode = ForwardMode.EXTEND
 
         # Evict SWA tokens before allocating, so the SWA pool has space.
-        if self.is_hybrid:
-            self.maybe_evict_swa()
+        self.maybe_evict_swa()
 
         # Allocate req slots
         bs = len(self.reqs)
@@ -1051,7 +1053,7 @@ class ScheduleBatch:
             self.req_to_token_pool.free(req.req_pool_idx)
         else:
             last_uncached_pos = (
-                len(req.prefix_indices) // server_args.page_size
+                req.last_matched_prefix_len // server_args.page_size
             ) * server_args.page_size
             token_indices = self.req_to_token_pool.req_to_token[
                 req.req_pool_idx, last_uncached_pos : seq_lens_cpu[idx]
@@ -1096,8 +1098,7 @@ class ScheduleBatch:
         bs = len(self.reqs)
 
         # Evict SWA tokens outside sliding window
-        if self.is_hybrid:
-            self.maybe_evict_swa()
+        self.maybe_evict_swa()
 
         if self.spec_algorithm is not None and self.spec_algorithm.is_eagle():
             # if spec decoding is used, the decode batch is prepared inside
@@ -1411,7 +1412,7 @@ class ScheduleBatch:
         total_cache_loc_size = cache_loc_paddings[select_bs_index]
         assert total_cache_loc_size >= len(cache_loc_flat)
 
-        cache_loc_cpu = np.empty(total_cache_loc_size, dtype=np.int32)
+        cache_loc_cpu = np.zeros(total_cache_loc_size, dtype=np.int32)
         if len(cache_loc_flat) > 0:
             cache_loc_cpu[: len(cache_loc_flat)] = cache_loc_flat
         # Initialize padding area to ensure multiprocess consistency

--- a/python/sgl_jax/srt/managers/schedule_policy.py
+++ b/python/sgl_jax/srt/managers/schedule_policy.py
@@ -147,11 +147,13 @@ class SchedulePolicy:
             prefix_ids = r.adjust_max_prefix_ids()
             extra_key = r.extra_key
             # NOTE: the prefix_indices must always be aligned with last_node
-            r.prefix_indices, r.last_node, r.last_host_node, r.host_hit_length = (
-                self.tree_cache.match_prefix(
-                    rid=r.rid, key=RadixKey(token_ids=prefix_ids, extra_key=extra_key)
-                )
+            match_result = self.tree_cache.match_prefix(
+                rid=r.rid, key=RadixKey(token_ids=prefix_ids, extra_key=extra_key)
             )
+            r.prefix_indices = match_result.device_indices
+            r.last_node = match_result.last_device_node
+            r.last_host_node = match_result.last_host_node
+            r.host_hit_length = match_result.host_hit_length
 
             # NOTE(sang): This logic is for in-batch prefix caching;
             # If there are more than 1 request that have small matching prefix from
@@ -161,9 +163,10 @@ class SchedulePolicy:
             # threshold means we cannot use in-batch prefix caching for short prefixes.
             # It is kind of common when the engine is long running (e.g., imagine the prefix "the").
             if len(r.prefix_indices) <= IN_BATCH_PREFIX_CACHING_CHECK_THRESHOLD:
-                in_batch_matching_prefixes, _, _, _ = self.waiting_queue_radix_tree.match_prefix(
+                in_batch_match = self.waiting_queue_radix_tree.match_prefix(
                     rid=r.rid, key=RadixKey(token_ids=prefix_ids, extra_key=extra_key)
                 )
+                in_batch_matching_prefixes = in_batch_match.device_indices
                 if (
                     len(in_batch_matching_prefixes)
                     >= IN_BATCH_PREFIX_CACHING_DEPRIORITIZE_THRESHOLD

--- a/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
+++ b/python/sgl_jax/srt/mem_cache/swa_radix_cache.py
@@ -363,7 +363,8 @@ class SWARadixCache(BasePrefixCache):
             last_host_node=last_node,
         )
 
-    def insert(self, key: RadixKey | list, value=None, prev_prefix_len: int = 0) -> int:
+    def insert(self, key: RadixKey | list, value=None, prev_prefix_len: int = 0,
+               swa_evicted_seqlen: int = 0) -> int:
         if self.disable:
             return 0
 
@@ -373,7 +374,8 @@ class SWARadixCache(BasePrefixCache):
 
         if value is None:
             value = [x for x in key.token_ids]
-        return self._insert_helper(self.root_node, key, value, prev_prefix_len)
+        return self._insert_helper(self.root_node, key, value, prev_prefix_len,
+                                    swa_evicted_seqlen=swa_evicted_seqlen)
 
     def cache_finished_req(self, req: Req) -> None:
         """Cache request when it finishes."""
@@ -404,7 +406,8 @@ class SWARadixCache(BasePrefixCache):
         self.insert(
             RadixKey(token_ids[:page_aligned_len], req.extra_key),
             page_aligned_kv_indices,
-            len(req.prefix_indices),
+            req.last_matched_prefix_len,
+            swa_evicted_seqlen=req.swa_evicted_seqlen,
         )
 
         # Remove req slot release the cache lock
@@ -432,33 +435,36 @@ class SWARadixCache(BasePrefixCache):
 
         # Radix Cache takes one ref in memory pool
         # Note: the insert function already frees the overlapped kv_indices
+        old_prefix_len = req.last_matched_prefix_len
         new_prefix_len = self.insert(
             RadixKey(page_aligned_token_ids, req.extra_key),
             page_aligned_kv_indices,
-            len(req.prefix_indices),
+            old_prefix_len,
+            swa_evicted_seqlen=req.swa_evicted_seqlen,
         )
 
-        # The prefix indices could be updated, reuse it
-        new_indices, new_last_node, _, _ = self.match_prefix(
+        match_result = self.match_prefix(
             RadixKey(page_aligned_token_ids, req.extra_key)
         )
-        assert len(req.prefix_indices) <= len(new_indices), f"{req.prefix_indices=}, {new_indices=}"
+        new_indices = match_result.device_indices
+        new_last_node = match_result.last_device_node
+        assert old_prefix_len <= len(new_indices), f"{old_prefix_len=}, {new_indices=}"
         assert new_prefix_len <= len(new_indices), f"{new_prefix_len=}, {new_indices=}"
         self.req_to_token_pool.write(
-            (req.req_pool_idx, slice(len(req.prefix_indices), len(new_indices))),
-            new_indices[len(req.prefix_indices) :],
+            (req.req_pool_idx, slice(old_prefix_len, len(new_indices))),
+            new_indices[old_prefix_len:],
         )
 
         self.dec_lock_ref(req.last_node, req.swa_uuid_for_lock)
         swa_uuid_for_lock = self.inc_lock_ref(new_last_node)
 
-        # `req.prefix_indices` will be used in `PrefillAdder::add_chunked_req` later
         if self.page_size != 1:
-            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices) :]])
+            req.prefix_indices = np.concatenate([new_indices, kv_indices[len(new_indices):]])
         else:
             req.prefix_indices = new_indices
         req.last_node = new_last_node
         req.swa_uuid_for_lock = swa_uuid_for_lock
+        req.last_matched_prefix_len = len(new_indices)
 
     def pretty_print(self) -> None:
         self._print_helper(self.root_node, 0)
@@ -494,7 +500,6 @@ class SWARadixCache(BasePrefixCache):
 
                 # 3. delete the leaf node
                 self._delete_leaf(x)
-                self.swa_evictable_size_ -= actual_swa_free
 
                 # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
                 x, leaf_full_num_evicted = self._iteratively_delete_tombstone_leaf(x)
@@ -529,7 +534,6 @@ class SWARadixCache(BasePrefixCache):
 
                     # 3. tombstone the node
                     self._tombstone_internal_node(x)
-                    self.swa_evictable_size_ -= actual_swa_free
                 else:
                     assert (
                         x.full_lock_ref == 0
@@ -547,7 +551,6 @@ class SWARadixCache(BasePrefixCache):
 
                     # 3. delete the leaf node
                     self._delete_leaf(x)
-                    self.swa_evictable_size_ -= actual_swa_free
 
                     # 4. Iteratively delete tombstone leaves to maintain invariant that leaf nodes are not tombstone
                     self._iteratively_delete_tombstone_leaf(x)
@@ -635,9 +638,8 @@ class SWARadixCache(BasePrefixCache):
         self.full_lru_list.sanity_check(self)
         self.swa_lru_list.sanity_check(self)
 
-    def evictable_size(self) -> tuple[int, int]:
-        # Note: use full_evictable_size() and swa_evictable_size() instead.
-        raise NotImplementedError
+    def evictable_size(self) -> int:
+        return min(self.full_evictable_size_, self.swa_evictable_size_)
 
     def full_evictable_size(self) -> int:
         return self.full_evictable_size_
@@ -678,11 +680,35 @@ class SWARadixCache(BasePrefixCache):
         # protected size refers to the size of the swa cache that is locked
         return self.swa_protected_size_
 
-    def adjust_swa_protected_size(self, delta: int):
-        """Adjust swa_protected_size_ by delta (can be negative)."""
-        if self.disable:
+    def _node_prefix_len(self, node: TreeNode | None) -> int:
+        prefix_len = 0
+        while node and node != self.root_node:
+            prefix_len += len(node.value)
+            node = node.parent
+        return prefix_len
+
+    def evict_req_swa(self, req: "Req", pre_len: int) -> None:
+        protected_prefix_len = self._node_prefix_len(req.last_node)
+        assert protected_prefix_len % self.page_size == 0, (
+            f"protected_prefix_len must be page aligned, "
+            f"{protected_prefix_len=}, {self.page_size=}")
+
+        req.swa_evicted_seqlen = max(req.swa_evicted_seqlen, protected_prefix_len)
+
+        new_evicted = max(
+            req.swa_evicted_seqlen,
+            pre_len - self.sliding_window_size - self.page_size,
+        )
+        if self.page_size > 1:
+            new_evicted = (new_evicted // self.page_size) * self.page_size
+        if new_evicted <= req.swa_evicted_seqlen:
             return
-        self.swa_protected_size_ += delta
+
+        free_slots = self.req_to_token_pool.req_to_token[
+            req.req_pool_idx, req.swa_evicted_seqlen : new_evicted
+        ]
+        self.token_to_kv_pool_allocator.free_swa(free_slots)
+        req.swa_evicted_seqlen = new_evicted
 
     def all_values_flatten(self) -> jnp.Array:
         values = []
@@ -716,9 +742,10 @@ class SWARadixCache(BasePrefixCache):
             child = node.children[child_key]
 
             # update best_value_len and best_last_node if needed
-            if child.swa_tombstone and match_len_since_tombstone >= self.sliding_window_size:
-                best_value_len = len(value)
-                best_last_node = node
+            if child.swa_tombstone:
+                if match_len_since_tombstone >= self.sliding_window_size:
+                    best_value_len = len(value)
+                    best_last_node = node
                 match_len_since_tombstone = 0
 
             prefix_len = self.key_match_fn(child.key, key)
@@ -744,17 +771,16 @@ class SWARadixCache(BasePrefixCache):
             best_value_len = len(value)
             best_last_node = node
 
-        # update time for matched nodes, and make nodes closer to root to be least recently used
-        # this allows swa to evict nodes closer to root first
-        self.full_lru_list.reset_node_and_parents_mru(best_last_node, self.root_node)
-        self.swa_lru_list.reset_node_and_parents_mru(best_last_node, self.root_node)
+        last_node = node
 
-        # This last_access_time is for sanity check, can be deleted after validation in production
+        self.full_lru_list.reset_node_and_parents_mru(last_node, self.root_node)
+        self.swa_lru_list.reset_node_and_parents_mru(last_node, self.root_node)
+
         cur_time = time.monotonic()
-        while node:
-            node.last_access_time = cur_time
+        while last_node:
+            last_node.last_access_time = cur_time
             cur_time -= 0.0001
-            node = node.parent
+            last_node = last_node.parent
 
         return value[:best_value_len], best_last_node
 
@@ -797,7 +823,25 @@ class SWARadixCache(BasePrefixCache):
             self.swa_lru_list.insert_mru(child)
         return new_node
 
-    def _insert_helper(self, node: TreeNode, key: RadixKey, value, update_kv_after_len: int) -> int:
+    def _add_new_node(self, parent: TreeNode, key: RadixKey, value,
+                      swa_tombstone: bool = False) -> TreeNode:
+        assert len(key) > 0
+        child_key = self.get_child_key_fn(key)
+        new_node = TreeNode()
+        new_node.parent = parent
+        new_node.key = key
+        new_node.value = np.array(value, copy=True)
+        new_node.swa_tombstone = swa_tombstone
+        parent.children[child_key] = new_node
+        self.full_lru_list.insert_mru(new_node)
+        self.full_evictable_size_ += len(value)
+        if not swa_tombstone:
+            self.swa_lru_list.insert_mru(new_node)
+            self.swa_evictable_size_ += len(value)
+        return new_node
+
+    def _insert_helper(self, node: TreeNode, key: RadixKey, value,
+                        update_kv_after_len: int, swa_evicted_seqlen: int = 0) -> int:
         # Update the last access time from root to leaf, so that
         # swa will tombstone the node closer to root first
         node.last_access_time = time.monotonic()
@@ -824,24 +868,44 @@ class SWARadixCache(BasePrefixCache):
                 new_node = self._split_node(node, prefix_len)
                 node = new_node
 
-            # if tombstone after update_kv_after_len, update node.value to be the input value.
-            # This is needed because it is possible that the last sliding window size tokens
-            # contains tombstone. If this is the case and we don't update the kv value, then
-            # the prefill prefix matching will stuck.
             if update_kv_after_len < total_prefix_length + prefix_len:
                 first_diff_idx = max(0, update_kv_after_len - total_prefix_length)
+                node_start = total_prefix_length
+                node_end = total_prefix_length + prefix_len
+
                 if node.swa_tombstone:
-                    assert (
-                        node.swa_lock_ref == 0
-                    ), f"tombstone swa_lock_ref should always be 0, {node.full_lock_ref=}, {node.swa_lock_ref=}, {node.id=}"
-                    self.token_to_kv_pool_allocator.free(node.value[first_diff_idx:])
-                    node.value = np.array(value[:prefix_len], copy=True)
-                    node.swa_tombstone = False
+                    assert node.swa_lock_ref == 0, (
+                        f"tombstone swa_lock_ref should always be 0, "
+                        f"{node.full_lock_ref=}, {node.swa_lock_ref=}, {node.id=}")
+                    assert swa_evicted_seqlen % self.page_size == 0, (
+                        f"swa_evicted_seqlen must be page aligned, "
+                        f"{swa_evicted_seqlen=}, {self.page_size=}")
 
-                    # insert the node into the lru lists
-                    self.swa_lru_list.insert_mru(node)
+                    if swa_evicted_seqlen <= node_start:
+                        # Branch 1: Full revive
+                        self.token_to_kv_pool_allocator.free(node.value[first_diff_idx:])
+                        node.value = np.array(value[:prefix_len], copy=True)
+                        node.swa_tombstone = False
+                        self.swa_lru_list.insert_mru(node)
+                        self.swa_evictable_size_ += len(node.value)
 
-                    self.swa_evictable_size_ += self._swa_eff_len(node.value)
+                    elif swa_evicted_seqlen < node_end:
+                        # Branch 2: Partial revive — split at eviction boundary
+                        start_update_idx = swa_evicted_seqlen - node_start
+                        self.token_to_kv_pool_allocator.free(
+                            node.value[start_update_idx:prefix_len])
+                        self._split_node(node, start_update_idx)
+                        node.value = np.array(value[start_update_idx:prefix_len], copy=True)
+                        node.swa_tombstone = False
+                        self.swa_lru_list.insert_mru(node)
+                        self.swa_evictable_size_ += len(node.value)
+                        self.token_to_kv_pool_allocator.free(
+                            value[first_diff_idx:start_update_idx])
+
+                    else:
+                        # Branch 3: Keep tombstone
+                        self.token_to_kv_pool_allocator.free(
+                            value[first_diff_idx:prefix_len])
                 else:
                     self.token_to_kv_pool_allocator.free(value[first_diff_idx:prefix_len])
 
@@ -853,15 +917,19 @@ class SWARadixCache(BasePrefixCache):
                 child_key = self.get_child_key_fn(key)
 
         if len(key):
-            new_node = TreeNode()
-            new_node.parent = node
-            new_node.key = key
-            new_node.value = np.array(value, copy=True)
-            self.full_lru_list.insert_mru(new_node)
-            self.swa_lru_list.insert_mru(new_node)
-            node.children[child_key] = new_node
-            self.full_evictable_size_ += len(value)
-            self.swa_evictable_size_ += self._swa_eff_len(new_node.value)
+            if swa_evicted_seqlen >= total_prefix_length + len(key):
+                self.token_to_kv_pool_allocator.free(value)
+                return total_prefix_length
+
+            if (swa_evicted_seqlen > total_prefix_length
+                    and swa_evicted_seqlen < total_prefix_length + len(key)):
+                swa_tombstone_len = swa_evicted_seqlen - total_prefix_length
+                node = self._add_new_node(node, key[:swa_tombstone_len],
+                                          value[:swa_tombstone_len], swa_tombstone=True)
+                key = key[swa_tombstone_len:]
+                value = value[swa_tombstone_len:]
+
+            self._add_new_node(node, key, value, swa_tombstone=False)
 
         return total_prefix_length
 
@@ -889,24 +957,24 @@ class SWARadixCache(BasePrefixCache):
     def _delete_leaf(self, node: TreeNode) -> None:
         assert not node.swa_tombstone, f"Invariant violated: leaf node is a tombstone, {node.id=}"
         assert len(node.children) == 0, f"leaf node has children, {node.id=}"
-        for k, v in node.parent.children.items():
-            if v == node:
-                break
-        del node.parent.children[k]
+        key = self.get_child_key_fn(node.key)
+        v = node.parent.children.pop(key, None)
+        assert v == node, f"parent does not have child key, {key}"
         self.full_evictable_size_ -= len(node.value)
+        self.swa_evictable_size_ -= len(node.value)
 
     def _tombstone_internal_node(self, node: TreeNode) -> None:
         assert len(node.children) != 0, f"Cannot tombstone a leaf node, {node.id=}"
         node.swa_tombstone = True
+        self.swa_evictable_size_ -= len(node.value)
 
     def _delete_tombstone_leaf(self, node: TreeNode) -> None:
         assert node.swa_tombstone, f"Deleting a unexpected non-tombstone leaf node, {node.id=}"
         assert len(node.children) == 0, f"leaf node has children, {node.id=}"
-        for k, v in node.parent.children.items():
-            if v == node:
-                break
-        del node.parent.children[k]
-        self.full_evictable_size_ -= len(node.key)
+        key = self.get_child_key_fn(node.key)
+        v = node.parent.children.pop(key, None)
+        assert v == node, f"parent does not have child key, {key}"
+        self.full_evictable_size_ -= len(node.value)
 
     def _collect_leaves(self) -> list[TreeNode]:
         ret_list = []

--- a/python/sgl_jax/srt/models/mimo_v2_flash.py
+++ b/python/sgl_jax/srt/models/mimo_v2_flash.py
@@ -19,16 +19,13 @@ from sgl_jax.srt.layers.moe import EPMoE, GateLogit, TopK, create_moe_weights_ma
 from sgl_jax.srt.layers.radix_attention import RadixAttention
 from sgl_jax.srt.mem_cache.memory_pool import KVCache
 from sgl_jax.srt.model_executor.forward_batch_info import ForwardBatch
-from sgl_jax.srt.utils.weight_utils import (
-    WeightLoader,
-    WeightMapping,
-    replicate_kv_heads,
-)
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 
 logger = logging.getLogger(__name__)
 
 
 class MiMoV2MLP(nnx.Module):
+
     def __init__(
         self,
         hidden_size: int,
@@ -73,6 +70,7 @@ class MiMoV2MLP(nnx.Module):
 
 
 class MiMoV2Moe(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -148,6 +146,7 @@ class MiMoV2Moe(nnx.Module):
 
 
 class MiMoV2Attention(nnx.Module):
+
     def __init__(
         self,
         hidden_size: int,
@@ -292,6 +291,7 @@ class MiMoV2Attention(nnx.Module):
 
 
 class MiMoV2DecoderLayer(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -425,6 +425,7 @@ class MiMoV2DecoderLayer(nnx.Module):
 
 
 class MiMoV2Model(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -482,6 +483,7 @@ class MiMoV2Model(nnx.Module):
 
 
 class MiMoV2FlashForCausalLM(nnx.Module):
+
     def __init__(
         self,
         config: PretrainedConfig,
@@ -493,7 +495,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self.dtype = dtype
         self.model = MiMoV2Model(config, dtype=self.dtype, mesh=mesh)
         # Buffer to hold raw FP8 K/V weights+scales for per-head fused dequant.
-        # Populated during weight loading, consumed by _dequant_fused_kv_heads.
+        # Populated during weight loading, consumed by WeightLoader.dequant_fused_kv().
         self._kv_buffers: dict[int, dict] = {}
 
         if not getattr(self.config, "tie_word_embeddings", True):
@@ -508,7 +510,11 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         self.logits_processor = LogitsProcessor(config.vocab_size, mesh=self.mesh)
 
     def load_weights(self, model_config: ModelConfig):
-        loader = WeightLoader(
+        # Pre-warm GCSFuse cache: sequential read of large safetensors files
+        # dramatically speeds up subsequent random-access MoE expert loading.
+        self._warmup_safetensors_cache(model_config)
+
+        self.loader = WeightLoader(
             model=self,
             model_config=model_config,
             mesh=self.mesh,
@@ -516,386 +522,78 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         )
         self._quant_config = model_config.quantization_config
         weight_mappings = self._create_weight_mappings()
-        loader.load_weights_from_safetensors(weight_mappings)
+        self.loader.load_weights_from_safetensors(weight_mappings)
         logger.info("MiMoV2Flash weights loaded successfully!")
 
         # Post-load: dequantize FP8 attention + layer-0 MLP to bf16.
-        # Q/K head_dim padding (192→256) is handled by the kernel internally.
-        if self._is_static_quant:
-            self._dequantize_fp8_to_bf16()
-            # K+V: fused per-head dequant (cross K/V boundary blocks)
-            self._dequant_fused_kv_heads()
-            # KV head replication for TP alignment (after K/V are bf16 LinearBase)
-            self._ensure_kv_head_replication()
+        if self.loader.is_static_quant:
+            head_dim = self.config.head_dim
+            v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+            # 1. Dequant Q only (K/V go through fused KV path via _kv_buffers)
+            self.loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[("self_attn.q_proj", head_dim)],
+            )
+            # 2. Fused KV per-head dequant (cross K/V boundary blocks)
+            self.loader.dequant_fused_kv(self._kv_buffers, self.model.layers, self.config)
+            # 3. Layer-0 dense MLP
+            self.loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+                layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
+            )
+            # 4. KV head replication for TP alignment
+            self.loader.replicate_kv_heads(
+                self.model.layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
 
-    def _is_quant_ignored(self, hf_path: str) -> bool:
-        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
-        quant_cfg = getattr(self, "_quant_config", None)
-        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
-            return True  # not quantized at all
-        ignored = quant_cfg.ignored_layers or []
-        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+    @staticmethod
+    def _warmup_safetensors_cache(model_config: ModelConfig):
+        """Pre-read safetensors files to warm GCSFuse cache.
 
-    @property
-    def _is_static_quant(self) -> bool:
-        quant_cfg = getattr(self, "_quant_config", None)
-        return quant_cfg is not None and quant_cfg.is_static_checkpoint
-
-    # ------------------------------------------------------------------
-    # Post-load transforms: dequantize FP8 → BF16, pad head dims
-    # ------------------------------------------------------------------
-
-    def _dequantize_quantized_linear(self, ql, head_dim=None) -> LinearBase:
-        """Dequantize a single QuantizedLinear to bf16 LinearBase.
-
-        weight_q may be in HF layout [out, in] or model layout [in, out]
-        depending on the transpose flag used during loading.
-        weight_scale is in kernel-ready 3D layout [in_blocks, 1, out_dim].
-
-        Handles kv_head_padding: when weight_q has been replicated along the
-        output axis (e.g. 4 kv_heads → 16 for TP), the scale only covers the
-        original (unreplicated) output dimension.  We extract one copy of the
-        original heads, dequantize, then re-replicate in bf16.
-
-        Args:
-            head_dim: If set, enables per-head block quant handling. Required
-                when head_dim % block_size != 0 (e.g., head_dim=192 with
-                block_size=128), as the HF checkpoint uses per-head block
-                boundaries instead of uniform blocks.
+        GCSFuse random reads are ~400ms per tensor (cold) vs ~1ms (warm).
+        Sequential bulk read fills the cache so MoE loading uses warm reads.
         """
-        weight_q = ql.weight_q.value
-        weight_scale = ql.weight_scale.value
-        logger.info(
-            "Dequant debug: weight_q.shape=%s weight_scale.shape=%s kernel_axes=%s head_dim=%s",
-            weight_q.shape,
-            weight_scale.shape,
-            ql.kernel_axes,
-            head_dim,
-        )
+        import glob
+        import os
+        from concurrent.futures import ThreadPoolExecutor
 
-        if weight_scale.ndim == 3:
-            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
-        elif weight_scale.ndim == 2:
-            # 2D block-quant scale: (out_blocks, in_blocks) in HF layout.
-            # Expand to 3D kernel-ready (in_blocks, 1, out_dim) then reuse _block_dequant.
-            from sgl_jax.srt.kernels.quantized_matmul.blockwise_utils import (
-                expand_block_scale,
-            )
-
-            # Determine out_dim: weight_q is (in, out) model layout or (out, in) HF layout.
-            _, in_blocks = weight_scale.shape
-            out_dim = weight_q.shape[1] if weight_q.shape[0] % in_blocks == 0 else weight_q.shape[0]
-            block_size_out = 128
-            scale_3d = expand_block_scale(weight_scale, out_dim, block_size_out)
-            weight_bf16 = self._block_dequant(weight_q, scale_3d, head_dim=head_dim)
-        elif weight_scale.ndim == 1:
-            out_dim = weight_scale.shape[0]
-            if weight_q.shape[1] == out_dim:
-                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
-                    jnp.bfloat16
-                )
-            else:
-                weight_bf16 = (
-                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
-                ).astype(jnp.bfloat16)
-        else:
-            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
-
-        # weight_bf16 is now in model layout [in, out]
-        in_features, out_features = weight_bf16.shape
-
-        with jax.set_mesh(ql.mesh):
-            new_linear = LinearBase(
-                input_size=in_features,
-                output_size=out_features,
-                kernel_axes=ql.kernel_axes,
-                use_bias=ql.bias is not None,
-                params_dtype=jnp.bfloat16,
-                mesh=ql.mesh,
-            )
-            new_linear.weight = nnx.Param(weight_bf16)
-            if ql.bias is not None:
-                new_linear.bias = nnx.Param(ql.bias.value.astype(jnp.bfloat16))
-        return new_linear
-
-    def _block_dequant(
-        self, weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
-    ) -> jax.Array:
-        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
-
-        Returns bf16 weight in model layout [in_dim, out_dim].
-        Handles kv_head_padding where weight_q is larger than scale coverage
-        by tiling the scale to match.
-
-        Args:
-            head_dim: If set, enables per-head block quant handling when scale
-                out_dim doesn't match weight dims. The scale is re-indexed using
-                per-head block boundaries instead of uniform block mapping.
-        """
-        import math
-
-        in_blocks = weight_scale.shape[0]
-        out_dim = weight_scale.shape[2]
-
-        # Detect layout and kv-padding
-        dim0, dim1 = weight_q.shape
-
-        if dim1 == out_dim:
-            # Model layout [in, out], no kv-padding
-            pass
-        elif dim0 == out_dim:
-            # HF layout [out, in] — transpose to model layout
-            weight_q = jnp.transpose(weight_q)
-        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
-            # Per-head block quant: scale was expanded for wrong n_out.
-            # Determine layout: in_dim must be divisible by in_blocks.
-            if dim0 % in_blocks == 0:
-                actual_out = dim1  # model layout [in, out]
-            else:
-                weight_q = jnp.transpose(weight_q)
-                actual_out = dim0  # was HF layout [out, in]
-
-            # Re-index scale using per-head block boundaries.
-            # The wrongly-expanded scale has uniform block mapping (ch // 128),
-            # but we need per-head mapping where each head's blocks are independent.
-            block_size = out_dim // (out_dim // 128) if out_dim >= 128 else 128
-            block_size = 128  # from weight_block_size config
-            blocks_per_head = math.ceil(head_dim / block_size)
-            num_heads = actual_out // head_dim
-
-            # Build gather index: for each output channel, find the corresponding
-            # channel in the uniformly-expanded scale that has the correct block's value.
-            gather_idx = jnp.array(
-                [
-                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
-                    for j in range(actual_out)
-                ]
-            )
-            weight_scale = weight_scale[:, :, gather_idx]  # (in_blocks, 1, actual_out)
-            out_dim = actual_out
-
-            logger.info(
-                "Per-head block dequant: %d heads × head_dim=%d, %d blocks/head, "
-                "remapped scale to (%s)",
-                num_heads,
-                head_dim,
-                blocks_per_head,
-                weight_scale.shape,
-            )
-        elif dim1 > out_dim and dim1 % out_dim == 0:
-            # Model layout [in, kv_padded_out] — tile scale to match
-            kv_replicas = dim1 // out_dim
-            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
-            out_dim = dim1
-            logger.info(
-                "Detected kv_head_padding: tiling scale %dx to match %d out channels",
-                kv_replicas,
-                out_dim,
-            )
-        elif dim0 > out_dim and dim0 % out_dim == 0:
-            # HF layout [kv_padded_out, in] — transpose and tile scale
-            kv_replicas = dim0 // out_dim
-            weight_q = jnp.transpose(weight_q)
-            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
-            out_dim = weight_q.shape[1]
-            logger.info(
-                "Detected kv_head_padding (HF layout): tiling scale %dx to match %d out channels",
-                kv_replicas,
-                out_dim,
-            )
-        else:
-            raise ValueError(
-                f"Cannot match weight_q shape {weight_q.shape} with scale out_dim={out_dim}"
-            )
-
-        # weight_q is now [in_dim, out_dim] in model layout
-        in_dim = weight_q.shape[0]
-        block_k = in_dim // in_blocks
-        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
-        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
-
-        return weight_bf16
-
-    def _dequantize_fp8_to_bf16(self):
-        """Dequantize FP8 QuantizedLinear → bf16 LinearBase.
-
-        Targets:
-        - All layers: self_attn.q_proj, k_proj, v_proj
-        - Layer 0: mlp.gate_proj, up_proj, down_proj (dense MLP only)
-        """
-        from sgl_jax.srt.layers.linear import QuantizedLinear
-
-        for layer_idx, layer in enumerate(self.model.layers):
-            attn = layer.self_attn
-            # Only Q and o_proj go through QuantizedLinear path.
-            # K/V are handled by _dequant_fused_kv_heads (per-head fused dequant).
-            for proj_name in ("q_proj",):
-                proj = getattr(attn, proj_name)
-                if isinstance(proj, QuantizedLinear):
-                    hd = attn.head_dim
-                    setattr(attn, proj_name, self._dequantize_quantized_linear(proj, head_dim=hd))
-                    logger.info("Dequantized layer %d %s → bf16", layer_idx, proj_name)
-
-            # Layer 0 dense MLP
-            if layer_idx == 0 and not layer.is_layer_sparse:
-                for proj_name in ("gate_proj", "up_proj", "down_proj"):
-                    proj = getattr(layer.mlp, proj_name)
-                    if isinstance(proj, QuantizedLinear):
-                        setattr(layer.mlp, proj_name, self._dequantize_quantized_linear(proj))
-                        logger.info("Dequantized layer 0 MLP %s → bf16", proj_name)
-
-        logger.info("FP8 → BF16 dequantization complete.")
-
-    def _ensure_kv_head_replication(self):
-        """Replicate KV heads for TP alignment when the weight loader missed them."""
-        attn = self.model.layers[0].self_attn
-        replicate_kv_heads(
-            layers=self.model.layers,
-            mesh=self.mesh,
-            head_dim=attn.head_dim,
-            v_head_dim=attn.v_head_dim,
-            target_kv_heads=attn.k_head_num,
-        )
-
-    def _uniform_block_dequant(self, weight, scale, block_size):
-        """Simple uniform block dequant for weight[out_dim, in_dim] * scale[out_blocks, in_blocks].
-
-        Used for layers where K/V are quantized uniformly across all heads
-        (no cross-boundary scale sharing between K and V).
-        """
-        out_dim, in_dim = weight.shape
-        out_blocks = scale.shape[0]
-        padded_out = out_blocks * block_size
-        in_blocks = scale.shape[1]
-        if padded_out > out_dim:
-            weight = jnp.pad(weight, ((0, padded_out - out_dim), (0, 0)))
-        w_4d = weight.astype(jnp.float32).reshape(out_blocks, block_size, in_blocks, block_size)
-        s_4d = scale[:, None, :, None]
-        result = (w_4d * s_4d).reshape(padded_out, in_dim)[:out_dim, :].astype(jnp.bfloat16)
-        return result
-
-    def _dequant_fused_kv_heads(self):
-        """Dequantize FP8 K+V weights with per-layer quantization scheme detection.
-
-        Different layers may use different quantization schemes:
-        - Per-head fused: K+V quantized as fused [K(head_dim), V(v_head_dim)] per KV head.
-          Block boundaries cross K/V boundary, so they must be fused for correct dequant.
-          Signature: k_scale_blocks == num_kv_heads * ceil(head_dim/block_size)
-        - Uniform: K and V quantized independently across the whole tensor.
-          No cross-boundary issue, can dequant K and V separately.
-          Signature: k_scale_blocks == ceil(num_kv_heads * head_dim / block_size)
-        """
-        import math
-
-        from jax.sharding import NamedSharding
-
-        kv_buffers = self._kv_buffers
-        if not kv_buffers:
+        model_path = model_config.model_path
+        st_files = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+        if not st_files:
             return
 
-        head_dim = self.config.head_dim
-        v_head_dim = getattr(self.config, "v_head_dim", head_dim)
-        quant_cfg = getattr(self, "_quant_config", None)
-        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+        total_size = sum(os.path.getsize(f) for f in st_files)
+        logger.info(
+            "Warming up GCSFuse cache: %d files, %.1f GB",
+            len(st_files),
+            total_size / 1024**3,
+        )
 
-        fused_dim = head_dim + v_head_dim
-        blocks_per_head = math.ceil(fused_dim / block_size)
-        padded_dim = blocks_per_head * block_size
-        k_blocks_per_head = math.ceil(head_dim / block_size)
-        v_blocks_per_head = blocks_per_head - k_blocks_per_head
+        def _read_file(path):
+            """Read file sequentially to populate GCSFuse cache."""
+            buf = bytearray(4 * 1024 * 1024)  # 4MB buffer
+            with open(path, "rb") as f:
+                while f.readinto(buf):
+                    pass
 
-        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+        import time
 
-        for layer_idx in sorted(kv_buffers.keys()):
-            buf = kv_buffers[layer_idx]
-            k_weight = buf["k_weight"]
-            k_scale = buf["k_scale"]
-            v_weight = buf["v_weight"]
-            v_scale = buf["v_scale"]
-
-            in_dim = k_weight.shape[1]
-            in_blocks = in_dim // block_size
-
-            # Per-layer num_kv_heads from actual weight shape
-            num_kv_heads = k_weight.shape[0] // head_dim
-            k_scale_blocks = k_scale.shape[0]
-
-            # Detect quantization scheme for this layer
-            expected_per_head = num_kv_heads * k_blocks_per_head
-            expected_uniform = math.ceil(num_kv_heads * head_dim / block_size)
-            is_per_head = (
-                k_scale_blocks == expected_per_head and expected_per_head != expected_uniform
-            )
-
-            if is_per_head:
-                # Per-head fused: K+V must be fused because scale blocks cross K/V boundary
-                k_w = k_weight.reshape(num_kv_heads, head_dim, in_dim)
-                v_w = v_weight.reshape(num_kv_heads, v_head_dim, in_dim)
-                k_s = k_scale.reshape(num_kv_heads, k_blocks_per_head, in_blocks)
-                v_s = v_scale.reshape(num_kv_heads, v_blocks_per_head, in_blocks)
-                fused_w = jnp.concatenate([k_w, v_w], axis=1)
-                fused_s = jnp.concatenate([k_s, v_s], axis=1)
-                if fused_dim < padded_dim:
-                    fused_w = jnp.pad(fused_w, ((0, 0), (0, padded_dim - fused_dim), (0, 0)))
-                fused_5d = fused_w.astype(jnp.float32).reshape(
-                    num_kv_heads, blocks_per_head, block_size, in_blocks, block_size
-                )
-                scale_5d = fused_s[:, :, None, :, None]
-                dequanted = (
-                    (fused_5d * scale_5d)
-                    .reshape(num_kv_heads, padded_dim, in_dim)[:, :fused_dim, :]
-                    .astype(jnp.bfloat16)
-                )
-                k_bf16 = dequanted[:, :head_dim, :].reshape(num_kv_heads * head_dim, in_dim)
-                v_bf16 = dequanted[:, head_dim:, :].reshape(num_kv_heads * v_head_dim, in_dim)
-            else:
-                # Uniform: K and V can be dequanted independently
-                k_bf16 = self._uniform_block_dequant(k_weight, k_scale, block_size)
-                v_bf16 = self._uniform_block_dequant(v_weight, v_scale, block_size)
-
-            # Transpose [out, in] → [in, out], shard, replace
-            k_bf16 = jax.device_put(jnp.transpose(k_bf16), tp_sharding)
-            v_bf16 = jax.device_put(jnp.transpose(v_bf16), tp_sharding)
-
-            attn = self.model.layers[layer_idx].self_attn
-            in_k, out_k = k_bf16.shape
-            in_v, out_v = v_bf16.shape
-
-            with jax.set_mesh(self.mesh):
-                k_linear = LinearBase(
-                    input_size=in_k,
-                    output_size=out_k,
-                    kernel_axes=(None, "tensor"),
-                    use_bias=False,
-                    params_dtype=jnp.bfloat16,
-                    mesh=self.mesh,
-                )
-                k_linear.weight = nnx.Param(k_bf16)
-                attn.k_proj = k_linear
-
-                v_linear = LinearBase(
-                    input_size=in_v,
-                    output_size=out_v,
-                    kernel_axes=(None, "tensor"),
-                    use_bias=False,
-                    params_dtype=jnp.bfloat16,
-                    mesh=self.mesh,
-                )
-                v_linear.weight = nnx.Param(v_bf16)
-                attn.v_proj = v_linear
-
-            if layer_idx % 10 == 0 or layer_idx == 0:
-                logger.info(
-                    "Layer %d KV dequant: %s, heads=%d, K=%s V=%s",
-                    layer_idx,
-                    "per-head" if is_per_head else "uniform",
-                    num_kv_heads,
-                    k_bf16.shape,
-                    v_bf16.shape,
-                )
-
-        kv_buffers.clear()
-        logger.info("FP8 KV dequantization complete for all layers.")
+        t0 = time.time()
+        with ThreadPoolExecutor(max_workers=min(8, len(st_files))) as executor:
+            list(executor.map(_read_file, st_files))
+        t1 = time.time()
+        logger.info(
+            "GCSFuse cache warm-up done: %.1fs (%.0f MB/s)",
+            t1 - t0,
+            total_size / 1024**2 / (t1 - t0) if t1 > t0 else 0,
+        )
 
     def _create_weight_mappings(self) -> dict:
         mappings = {
@@ -928,7 +626,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
         target = prefix
 
         mappings = {}
-        is_fp8 = self._is_static_quant
+        is_fp8 = self.loader.is_static_quant
 
         # Attention projections
         for proj, sharding, kv_pad, hd_pad in [
@@ -938,7 +636,7 @@ class MiMoV2FlashForCausalLM(nnx.Module):
             ("o_proj", ("tensor", None), False, True),
         ]:
             hf_key = f"{prefix}.self_attn.{proj}"
-            ignored = self._is_quant_ignored(hf_key)
+            ignored = self.loader.is_quant_ignored(hf_key)
 
             # FP8 K/V: bypass QuantizedLinear, store raw FP8 data for fused
             # per-head dequant (cross K/V boundary blocks).
@@ -1044,6 +742,9 @@ class MiMoV2FlashForCausalLM(nnx.Module):
 
             if is_fp8:
                 augmented = {}
+                # FusedEPMoE scales must live on the model mesh (data, tensor)
+                # to avoid expert-mesh NamedSharding conflicts in shard_map.
+                # EPMoE scales stay on the expert mesh.
                 use_model_mesh_for_scale = moe_backend == "fused"
                 for key, mapping in moe_mappings.items():
                     augmented[key] = mapping

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -19,7 +19,7 @@ from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
 logger = logging.getLogger(__name__)
 
 
-class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+class MiMoV2ForCausalLM(MiMoV2FlashForCausalLM):
 
     def __init__(
         self,
@@ -240,4 +240,4 @@ class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
         return mappings
 
 
-EntryClass = MiMoV2ProForCausalLM
+EntryClass = MiMoV2ForCausalLM

--- a/python/sgl_jax/srt/models/mimo_v2_pro.py
+++ b/python/sgl_jax/srt/models/mimo_v2_pro.py
@@ -1,0 +1,243 @@
+"""MiMo-V2-Pro model implementation for SGLang-JAX.
+
+Inherits from MiMoV2FlashForCausalLM. The main difference is the weight format:
+Pro uses a fused qkv_proj instead of separate q/k/v_proj weights. The FP8
+checkpoint was quantized per-TP-shard and concatenated, so the fused QKV has
+a per-shard-interleaved layout that requires special dequantization handling.
+"""
+
+import logging
+
+import jax
+import jax.numpy as jnp
+from transformers import PretrainedConfig
+
+from sgl_jax.srt.layers.moe import create_moe_weights_mapping
+from sgl_jax.srt.models.mimo_v2_flash import MiMoV2FlashForCausalLM
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+logger = logging.getLogger(__name__)
+
+
+class MiMoV2ProForCausalLM(MiMoV2FlashForCausalLM):
+
+    def __init__(
+        self,
+        config: PretrainedConfig,
+        mesh: jax.sharding.Mesh | None = None,
+        dtype: jnp.dtype = jnp.bfloat16,
+    ):
+        super().__init__(config, mesh, dtype)
+        # Buffer to hold fused QKV FP8 weights/scales before per-shard dequant.
+        # Populated during weight loading, consumed by WeightLoader.dequant_fused_qkv.
+        self._fused_qkv_buffers: dict[int, dict] = {}
+
+    def load_weights(self, model_config):
+        """Load weights with special handling for per-shard-quantized fused QKV."""
+        self.loader = WeightLoader(
+            model=self,
+            model_config=model_config,
+            mesh=self.mesh,
+            dtype=self.dtype,
+        )
+        self._quant_config = model_config.quantization_config
+        weight_mappings = self._create_weight_mappings()
+        self.loader.load_weights_from_safetensors(weight_mappings)
+        logger.info("MiMoV2Pro weights loaded successfully!")
+
+        if self.loader.is_static_quant:
+            head_dim = self.config.head_dim
+            v_head_dim = getattr(self.config, "v_head_dim", head_dim)
+            # Dequantize fused QKV per-shard, then split into Q/K/V bf16.
+            self.loader.dequant_fused_qkv(self._fused_qkv_buffers, self.model.layers, self.config)
+            # Dequantize remaining FP8 weights (layer 0 MLP, etc).
+            self.loader.dequant_fp8_layers(
+                self.model.layers,
+                specs=[
+                    ("mlp.gate_proj", None),
+                    ("mlp.up_proj", None),
+                    ("mlp.down_proj", None),
+                ],
+                layer_filter=lambda idx, layer: idx == 0 and not layer.is_layer_sparse,
+            )
+            self.loader.replicate_kv_heads(
+                self.model.layers,
+                specs=[("self_attn.k_proj", head_dim), ("self_attn.v_proj", v_head_dim)],
+                target_kv_heads_fn=lambda attn: attn.k_head_num,
+            )
+
+    def _create_layer_mappings(self, layer_idx: int) -> dict:
+        """Override to handle fused qkv_proj weights in MiMo-V2-Pro checkpoints."""
+        prefix = f"model.layers.{layer_idx}"
+        target = prefix
+
+        mappings = {}
+        is_fp8 = self.loader.is_static_quant
+
+        # --- Fused QKV projection ---
+        hf_qkv_key = f"{prefix}.self_attn.qkv_proj"
+        qkv_ignored = self.loader.is_quant_ignored(hf_qkv_key)
+
+        if is_fp8 and not qkv_ignored:
+            # FP8 fused QKV: store raw weight+scale in buffer, dequant post-load.
+            # Use a callback mapping that stores into _fused_qkv_buffers instead of
+            # trying to split the per-shard-interleaved data.
+            mappings[f"{hf_qkv_key}.weight"] = WeightMapping(
+                target_path=f"__FUSED_QKV_WEIGHT__{layer_idx}",
+                sharding=(None, None),
+                transpose=False,
+            )
+            mappings[f"{hf_qkv_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"__FUSED_QKV_SCALE__{layer_idx}",
+                sharding=(None, None),
+                transpose=False,
+            )
+        else:
+            # BF16 or ignored: split normally (contiguous Q/K/V layout is fine)
+            qkv_weight_suffix = "weight"
+            mappings[f"{hf_qkv_key}.weight"] = WeightMapping(
+                target_path=[
+                    f"{target}.self_attn.q_proj.{qkv_weight_suffix}",
+                    f"{target}.self_attn.k_proj.{qkv_weight_suffix}",
+                    f"{target}.self_attn.v_proj.{qkv_weight_suffix}",
+                ],
+                sharding=(None, "tensor"),
+                transpose=True,
+                head_dim_padding=False,
+                kv_head_padding=True,
+            )
+
+        # --- o_proj (separate, same as Flash) ---
+        hf_o_key = f"{prefix}.self_attn.o_proj"
+        o_ignored = self.loader.is_quant_ignored(hf_o_key)
+        o_weight_suffix = "weight" if (not is_fp8 or o_ignored) else "weight_q"
+
+        mappings[f"{hf_o_key}.weight"] = WeightMapping(
+            target_path=f"{target}.self_attn.o_proj.{o_weight_suffix}",
+            sharding=("tensor", None),
+            transpose=True,
+            head_dim_padding=True,
+        )
+
+        if is_fp8 and not o_ignored:
+            mappings[f"{hf_o_key}.weight_scale_inv"] = WeightMapping(
+                target_path=f"{target}.self_attn.o_proj.weight_scale",
+                sharding=(None, None),
+                transpose=False,
+            )
+
+        # --- Attention sink bias (same as Flash) ---
+        is_swa = (
+            hasattr(self.config, "hybrid_layer_pattern")
+            and 0 <= layer_idx < len(self.config.hybrid_layer_pattern)
+            and self.config.hybrid_layer_pattern[layer_idx] == 1
+        )
+        has_sink_bias = (is_swa and getattr(self.config, "add_swa_attention_sink_bias", False)) or (
+            not is_swa and getattr(self.config, "add_full_attention_sink_bias", False)
+        )
+        if has_sink_bias:
+            mappings[f"{prefix}.self_attn.attention_sink_bias"] = WeightMapping(
+                target_path=f"{target}.self_attn.attention_sink_bias",
+                sharding=("tensor",),
+                transpose=False,
+            )
+
+        # --- Layernorms (same as Flash) ---
+        mappings[f"{prefix}.input_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.input_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+        mappings[f"{prefix}.post_attention_layernorm.weight"] = WeightMapping(
+            target_path=f"{target}.post_attention_layernorm.scale",
+            sharding=(None,),
+            transpose=False,
+        )
+
+        # --- MLP / MoE (same as Flash) ---
+        is_sparse = (
+            hasattr(self.config, "moe_layer_freq")
+            and 0 <= layer_idx < len(self.config.moe_layer_freq)
+            and not isinstance(self.config.moe_layer_freq, int)
+            and self.config.moe_layer_freq[layer_idx]
+        )
+
+        if is_sparse:
+            mappings[f"{prefix}.mlp.gate.weight"] = WeightMapping(
+                target_path=f"{target}.mlp.moe_gate.kernel",
+                sharding=(None, None),
+                transpose=True,
+            )
+
+            if getattr(self.config, "topk_method", "greedy") == "noaux_tc":
+                mappings[f"{prefix}.mlp.gate.e_score_correction_bias"] = WeightMapping(
+                    target_path=f"{target}.mlp.correction_bias",
+                    sharding=(None,),
+                    transpose=False,
+                )
+
+            num_experts = getattr(
+                self.config,
+                "n_routed_experts",
+                getattr(self.config, "num_experts", 8),
+            )
+            moe_backend = getattr(self.config, "moe_backend", "epmoe")
+
+            moe_mappings = create_moe_weights_mapping(
+                prefix=prefix,
+                target_prefix=target,
+                num_experts=num_experts,
+                moe_backend=moe_backend,
+                moe_path="mlp.experts",
+                source_expert_pattern="{i}",
+            )
+
+            if is_fp8:
+                augmented = {}
+                use_model_mesh_for_scale = moe_backend == "fused"
+                for key, mapping in moe_mappings.items():
+                    augmented[key] = mapping
+                    target_param = mapping.target_path[0]
+                    src_paths = mapping.target_path[1:]
+                    scale_key = key + "_scale"
+                    scale_target = target_param + "_scale"
+                    scale_srcs = [p.replace(".weight", ".weight_scale_inv") for p in src_paths]
+                    scale_sharding = (
+                        (("data", "tensor"), None, None)
+                        if use_model_mesh_for_scale
+                        else ("expert", None, None)
+                    )
+                    augmented[scale_key] = WeightMapping(
+                        target_path=[scale_target] + scale_srcs,
+                        sharding=scale_sharding,
+                        transpose=use_model_mesh_for_scale,
+                        concat_axis=mapping.concat_axis,
+                        physical_to_logical_map=mapping.physical_to_logical_map,
+                    )
+                moe_mappings = augmented
+
+            mappings.update(moe_mappings)
+        else:
+            for proj, sharding in [
+                ("gate_proj", (None, "tensor")),
+                ("up_proj", (None, "tensor")),
+                ("down_proj", ("tensor", None)),
+            ]:
+                hf_key = f"{prefix}.mlp.{proj}"
+                weight_suffix = "weight_q" if is_fp8 else "weight"
+                mappings[f"{hf_key}.weight"] = WeightMapping(
+                    target_path=f"{target}.mlp.{proj}.{weight_suffix}",
+                    sharding=sharding,
+                    transpose=True,
+                )
+                if is_fp8:
+                    mappings[f"{hf_key}.weight_scale_inv"] = WeightMapping(
+                        target_path=f"{target}.mlp.{proj}.weight_scale",
+                        sharding=(None, None),
+                        transpose=False,
+                    )
+
+        return mappings
+
+
+EntryClass = MiMoV2ProForCausalLM

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -1,12 +1,17 @@
 import copy
 import glob
+import json
 import logging
+import math
 import os
 import pickle
 import re
+import struct
+import time
 from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
 import jax
 import jax.numpy as jnp
@@ -14,6 +19,9 @@ import ml_dtypes
 import numpy as np
 from flax import nnx
 from jax.experimental import multihost_utils
+
+if TYPE_CHECKING:
+    from sgl_jax.srt.layers.linear import LinearBase
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 from safetensors import safe_open
@@ -137,6 +145,7 @@ class WeightLoader:
 
             self.head_dim_pad = (self.head_dim_original + 127) // 128 * 128 - self.head_dim_original
             self.head_dim = self.head_dim_original
+            self.v_head_dim = getattr(model_config, "v_head_dim", self.head_dim_original)
         if hasattr(self.mesh, "shape") and "tensor" in self.mesh.shape:
             self.sharding_size = self.mesh.shape["tensor"]
         else:
@@ -152,6 +161,570 @@ class WeightLoader:
             )
         else:
             self.moe_abstract_mesh = None
+
+    # ------------------------------------------------------------------
+    # Quant config helpers
+    # ------------------------------------------------------------------
+
+    @property
+    def is_static_quant(self) -> bool:
+        """Check if the model uses a static FP8 checkpoint."""
+        quant_cfg = getattr(self.model_config, "quantization_config", None)
+        return quant_cfg is not None and quant_cfg.is_static_checkpoint
+
+    def is_quant_ignored(self, hf_path: str) -> bool:
+        """Check if a HuggingFace weight path is in the quantization ignored_layers list."""
+        quant_cfg = getattr(self.model_config, "quantization_config", None)
+        if quant_cfg is None or not quant_cfg.is_static_checkpoint:
+            return True
+        ignored = quant_cfg.ignored_layers or []
+        return any(hf_path == ig or hf_path.endswith(f".{ig}") for ig in ignored)
+
+    # ------------------------------------------------------------------
+    # Post-load hooks: dequant FP8 → BF16, KV head replication
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def create_bf16_linear(
+        weight: jax.Array, kernel_axes, mesh, use_bias=False, bias=None
+    ) -> "LinearBase":
+        """Create a bf16 LinearBase from a weight array [in, out]."""
+        from sgl_jax.srt.layers.linear import LinearBase
+
+        in_features, out_features = weight.shape
+        with jax.set_mesh(mesh):
+            new_linear = LinearBase(
+                input_size=in_features,
+                output_size=out_features,
+                kernel_axes=kernel_axes,
+                use_bias=use_bias,
+                params_dtype=jnp.bfloat16,
+                mesh=mesh,
+            )
+            new_linear.weight = nnx.Param(weight)
+            if bias is not None:
+                new_linear.bias = nnx.Param(bias.astype(jnp.bfloat16))
+        return new_linear
+
+    def dequant_fp8_linear(self, ql, head_dim: int | None = None) -> "LinearBase":
+        """Dequantize a single QuantizedLinear → bf16 LinearBase.
+
+        Handles 3D block-quant scales, 1D per-channel scales, kv_head_padding,
+        and per-head block quant (when head_dim % block_size != 0).
+
+        Args:
+            ql: QuantizedLinear module with weight_q and weight_scale.
+            head_dim: If set, enables per-head block quant handling.
+        """
+        weight_q = ql.weight_q.value
+        weight_scale = ql.weight_scale.value
+
+        if weight_scale.ndim == 3:
+            weight_bf16 = self._block_dequant(weight_q, weight_scale, head_dim=head_dim)
+        elif weight_scale.ndim == 1:
+            out_dim = weight_scale.shape[0]
+            if weight_q.shape[1] == out_dim:
+                weight_bf16 = (weight_q.astype(jnp.float32) * weight_scale[None, :]).astype(
+                    jnp.bfloat16
+                )
+            else:
+                weight_bf16 = (
+                    jnp.transpose(weight_q).astype(jnp.float32) * weight_scale[None, :]
+                ).astype(jnp.bfloat16)
+        else:
+            raise ValueError(f"Unexpected weight_scale ndim={weight_scale.ndim}")
+
+        bias = ql.bias.value if ql.bias is not None else None
+        return self.create_bf16_linear(
+            weight_bf16, ql.kernel_axes, ql.mesh, ql.bias is not None, bias
+        )
+
+    @staticmethod
+    def _block_dequant(
+        weight_q: jax.Array, weight_scale: jax.Array, head_dim: int | None = None
+    ) -> jax.Array:
+        """Block-dequantize weight_q using 3D scale [in_blocks, 1, out_dim].
+
+        Returns bf16 weight in model layout [in_dim, out_dim].
+        Handles kv_head_padding (scale tiling) and per-head block quant.
+        """
+        import math
+
+        in_blocks = weight_scale.shape[0]
+        out_dim = weight_scale.shape[2]
+        dim0, dim1 = weight_q.shape
+
+        if dim1 == out_dim:
+            pass  # Model layout [in, out], no kv-padding
+        elif dim0 == out_dim:
+            weight_q = jnp.transpose(weight_q)  # HF layout [out, in]
+        elif head_dim is not None and dim1 != out_dim and dim0 != out_dim:
+            # Per-head block quant: scale was expanded for wrong n_out.
+            if dim0 % in_blocks == 0:
+                actual_out = dim1  # model layout [in, out]
+            else:
+                weight_q = jnp.transpose(weight_q)
+                actual_out = dim0  # was HF layout [out, in]
+
+            block_size = 128
+            blocks_per_head = math.ceil(head_dim / block_size)
+            num_heads = actual_out // head_dim
+
+            gather_idx = jnp.array(
+                [
+                    ((j // head_dim) * blocks_per_head + (j % head_dim) // block_size) * block_size
+                    for j in range(actual_out)
+                ]
+            )
+            weight_scale = weight_scale[:, :, gather_idx]
+            out_dim = actual_out
+
+            logger.info(
+                "Per-head block dequant: %d heads x head_dim=%d, %d blocks/head, "
+                "remapped scale to (%s)",
+                num_heads,
+                head_dim,
+                blocks_per_head,
+                weight_scale.shape,
+            )
+        elif dim1 > out_dim and dim1 % out_dim == 0:
+            # Model layout [in, kv_padded_out] — tile scale
+            kv_replicas = dim1 // out_dim
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = dim1
+        elif dim0 > out_dim and dim0 % out_dim == 0:
+            # HF layout [kv_padded_out, in] — transpose and tile scale
+            kv_replicas = dim0 // out_dim
+            weight_q = jnp.transpose(weight_q)
+            weight_scale = jnp.tile(weight_scale, (1, 1, kv_replicas))
+            out_dim = weight_q.shape[1]
+        else:
+            raise ValueError(
+                f"Cannot match weight_q shape {weight_q.shape} with scale out_dim={out_dim}"
+            )
+
+        in_dim = weight_q.shape[0]
+        block_k = in_dim // in_blocks
+        weight_f = weight_q.astype(jnp.float32).reshape(in_blocks, block_k, out_dim)
+        weight_bf16 = (weight_f * weight_scale).reshape(in_dim, out_dim).astype(jnp.bfloat16)
+        return weight_bf16
+
+    def dequant_fp8_layers(
+        self,
+        layers: list,
+        specs: list[tuple[str, int | None]],
+        *,
+        layer_filter=None,
+    ):
+        """Dequantize specified QuantizedLinear projections → bf16 LinearBase.
+
+        Args:
+            layers: model.layers list.
+            specs: list of (dotted_path, head_dim) tuples, e.g.
+                [("self_attn.q_proj", 192), ("self_attn.v_proj", 128)].
+            layer_filter: optional callable(layer_idx, layer) -> bool.
+        """
+        from sgl_jax.srt.layers.linear import QuantizedLinear
+
+        for layer_idx, layer in enumerate(layers):
+            if layer_filter is not None and not layer_filter(layer_idx, layer):
+                continue
+            for proj_path, hd in specs:
+                parts = proj_path.split(".")
+                parent = layer
+                for p in parts[:-1]:
+                    parent = getattr(parent, p)
+                attr_name = parts[-1]
+                proj = getattr(parent, attr_name)
+                if isinstance(proj, QuantizedLinear):
+                    setattr(parent, attr_name, self.dequant_fp8_linear(proj, head_dim=hd))
+                    logger.info("Dequantized layer %d %s -> bf16", layer_idx, proj_path)
+
+        logger.info("FP8 -> BF16 dequantization complete.")
+
+    def replicate_kv_heads(
+        self,
+        layers: list,
+        specs: list[tuple[str, int]],
+        target_kv_heads_fn,
+    ):
+        """Replicate KV heads for TP alignment.
+
+        Args:
+            layers: model.layers list.
+            specs: list of (dotted_path, head_dim) tuples, e.g.
+                [("self_attn.k_proj", 192), ("self_attn.v_proj", 128)].
+            target_kv_heads_fn: callable(attn_module) -> int, returns expected
+                TP-aligned KV head count.
+        """
+        from jax.sharding import NamedSharding
+        from jax.sharding import PartitionSpec as P
+
+        for layer_idx, layer in enumerate(layers):
+            attn = layer.self_attn
+            target_kv_heads = target_kv_heads_fn(attn)
+
+            for proj_path, hd in specs:
+                parts = proj_path.split(".")
+                parent = layer
+                for p in parts[:-1]:
+                    parent = getattr(parent, p)
+                attr_name = parts[-1]
+                proj = getattr(parent, attr_name)
+                w = proj.weight.value
+                expected_size = target_kv_heads * hd
+                actual_size = w.shape[1]
+
+                if actual_size == expected_size:
+                    continue
+
+                if actual_size > 0 and expected_size % actual_size == 0:
+                    num_replicas = expected_size // actual_size
+                    orig_kv = actual_size // hd
+
+                    logger.info(
+                        "KV head replication: layer %d %s %d->%d heads (%d->%d)",
+                        layer_idx,
+                        proj_path,
+                        orig_kv,
+                        target_kv_heads,
+                        actual_size,
+                        expected_size,
+                    )
+
+                    w_full = jax.device_put(w, NamedSharding(self.mesh, P()))
+                    w_3d = w_full.reshape(w.shape[0], orig_kv, hd)
+                    w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
+                    w_new = w_rep.reshape(w.shape[0], expected_size)
+                    w_new = jax.device_put(w_new, NamedSharding(self.mesh, P(None, "tensor")))
+
+                    setattr(
+                        parent,
+                        attr_name,
+                        self.create_bf16_linear(w_new, proj.kernel_axes, self.mesh),
+                    )
+
+    @staticmethod
+    def _uniform_block_dequant(weight, scale, block_size):
+        """Uniform block dequant for weight[out_dim, in_dim] * scale[out_blocks, in_blocks]."""
+        out_dim, in_dim = weight.shape
+        out_blocks = scale.shape[0]
+        padded_out = out_blocks * block_size
+        in_blocks = scale.shape[1]
+        if padded_out > out_dim:
+            weight = jnp.pad(weight, ((0, padded_out - out_dim), (0, 0)))
+        w_4d = weight.astype(jnp.float32).reshape(out_blocks, block_size, in_blocks, block_size)
+        s_4d = scale[:, None, :, None]
+        result = (w_4d * s_4d).reshape(padded_out, in_dim)[:out_dim, :].astype(jnp.bfloat16)
+        return result
+
+    def dequant_fused_kv(
+        self,
+        kv_buffers: dict[int, dict],
+        layers: list,
+        config,
+    ):
+        """Dequantize FP8 K+V weights with per-layer quantization scheme detection.
+
+        Handles two schemes:
+        - Per-head fused: K+V quantized as fused [K(head_dim), V(v_head_dim)] per head.
+          Block boundaries cross K/V boundary, so they must be fused for correct dequant.
+        - Uniform: K and V quantized independently across the whole tensor.
+
+        Args:
+            kv_buffers: dict mapping layer_idx -> {k_weight, k_scale, v_weight, v_scale}
+            layers: model.layers list
+            config: model config with head_dim, v_head_dim
+        """
+        import math
+
+        from jax.sharding import NamedSharding
+
+        if not kv_buffers:
+            return
+
+        head_dim = config.head_dim
+        v_head_dim = getattr(config, "v_head_dim", head_dim)
+        quant_cfg = getattr(config, "quantization_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        fused_dim = head_dim + v_head_dim
+        blocks_per_head = math.ceil(fused_dim / block_size)
+        padded_dim = blocks_per_head * block_size
+        k_blocks_per_head = math.ceil(head_dim / block_size)
+        v_blocks_per_head = blocks_per_head - k_blocks_per_head
+
+        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+
+        for layer_idx in sorted(kv_buffers.keys()):
+            buf = kv_buffers[layer_idx]
+            k_weight = buf["k_weight"]
+            k_scale = buf["k_scale"]
+            v_weight = buf["v_weight"]
+            v_scale = buf["v_scale"]
+
+            in_dim = k_weight.shape[1]
+            in_blocks = in_dim // block_size
+
+            num_kv_heads = k_weight.shape[0] // head_dim
+            k_scale_blocks = k_scale.shape[0]
+
+            expected_per_head = num_kv_heads * k_blocks_per_head
+            expected_uniform = math.ceil(num_kv_heads * head_dim / block_size)
+            is_per_head = (
+                k_scale_blocks == expected_per_head and expected_per_head != expected_uniform
+            )
+
+            if is_per_head:
+                k_w = k_weight.reshape(num_kv_heads, head_dim, in_dim)
+                v_w = v_weight.reshape(num_kv_heads, v_head_dim, in_dim)
+                k_s = k_scale.reshape(num_kv_heads, k_blocks_per_head, in_blocks)
+                v_s = v_scale.reshape(num_kv_heads, v_blocks_per_head, in_blocks)
+                fused_w = jnp.concatenate([k_w, v_w], axis=1)
+                fused_s = jnp.concatenate([k_s, v_s], axis=1)
+                if fused_dim < padded_dim:
+                    fused_w = jnp.pad(fused_w, ((0, 0), (0, padded_dim - fused_dim), (0, 0)))
+                fused_5d = fused_w.astype(jnp.float32).reshape(
+                    num_kv_heads, blocks_per_head, block_size, in_blocks, block_size
+                )
+                scale_5d = fused_s[:, :, None, :, None]
+                dequanted = (
+                    (fused_5d * scale_5d)
+                    .reshape(num_kv_heads, padded_dim, in_dim)[:, :fused_dim, :]
+                    .astype(jnp.bfloat16)
+                )
+                k_bf16 = dequanted[:, :head_dim, :].reshape(num_kv_heads * head_dim, in_dim)
+                v_bf16 = dequanted[:, head_dim:, :].reshape(num_kv_heads * v_head_dim, in_dim)
+            else:
+                k_bf16 = self._uniform_block_dequant(k_weight, k_scale, block_size)
+                v_bf16 = self._uniform_block_dequant(v_weight, v_scale, block_size)
+
+            k_bf16 = jax.device_put(jnp.transpose(k_bf16), tp_sharding)
+            v_bf16 = jax.device_put(jnp.transpose(v_bf16), tp_sharding)
+
+            attn = layers[layer_idx].self_attn
+            attn.k_proj = self.create_bf16_linear(k_bf16, (None, "tensor"), self.mesh)
+            attn.v_proj = self.create_bf16_linear(v_bf16, (None, "tensor"), self.mesh)
+
+            if layer_idx % 10 == 0 or layer_idx == 0:
+                logger.info(
+                    "Layer %d KV dequant: %s, heads=%d, K=%s V=%s",
+                    layer_idx,
+                    "per-head" if is_per_head else "uniform",
+                    num_kv_heads,
+                    k_bf16.shape,
+                    v_bf16.shape,
+                )
+
+        kv_buffers.clear()
+        logger.info("FP8 KV dequantization complete for all layers.")
+
+    def dequant_fused_qkv(
+        self,
+        fused_qkv_buffers: dict[int, dict],
+        layers: list,
+        config,
+    ):
+        """Dequantize per-shard-interleaved fused QKV FP8 weights.
+
+        The FP8 checkpoint was quantized per-TP-shard and concatenated:
+          weight: [shard0_QKV | shard1_QKV | ... | shardN_QKV], shape [total_qkv, hidden]
+          scale:  [shard0_scale | shard1_scale | ... | shardN_scale], shape [total_blocks, in_blocks]
+
+        Each shard's QKV dim may not be a multiple of block_size, so scale blocks
+        within a shard can span K/V boundaries. We must dequantize per-shard first,
+        then extract Q/K/V from each shard.
+
+        All dequant math runs on CPU (numpy) to avoid TPU OOM.  Only the final
+        bf16 result is ``device_put`` to TPU with TP sharding.
+
+        Args:
+            fused_qkv_buffers: dict mapping layer_idx -> {"weight": np.ndarray, "scale": np.ndarray}
+            layers: model.layers list
+            config: model config with head_dim, v_head_dim, num_attention_heads, etc.
+        """
+        if not fused_qkv_buffers:
+            return
+
+        from jax.sharding import NamedSharding
+
+        head_dim = config.head_dim
+        v_head_dim = getattr(config, "v_head_dim", head_dim)
+        num_heads = config.num_attention_heads
+        num_kv_heads = config.num_key_value_heads
+
+        quant_cfg = getattr(config, "quantization_config", None)
+        block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+        tp_sharding = NamedSharding(self.mesh, P(None, "tensor"))
+
+        for layer_idx in sorted(fused_qkv_buffers.keys()):
+            buf = fused_qkv_buffers[layer_idx]
+            fused_weight = buf["weight"]  # numpy, [total_qkv, hidden], FP8
+            fused_scale = buf["scale"]  # numpy, [total_blocks, in_blocks], f32
+
+            in_dim = fused_weight.shape[1]  # hidden_size
+
+            # Infer n_shards: find TP size where per-shard blocking matches scale shape
+            n_shards, orig_kv_heads = self._infer_qkv_shards(
+                fused_weight.shape[0],
+                fused_scale.shape[0],
+                num_heads,
+                num_kv_heads,
+                head_dim,
+                v_head_dim,
+                block_size,
+            )
+
+            per_shard_q = (num_heads // n_shards) * head_dim
+            per_shard_k = (orig_kv_heads // n_shards) * head_dim
+            per_shard_v = (orig_kv_heads // n_shards) * v_head_dim
+            per_shard_total = per_shard_q + per_shard_k + per_shard_v
+            per_shard_blocks = math.ceil(per_shard_total / block_size)
+            padded_rows = per_shard_blocks * block_size
+            in_blocks = in_dim // block_size
+
+            if layer_idx % 10 == 0:
+                logger.info(
+                    "Layer %d: dequant fused QKV FP8 (CPU), n_shards=%d, "
+                    "per_shard=%d (Q=%d K=%d V=%d), blocks=%d",
+                    layer_idx,
+                    n_shards,
+                    per_shard_total,
+                    per_shard_q,
+                    per_shard_k,
+                    per_shard_v,
+                    per_shard_blocks,
+                )
+
+            q_parts, k_parts, v_parts = [], [], []
+
+            for shard_idx in range(n_shards):
+                # Extract this shard's weight and scale (numpy slicing)
+                w_start = shard_idx * per_shard_total
+                shard_w = fused_weight[w_start : w_start + per_shard_total, :]
+
+                s_start = shard_idx * per_shard_blocks
+                shard_s = fused_scale[s_start : s_start + per_shard_blocks, :]
+
+                # Pad weight rows to block boundary for dequant
+                if per_shard_total < padded_rows:
+                    shard_w = np.pad(shard_w, ((0, padded_rows - per_shard_total), (0, 0)))
+
+                # Block dequantize on CPU: [padded_rows, in_dim] × [blocks, in_blocks]
+                shard_f = shard_w.astype(np.float32).reshape(
+                    per_shard_blocks, block_size, in_blocks, block_size
+                )
+                shard_s_4d = shard_s[:, None, :, None]
+                shard_dequant = (shard_f * shard_s_4d).reshape(padded_rows, in_dim)[
+                    :per_shard_total, :
+                ]
+
+                # Split into Q, K, V and transpose to model layout [in, out_shard].
+                # .T is O(1) numpy view; .copy() releases the shard_dequant reference.
+                q_parts.append(shard_dequant[:per_shard_q, :].T.copy())
+                k_parts.append(shard_dequant[per_shard_q : per_shard_q + per_shard_k, :].T.copy())
+                v_parts.append(shard_dequant[per_shard_q + per_shard_k :, :].T.copy())
+
+            # Free CPU buffers for this layer
+            del buf["weight"], buf["scale"]
+
+            # Concat on CPU, convert to bf16, shard to TPU via callback.
+            # Uses make_array_from_callback to avoid the allgather that
+            # device_put triggers in multi-host (assert_equal OOM).
+            # Process Q/K/V sequentially to limit peak CPU memory.
+            attn = layers[layer_idx].self_attn
+            for proj_name, parts in [
+                ("q_proj", q_parts),
+                ("k_proj", k_parts),
+                ("v_proj", v_parts),
+            ]:
+                merged = np.ascontiguousarray(
+                    np.concatenate(parts, axis=1).astype(ml_dtypes.bfloat16)
+                )
+                del parts[:]
+                # Bind merged via default arg to avoid late-binding closure issue.
+                weight = jax.make_array_from_callback(
+                    merged.shape,
+                    tp_sharding,
+                    lambda idx, m=merged: jnp.array(m[idx]),
+                )
+                del merged
+                setattr(
+                    attn,
+                    proj_name,
+                    self.create_bf16_linear(weight, (None, "tensor"), self.mesh),
+                )
+
+            if layer_idx == 0:
+                q_w = attn.q_proj.weight.value
+                k_w = attn.k_proj.weight.value
+                v_w = attn.v_proj.weight.value
+                logger.info(
+                    "Layer 0 dequant result: Q=%s K=%s V=%s",
+                    q_w.shape,
+                    k_w.shape,
+                    v_w.shape,
+                )
+
+        # Clean up buffers
+        fused_qkv_buffers.clear()
+        logger.info("Fused QKV FP8 dequantization complete (CPU numpy path).")
+
+    @staticmethod
+    def _infer_qkv_shards(
+        total_out_dim: int,
+        total_scale_blocks: int,
+        num_heads: int,
+        num_kv_heads: int,
+        head_dim: int,
+        v_head_dim: int,
+        block_size: int,
+    ) -> tuple[int, int]:
+        """Infer the number of TP shards used during FP8 quantization.
+
+        The config's num_kv_heads may be GQA-replicated (e.g. 32 instead of
+        the original 8), so we also try divisors of num_kv_heads to find the
+        original value used during per-shard quantization.
+
+        Returns (tp_shards, original_num_kv_heads).
+        """
+        # Collect candidate kv_heads values: config value and its divisors
+        kv_candidates = []
+        for d in range(1, num_kv_heads + 1):
+            if num_kv_heads % d == 0:
+                kv_candidates.append(d)
+        # Try config value first, then smaller divisors (descending)
+        kv_candidates = sorted(set(kv_candidates), reverse=True)
+
+        # TP candidates: all divisors of num_heads (covers any quantization-time TP)
+        tp_candidates = sorted(d for d in range(1, num_heads + 1) if num_heads % d == 0)
+
+        for orig_kv in kv_candidates:
+            for tp in tp_candidates:
+                if orig_kv % tp != 0:
+                    continue
+                per_shard = (
+                    (num_heads // tp) * head_dim
+                    + (orig_kv // tp) * head_dim
+                    + (orig_kv // tp) * v_head_dim
+                )
+                per_shard_blocks = math.ceil(per_shard / block_size)
+                if per_shard_blocks * tp == total_scale_blocks and per_shard * tp == total_out_dim:
+                    if orig_kv != num_kv_heads:
+                        logger.info(
+                            "Inferred original num_kv_heads=%d (config has %d), tp=%d",
+                            orig_kv,
+                            num_kv_heads,
+                            tp,
+                        )
+                    return tp, orig_kv
+        raise ValueError(
+            f"Cannot infer QKV shard count: out_dim={total_out_dim}, "
+            f"scale_blocks={total_scale_blocks}, num_heads={num_heads}, "
+            f"num_kv_heads={num_kv_heads}, head_dim={head_dim}, "
+            f"v_head_dim={v_head_dim}, block_size={block_size}"
+        )
 
     def _normalize_physical_to_logical_map(
         self,
@@ -389,6 +962,12 @@ class WeightLoader:
             iterator = tqdm(weights_files, desc="Scanning Metadata", unit="file")
 
             for st_file in iterator:
+                # Parse safetensors header for byte offsets (for bulk MoE reads)
+                with open(st_file, "rb") as raw_f:
+                    header_size = struct.unpack("<Q", raw_f.read(8))[0]
+                    raw_header = json.loads(raw_f.read(header_size))
+                data_section_offset = 8 + header_size
+
                 with safe_open(st_file, framework="flax", device="cpu") as f:
                     for key in f.keys():  # noqa: SIM118
                         slice_info = f.get_slice(key)
@@ -397,6 +976,12 @@ class WeightLoader:
                             "shape": tuple(slice_info.get_shape()),
                             "dtype": slice_info.get_dtype(),
                         }
+                        # Add byte offset info for direct reads
+                        if key in raw_header:
+                            offsets = raw_header[key].get("data_offsets")
+                            if offsets:
+                                info["byte_offset"] = data_section_offset + offsets[0]
+                                info["byte_size"] = offsets[1] - offsets[0]
                         if key not in weight_info:
                             weight_info[key] = []
                         weight_info[key].append(info)
@@ -702,7 +1287,7 @@ class WeightLoader:
                     sample_map = {
                         p: logical_indices[i] for i, p in enumerate(physical_indices[:sample_size])
                     }
-                    logger.info("Cloning split-experts map (sample): %s", sample_map)
+                    logger.debug("Cloning split-experts map (sample): %s", sample_map)
             else:
                 logical_indices = physical_indices
 
@@ -737,9 +1322,9 @@ class WeightLoader:
 
             return out_array
 
-        result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice).astype(
-            target_dtype
-        )
+        result = jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice)
+        if result.dtype != target_dtype:
+            result = result.astype(target_dtype)
         if do_transpose and result.ndim >= 3:
             result = jnp.transpose(result, (0, 2, 1))
         return result
@@ -781,7 +1366,62 @@ class WeightLoader:
         else:
             num_physical_experts = num_logical_experts
 
-        if do_transpose and len(single_expert_shape) >= 2:
+        # Detect whether we can defer transpose to TPU instead of doing it
+        # on CPU during loading. This is possible when do_transpose=True but
+        # the weight dimensions (all dims after expert dim) are unsharded,
+        # meaning each callback loads the full tensor. Deferring avoids the
+        # costly strided memcpy from np.transpose on non-contiguous views.
+        defer_transpose = False
+        if do_transpose and len(single_expert_shape) >= 2 and target_sharding is not None:
+            spec = target_sharding.spec
+            # spec[0] is expert dim sharding, spec[1:] are weight dims
+            weight_dims_unsharded = all(s is None for s in spec[1:])
+            if weight_dims_unsharded:
+                defer_transpose = True
+                logger.info(
+                    "MoE defer_transpose=True: will load in HF layout and "
+                    "transpose on TPU (shape=%s)",
+                    single_expert_shape,
+                )
+
+        # Check if bulk raw byte reading is possible (byte offsets available
+        # from scan phase). This eliminates per-expert safetensors API calls
+        # and reduces GCSFuse round-trips by reading contiguous byte ranges.
+        # Skip bulk_read for small tensors (e.g. scales) — safetensors API
+        # with cached handles is faster than raw open/seek/read on GCSFuse.
+        _expert_elems = 1
+        for d in single_expert_shape:
+            _expert_elems *= d
+        _expert_bytes_est = _expert_elems * (1 if st_dtype.startswith("F8_") else 4)
+        _BULK_READ_MIN_BYTES = 1024 * 1024  # 1 MB per expert
+        bulk_read = (
+            defer_transpose
+            and _expert_bytes_est >= _BULK_READ_MIN_BYTES
+            and all(
+                "byte_offset" in weight_info[expected_hf_keys[i]][0]
+                for i in range(min(2, num_logical_experts))
+            )
+        )
+        if bulk_read:
+            logger.info(
+                "MoE bulk_read=True: using raw byte reads for %d experts",
+                num_logical_experts,
+            )
+
+        # Map safetensors dtype strings to numpy dtypes for raw reads
+        _st_to_np_dtype = {
+            "F32": np.float32,
+            "F16": np.float16,
+            "BF16": np.dtype("V2"),  # 2-byte view, reinterpret later
+            "I64": np.int64,
+            "I32": np.int32,
+            "BOOL": np.bool_,
+            "F8_E4M3": np.uint8,
+            "F8_E5M2": np.uint8,
+        }
+        np_read_dtype = _st_to_np_dtype.get(st_dtype, np.uint8)
+
+        if do_transpose and not defer_transpose and len(single_expert_shape) >= 2:
             final_single_shape = list(single_expert_shape)
             final_single_shape[-1], final_single_shape[-2] = (
                 final_single_shape[-2],
@@ -794,9 +1434,14 @@ class WeightLoader:
         stacked_shape = (num_physical_experts, *final_single_shape)
         sharding = target_sharding or jax.sharding.NamedSharding(self.mesh, P())
 
-        LOAD_WORKERS = 16
+        LOAD_WORKERS = int(os.environ.get("SGLANG_MOE_LOAD_WORKERS", "16"))
+
+        _callback_times = []
+        _detailed_logged = False
 
         def _load_stacked_slice(index):
+            nonlocal _detailed_logged
+            _cb_start = time.monotonic()
             expert_slice = index[0]
             inner_slice = index[1:]
 
@@ -817,22 +1462,54 @@ class WeightLoader:
                         p: logical_indices_to_load[i]
                         for i, p in enumerate(physical_indices[:sample_size])
                     }
-                    logger.info("Cloning experts map (sample): %s", sample_map)
+                    logger.debug("Cloning experts map (sample): %s", sample_map)
             else:
                 logical_indices_to_load = physical_indices
 
+            # --- Load first expert with detailed timing ---
             first_log_idx = logical_indices_to_load[0]
             first_hf_key = expected_hf_keys[first_log_idx]
             first_fname = weight_info[first_hf_key][0]["file"]
-            first_f = file_manager.get_handle(first_fname)
 
-            if not do_transpose:
+            _t0 = time.monotonic()
+            first_f = file_manager.get_handle(first_fname)
+            _t_handle = time.monotonic() - _t0
+
+            if not do_transpose or defer_transpose:
+                _t1 = time.monotonic()
                 first_chunk = first_f.get_slice(first_hf_key)[inner_slice]
+                _t_getslice = time.monotonic() - _t1
+                _t2 = time.monotonic()
                 first_chunk = _view_as_fp8_if_needed(first_chunk, target_dtype)
+                _t_fp8 = time.monotonic() - _t2
+                _t_transpose = 0.0
             else:
+                _t1 = time.monotonic()
                 data = first_f.get_slice(first_hf_key)[:]
+                _t_getslice = time.monotonic() - _t1
+                _t2 = time.monotonic()
                 data = _view_as_fp8_if_needed(data, target_dtype)
+                _t_fp8 = time.monotonic() - _t2
+                _t3 = time.monotonic()
                 first_chunk = np.transpose(data)[inner_slice]
+                _t_transpose = time.monotonic() - _t3
+
+            # Log detailed timing for first callback only
+            if not _detailed_logged:
+                _detailed_logged = True
+                expert_bytes = first_chunk.nbytes
+                logger.debug(
+                    "MoE callback[0] detail: experts_in_shard=%d "
+                    "get_handle=%.4fs get_slice=%.4fs fp8_view=%.4fs "
+                    "transpose=%.4fs expert_bytes=%d file=%s",
+                    sliced_num_physical,
+                    _t_handle,
+                    _t_getslice,
+                    _t_fp8,
+                    _t_transpose,
+                    expert_bytes,
+                    os.path.basename(first_fname),
+                )
 
             out_shape = (sliced_num_physical, *first_chunk.shape)
             out_array = np.empty(out_shape, dtype=first_chunk.dtype)
@@ -846,33 +1523,273 @@ class WeightLoader:
                 else:
                     logical_to_positions.setdefault(log_idx, []).append(phys_pos)
 
+            # Per-thread timing accumulators
+            _thread_stats = {
+                "get_handle": [],
+                "get_slice": [],
+                "fp8": [],
+                "transpose": [],
+                "copy": [],
+            }
+            _thread_files = []
+
             def load_and_fill_expert(args):
                 l_idx, positions = args
                 hf_k = expected_hf_keys[l_idx]
                 fname = weight_info[hf_k][0]["file"]
-                f = file_manager.get_handle(fname)
 
-                if not do_transpose:
+                t_a = time.monotonic()
+                f = file_manager.get_handle(fname)
+                t_b = time.monotonic()
+                _thread_stats["get_handle"].append(t_b - t_a)
+
+                if not do_transpose or defer_transpose:
                     chunk = f.get_slice(hf_k)[inner_slice]
+                    t_c = time.monotonic()
+                    _thread_stats["get_slice"].append(t_c - t_b)
                     chunk = _view_as_fp8_if_needed(chunk, target_dtype)
+                    t_d = time.monotonic()
+                    _thread_stats["fp8"].append(t_d - t_c)
+                    _thread_stats["transpose"].append(0.0)
                 else:
                     data = f.get_slice(hf_k)[:]
+                    t_c = time.monotonic()
+                    _thread_stats["get_slice"].append(t_c - t_b)
                     data = _view_as_fp8_if_needed(data, target_dtype)
+                    t_d = time.monotonic()
+                    _thread_stats["fp8"].append(t_d - t_c)
                     chunk = np.transpose(data)[inner_slice]
+                    t_e = time.monotonic()
+                    _thread_stats["transpose"].append(t_e - t_d)
 
+                t_copy_start = time.monotonic()
                 for pos in positions:
                     out_array[pos] = chunk
+                _thread_stats["copy"].append(time.monotonic() - t_copy_start)
+                _thread_files.append(os.path.basename(fname))
 
             if logical_to_positions:
                 tasks = list(logical_to_positions.items())
                 with ThreadPoolExecutor(max_workers=LOAD_WORKERS) as executor:
                     list(executor.map(load_and_fill_expert, tasks))
 
+            _callback_times.append(time.monotonic() - _cb_start)
+
+            # Log aggregated thread stats for first callback
+            if len(_callback_times) == 1 and _thread_stats["get_slice"]:
+                n = len(_thread_stats["get_slice"])
+                unique_files = len(set(_thread_files))
+                logger.debug(
+                    "MoE callback[0] threads: n=%d unique_files=%d "
+                    "get_handle=%.4fs get_slice(sum=%.2fs avg=%.4fs max=%.4fs) "
+                    "fp8=%.4fs transpose(sum=%.2fs avg=%.4fs) copy=%.4fs",
+                    n,
+                    unique_files,
+                    sum(_thread_stats["get_handle"]),
+                    sum(_thread_stats["get_slice"]),
+                    sum(_thread_stats["get_slice"]) / n,
+                    max(_thread_stats["get_slice"]),
+                    sum(_thread_stats["fp8"]),
+                    sum(_thread_stats["transpose"]),
+                    sum(_thread_stats["transpose"]) / n,
+                    sum(_thread_stats["copy"]),
+                )
+
             return out_array
 
-        return jax.make_array_from_callback(stacked_shape, sharding, _load_stacked_slice).astype(
-            target_dtype
-        )
+        t0 = time.monotonic()
+        if bulk_read:
+            # Host-level bulk loading: read all experts for local devices at
+            # once, then device_put in parallel. This replaces serial
+            # make_array_from_callback with a single bulk I/O + parallel
+            # device transfers.
+            local_devices = sharding.mesh.local_devices
+            n_local = len(local_devices)
+
+            # Determine which physical experts each local device needs
+            device_assignments = sharding.devices_indices_map(stacked_shape)
+            local_assignments = []
+            for dev in local_devices:
+                idx = device_assignments[dev]
+                expert_slice = idx[0]
+                s, e, st = expert_slice.indices(num_physical_experts)
+                local_assignments.append(list(range(s, e, st)))
+
+            # Collect ALL unique logical expert indices needed by this host
+            all_logical = set()
+            for phys_indices in local_assignments:
+                for p in phys_indices:
+                    if physical_to_logical_map is not None:
+                        all_logical.add(int(physical_to_logical_map[p]))
+                    else:
+                        all_logical.add(p)
+
+            # Group by file for bulk reading
+            file_groups = {}
+            for log_idx in all_logical:
+                hf_key = expected_hf_keys[log_idx]
+                info = weight_info[hf_key][0]
+                fname = info["file"]
+                byte_offset = info["byte_offset"]
+                file_groups.setdefault(fname, []).append((log_idx, byte_offset, hf_key))
+
+            # Compute per-expert byte size
+            expert_nbytes = 1
+            for d in single_expert_shape:
+                expert_nbytes *= d
+            elem_size = 1 if np_read_dtype == np.uint8 else np.dtype(np_read_dtype).itemsize
+            expert_nbytes *= elem_size
+
+            # Read all expert data from files (parallel across files)
+            expert_data_map = {}  # log_idx -> np.ndarray
+
+            def _bulk_read_file(fname, entries):
+                entries.sort(key=lambda e: e[1])
+                min_off = entries[0][1]
+                max_end = entries[-1][1] + expert_nbytes
+                rng = max_end - min_off
+                actual = len(entries) * expert_nbytes
+                result = {}
+                if rng <= actual * 2 and len(entries) > 1:
+                    with open(fname, "rb") as f:
+                        f.seek(min_off)
+                        bulk = f.read(rng)
+                    for log_idx, byte_off, hf_key in entries:
+                        local_off = byte_off - min_off
+                        arr = np.frombuffer(
+                            bulk,
+                            dtype=np_read_dtype,
+                            count=expert_nbytes // elem_size,
+                            offset=local_off,
+                        ).reshape(single_expert_shape)
+                        result[log_idx] = arr.copy()
+                else:
+                    with open(fname, "rb") as f:
+                        for log_idx, byte_off, hf_key in entries:
+                            f.seek(byte_off)
+                            raw = f.read(expert_nbytes)
+                            arr = np.frombuffer(
+                                raw,
+                                dtype=np_read_dtype,
+                            ).reshape(single_expert_shape)
+                            result[log_idx] = arr
+                return result
+
+            t_io_start = time.monotonic()
+            if len(file_groups) > 1:
+                with ThreadPoolExecutor(max_workers=len(file_groups)) as ex:
+                    futs = {
+                        ex.submit(_bulk_read_file, fn, ents): fn for fn, ents in file_groups.items()
+                    }
+                    for fut in futs:
+                        expert_data_map.update(fut.result())
+            else:
+                for fn, ents in file_groups.items():
+                    expert_data_map.update(_bulk_read_file(fn, ents))
+            t_io = time.monotonic() - t_io_start
+            total_read_mb = sum(v.nbytes for v in expert_data_map.values()) / 1e6
+
+            # Assemble per-device arrays and device_put (parallel)
+            t_assemble_start = time.monotonic()
+            n_experts_per_shard = len(local_assignments[0])
+
+            def _build_and_put(dev_idx):
+                dev = local_devices[dev_idx]
+                phys_indices = local_assignments[dev_idx]
+                shard = np.empty(
+                    (n_experts_per_shard, *single_expert_shape),
+                    dtype=np_read_dtype,
+                )
+                for pos, p in enumerate(phys_indices):
+                    log_idx = (
+                        int(physical_to_logical_map[p])
+                        if physical_to_logical_map is not None
+                        else p
+                    )
+                    shard[pos] = expert_data_map[log_idx]
+                shard = _view_as_fp8_if_needed(shard, target_dtype)
+                return jax.device_put(shard, dev)
+
+            with ThreadPoolExecutor(max_workers=n_local) as ex:
+                per_device_arrays = list(ex.map(_build_and_put, range(n_local)))
+            t_assemble = time.monotonic() - t_assemble_start
+
+            result = jax.make_array_from_single_device_arrays(
+                stacked_shape,
+                sharding,
+                per_device_arrays,
+            )
+            t_callback = time.monotonic() - t0
+
+            logger.debug(
+                "MoE host-bulk load: shape=%s dtype=%s "
+                "io=%.2fs (%.1f MB, %.1f MB/s) "
+                "assemble+put=%.2fs total=%.2fs "
+                "experts_read=%d files=%d devices=%d",
+                stacked_shape,
+                target_dtype,
+                t_io,
+                total_read_mb,
+                total_read_mb / t_io if t_io > 0 else 0,
+                t_assemble,
+                t_callback,
+                len(expert_data_map),
+                len(file_groups),
+                n_local,
+            )
+        else:
+            # Pre-warm safetensors file handles to avoid cold-start latency
+            # during serial callbacks. This is especially important for small
+            # tensors (scales) where GCSFuse file-open latency dominates.
+            unique_files = set()
+            for i in range(num_logical_experts):
+                hf_key = expected_hf_keys[i]
+                unique_files.add(weight_info[hf_key][0]["file"])
+            uncached = [fn for fn in unique_files if fn not in file_manager.handles]
+            if uncached:
+
+                def _prewarm(fn):
+                    return fn, safe_open(fn, framework="np", device="cpu")
+
+                with ThreadPoolExecutor(max_workers=min(len(uncached), 16)) as ex:
+                    for fn, handle in ex.map(_prewarm, uncached):
+                        file_manager.handles[fn] = handle
+
+            callback_fn = _load_stacked_slice
+            result = jax.make_array_from_callback(
+                stacked_shape,
+                sharding,
+                callback_fn,
+            )
+            t_callback = time.monotonic() - t0
+        t1 = time.monotonic()
+        if result.dtype != target_dtype:
+            result = result.astype(target_dtype)
+        t_astype = time.monotonic() - t1
+        # Deferred transpose: data was loaded in HF layout [experts, out, in],
+        # now transpose to kernel layout [experts, in, out] on TPU.
+        t2 = time.monotonic()
+        if defer_transpose and result.ndim >= 3:
+            result = jnp.transpose(result, (0, 2, 1))
+        t_defer = time.monotonic() - t2
+        if _callback_times:
+            defer_msg = f" defer_transpose={t_defer:.3f}s" if defer_transpose else ""
+            logger.debug(
+                "MoE tensor load: shape=%s dtype=%s callbacks=%d "
+                "callback_total=%.2fs (min=%.3fs max=%.3fs) "
+                "make_array=%.2fs astype=%.2fs workers=%d%s",
+                stacked_shape,
+                target_dtype,
+                len(_callback_times),
+                sum(_callback_times),
+                min(_callback_times),
+                max(_callback_times),
+                t_callback,
+                t_astype,
+                LOAD_WORKERS,
+                defer_msg,
+            )
+        return result
 
     def load_weights_from_safetensors(
         self,
@@ -957,6 +1874,8 @@ class WeightLoader:
 
                 can_optimize = (
                     isinstance(mapping.target_path, str)
+                    and not mapping.target_path.startswith("__FUSED_QKV_")
+                    and not mapping.target_path.startswith("__KV_")
                     and mapping.reshape is None
                     and mapping.repeat is None  # Check repeat here too!
                     and not mapping.kv_head_padding
@@ -1122,6 +2041,7 @@ class WeightLoader:
                         final_sharding = jax.sharding.NamedSharding(self.mesh, P(*mapping.sharding))
 
                     # 2. Call creator
+                    _t_load_start = time.monotonic()
                     stacked_weight = self._create_stacked_moe_lazy_tensor(
                         expected_hf_keys,
                         weight_info,
@@ -1130,6 +2050,7 @@ class WeightLoader:
                         target_sharding=final_sharding,  # Global loading
                         physical_to_logical_map=mapping.physical_to_logical_map,
                     )
+                    _t_load = time.monotonic() - _t_load_start
                     loaded_shape = stacked_weight.shape
 
                     if mapping.reshape is not None:
@@ -1149,7 +2070,7 @@ class WeightLoader:
                     )
 
                     if is_static_quant and moe_key.endswith("_scale"):
-                        logger.info(
+                        logger.debug(
                             "MoE scale debug group=%s target=%s loaded_shape=%s final_shape=%s "
                             "param_shape=%s reshape=%s repeat=%s sharding=%s",
                             moe_key,
@@ -1163,10 +2084,22 @@ class WeightLoader:
                         )
 
                     try:
+                        _t_assign_start = time.monotonic()
                         if stacked_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                             model_param.value = stacked_weight
                         else:
                             model_param.value = stacked_weight.astype(model_param.value.dtype)
+                        _t_assign = time.monotonic() - _t_assign_start
+                        logger.debug(
+                            "MoE group %s: load=%.2fs assign=%.2fs total=%.2fs "
+                            "shape=%s sharding=%s",
+                            moe_key,
+                            _t_load,
+                            _t_assign,
+                            _t_load + _t_assign,
+                            loaded_shape,
+                            mapping.sharding,
+                        )
                     except Exception as e:
                         logger.error(
                             "Failed MoE assign group=%s target=%s loaded_shape=%s final_shape=%s "
@@ -1247,7 +2180,7 @@ class WeightLoader:
                     )
 
                     if is_static_quant and moe_key.endswith("_scale"):
-                        logger.info(
+                        logger.debug(
                             "Split-MoE scale debug group=%s target=%s loaded_shape=%s final_shape=%s "
                             "param_shape=%s reshape=%s repeat=%s sharding=%s",
                             moe_key,
@@ -1500,6 +2433,23 @@ class WeightLoader:
                 )
             return
 
+        # Handle fused QKV buffer storage (used by MiMo-V2-Pro per-shard dequant).
+        # target_path like "__FUSED_QKV_WEIGHT__42" stores into model._fused_qkv_buffers.
+        if jax_path.startswith("__FUSED_QKV_"):
+            if hasattr(self.model, "_fused_qkv_buffers"):
+                is_scale = "SCALE" in jax_path
+                layer_idx = int(jax_path.rsplit("__", 1)[-1])
+                buf = self.model._fused_qkv_buffers.setdefault(layer_idx, {})
+                np_weight = np.asarray(processed_weight)
+                buf["scale" if is_scale else "weight"] = np_weight
+                logger.info(
+                    "Stored fused QKV %s for layer %d, shape=%s (CPU numpy)",
+                    "scale" if is_scale else "weight",
+                    layer_idx,
+                    np_weight.shape,
+                )
+            return
+
         # Apply output_multiplier_scale to lm_head weights (matching PyTorch implementation)
         if "lm_head" in hf_key and hasattr(self.model_config.hf_config, "output_multiplier_scale"):
             logger.info(
@@ -1555,13 +2505,18 @@ class WeightLoader:
     ):
         jax_paths = mapping.target_path
 
+        v_head_dim = getattr(self, "v_head_dim", self.head_dim_original)
+        v_head_dim_pad = (v_head_dim + 127) // 128 * 128 - v_head_dim
+        v_head_dim_padded = v_head_dim + v_head_dim_pad
+
         if hf_key.endswith(".bias"):
             q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
 
             q_bias = weight[:q_dim]
-            k_bias = weight[q_dim : q_dim + kv_dim]
-            v_bias = weight[q_dim + kv_dim : q_dim + 2 * kv_dim]
+            k_bias = weight[q_dim : q_dim + k_dim]
+            v_bias = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 q_bias = jnp.reshape(q_bias, (self.num_heads, self.head_dim_original))
@@ -1572,23 +2527,56 @@ class WeightLoader:
                 k_bias = jnp.pad(k_bias, ((0, 0), (0, self.head_dim_pad)))
                 k_bias = jnp.reshape(k_bias, (self.num_kv_heads * self.head_dim,))
 
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, self.head_dim_original))
-                v_bias = jnp.pad(v_bias, ((0, 0), (0, self.head_dim_pad)))
-                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * self.head_dim,))
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                v_bias = jnp.reshape(v_bias, (self.num_kv_heads, v_head_dim))
+                v_bias = jnp.pad(v_bias, ((0, 0), (0, v_head_dim_pad)))
+                v_bias = jnp.reshape(v_bias, (self.num_kv_heads * v_head_dim_padded,))
 
             splits = [q_bias, k_bias, v_bias]
+        elif "scale" in hf_key and weight.ndim == 2:
+            # Block-quant scale: split along block dimension, not element dimension.
+            # The fused QKV scale has shape [total_blocks, in_blocks] where blocks
+            # are computed per Q/K/V segment independently.
+            import math
+
+            quant_cfg = getattr(self.model_config, "quantization_config", None)
+            block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+
+            q_dim = self.num_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+
+            q_blocks = math.ceil(q_dim / block_size)
+            k_blocks = math.ceil(k_dim / block_size)
+            # V gets remaining blocks (may include padding to head_dim_original)
+            v_blocks = weight.shape[0] - q_blocks - k_blocks
+
+            logger.info(
+                "Splitting QKV scale %s shape=%s into Q=%d K=%d V=%d blocks",
+                hf_key,
+                weight.shape,
+                q_blocks,
+                k_blocks,
+                v_blocks,
+            )
+
+            q_scale = weight[:q_blocks, :]
+            k_scale = weight[q_blocks : q_blocks + k_blocks, :]
+            v_scale = weight[q_blocks + k_blocks :, :]
+
+            splits = [q_scale, k_scale, v_scale]
         else:
             q_dim = self.num_heads * self.head_dim_original
-            kv_dim = self.num_kv_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
 
             if mapping.transpose:
                 q_weight = weight[:, :q_dim]
-                k_weight = weight[:, q_dim : q_dim + kv_dim]
-                v_weight = weight[:, q_dim + kv_dim : q_dim + 2 * kv_dim]
+                k_weight = weight[:, q_dim : q_dim + k_dim]
+                v_weight = weight[:, q_dim + k_dim : q_dim + k_dim + v_dim]
             else:
                 q_weight = weight[:q_dim, :]
-                k_weight = weight[q_dim : q_dim + kv_dim, :]
-                v_weight = weight[q_dim + kv_dim : q_dim + 2 * kv_dim, :]
+                k_weight = weight[q_dim : q_dim + k_dim, :]
+                v_weight = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
 
             if mapping.head_dim_padding and self.head_dim_pad > 0:
                 if mapping.transpose:
@@ -1609,15 +2597,6 @@ class WeightLoader:
                     k_weight = jnp.reshape(
                         k_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
                     )
-
-                    v_weight = jnp.reshape(
-                        v_weight,
-                        (self.hidden_size, self.num_kv_heads, self.head_dim_original),
-                    )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, self.head_dim_pad)))
-                    v_weight = jnp.reshape(
-                        v_weight, (self.hidden_size, self.num_kv_heads * self.head_dim)
-                    )
                 else:
                     q_weight = jnp.reshape(
                         q_weight,
@@ -1637,13 +2616,24 @@ class WeightLoader:
                         k_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
                     )
 
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                if mapping.transpose:
                     v_weight = jnp.reshape(
                         v_weight,
-                        (self.num_kv_heads, self.head_dim_original, self.hidden_size),
+                        (self.hidden_size, self.num_kv_heads, v_head_dim),
                     )
-                    v_weight = jnp.pad(v_weight, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    v_weight = jnp.pad(v_weight, ((0, 0), (0, 0), (0, v_head_dim_pad)))
                     v_weight = jnp.reshape(
-                        v_weight, (self.num_kv_heads * self.head_dim, self.hidden_size)
+                        v_weight, (self.hidden_size, self.num_kv_heads * v_head_dim_padded)
+                    )
+                else:
+                    v_weight = jnp.reshape(
+                        v_weight,
+                        (self.num_kv_heads, v_head_dim, self.hidden_size),
+                    )
+                    v_weight = jnp.pad(v_weight, ((0, 0), (0, v_head_dim_pad), (0, 0)))
+                    v_weight = jnp.reshape(
+                        v_weight, (self.num_kv_heads * v_head_dim_padded, self.hidden_size)
                     )
 
             splits = [q_weight, k_weight, v_weight]
@@ -1657,6 +2647,11 @@ class WeightLoader:
             sharded_weight = self._shard_weight(processed_weight, mapping.sharding)
 
             model_param = self._get_param(params, jax_path)
+
+            # Expand 2D block-quant scale to 3D kernel-ready layout.
+            sharded_weight = self._maybe_expand_linear_block_scale(
+                sharded_weight, model_param, jax_path
+            )
 
             if sharded_weight.dtype in [jnp.float8_e4m3fn, jnp.float8_e5m2]:
                 model_param.value = sharded_weight
@@ -1776,76 +2771,3 @@ class WeightLoader:
 
         layer_num = int(parts[2])
         return layer_num >= self.model_config.num_hidden_layers
-
-
-def replicate_kv_heads(
-    layers,
-    mesh: jax.sharding.Mesh,
-    head_dim: int,
-    v_head_dim: int,
-    target_kv_heads: int,
-):
-    """Replicate KV heads for TP alignment when the weight loader missed them.
-
-    When v_head_dim != head_dim, the weight loader's _apply_kv_head_padding
-    can't pattern-match v_proj shapes. This function fixes that by checking
-    actual weight dims against expected (tp-aligned) dims and replicating.
-
-    Args:
-        layers: List of decoder layers, each with self_attn containing k_proj/v_proj.
-        mesh: JAX mesh for sharding.
-        head_dim: K/Q head dimension.
-        v_head_dim: V head dimension (may differ from head_dim).
-        target_kv_heads: Target number of KV heads after TP alignment.
-    """
-    from jax.sharding import NamedSharding
-    from jax.sharding import PartitionSpec as P
-
-    from sgl_jax.srt.layers.linear import LinearBase
-
-    for layer_idx, layer in enumerate(layers):
-        attn = layer.self_attn
-
-        for proj_name, hd in [
-            ("k_proj", head_dim),
-            ("v_proj", v_head_dim),
-        ]:
-            proj = getattr(attn, proj_name)
-            w = proj.weight.value
-            expected_size = target_kv_heads * hd
-            actual_size = w.shape[1]
-
-            if actual_size == expected_size:
-                continue
-
-            if actual_size > 0 and expected_size % actual_size == 0:
-                num_replicas = expected_size // actual_size
-                orig_kv = actual_size // hd
-
-                logger.info(
-                    "KV head replication: layer %d %s %d→%d heads (%d→%d)",
-                    layer_idx,
-                    proj_name,
-                    orig_kv,
-                    target_kv_heads,
-                    actual_size,
-                    expected_size,
-                )
-
-                w_full = jax.device_put(w, NamedSharding(mesh, P()))
-                w_3d = w_full.reshape(w.shape[0], orig_kv, hd)
-                w_rep = jnp.repeat(w_3d, num_replicas, axis=1)
-                w_new = w_rep.reshape(w.shape[0], expected_size)
-                w_new = jax.device_put(w_new, NamedSharding(mesh, P(None, "tensor")))
-
-                with jax.set_mesh(mesh):
-                    new_linear = LinearBase(
-                        input_size=w.shape[0],
-                        output_size=expected_size,
-                        kernel_axes=proj.kernel_axes,
-                        use_bias=False,
-                        params_dtype=jnp.bfloat16,
-                        mesh=mesh,
-                    )
-                    new_linear.weight = nnx.Param(w_new)
-                setattr(attn, proj_name, new_linear)

--- a/python/sgl_jax/test/mem_cache/test_swa_allocator.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_allocator.py
@@ -365,7 +365,7 @@ class TestSWAEviction(CustomTestCase):
 
     def _evict(self, req, pre_len):
         """Wrapper around the eviction logic matching _evict_swa."""
-        new_evicted = max(req.swa_evicted_seqlen, pre_len - self.sliding_window)
+        new_evicted = max(req.swa_evicted_seqlen, pre_len - self.sliding_window - self.page_size)
         if self.page_size > 1:
             new_evicted = (new_evicted // self.page_size) * self.page_size
         if new_evicted <= req.swa_evicted_seqlen:
@@ -378,14 +378,14 @@ class TestSWAEviction(CustomTestCase):
 
     # 16
     def test_evict_basic(self):
-        """100 tokens, window=64 -> evicts [0, 36)."""
+        """100 tokens, window=64, page_size=1 → evicts [0, 35)."""
         req = self._make_req(origin_len=100, output_len=0)
         self._setup_req_tokens(req, 100)
         pre_len = 100
 
         swa_before = self.alloc.swa_available_size()
         self._evict(req, pre_len)
-        expected_evicted = pre_len - self.sliding_window  # 36
+        expected_evicted = pre_len - self.sliding_window - self.page_size  # 35
         self.assertEqual(req.swa_evicted_seqlen, expected_evicted)
         self.assertEqual(self.alloc.swa_available_size(), swa_before + expected_evicted)
 
@@ -416,7 +416,7 @@ class TestSWAEviction(CustomTestCase):
 
     # 19
     def test_evict_page_aligned(self):
-        """page_size=4: frontier aligns down to page boundary."""
+        """page_size=4: frontier includes the extra safety page and aligns down."""
         page_size = 4
         kvcache = _make_swa_pool(size=256, size_swa=256, page_size=page_size, mesh=self.mesh)
         alloc = SWATokenToKVPoolAllocator(
@@ -429,20 +429,20 @@ class TestSWAEviction(CustomTestCase):
         self.assertIsNotNone(indices)
         req_pool.req_to_token[req.req_pool_idx, :100] = indices
 
-        # pre_len=100, window=64 -> raw evicted=36 -> page-aligned=36//4*4=36
-        new_evicted = max(req.swa_evicted_seqlen, 100 - self.sliding_window)
-        new_evicted = (new_evicted // page_size) * page_size  # 36
-        self.assertEqual(new_evicted, 36)
+        # pre_len=100, window=64, page=4 → raw evicted=32 → page-aligned=32
+        new_evicted = max(req.swa_evicted_seqlen, 100 - self.sliding_window - page_size)
+        new_evicted = (new_evicted // page_size) * page_size
+        self.assertEqual(new_evicted, 32)
 
-        # pre_len=101 -> raw=37 -> aligned=36 (no change from 36)
-        new_evicted2 = max(36, 101 - self.sliding_window)
+        # pre_len=101 → raw=33 → aligned=32 (no change from 32)
+        new_evicted2 = max(32, 101 - self.sliding_window - page_size)
         new_evicted2 = (new_evicted2 // page_size) * page_size
-        self.assertEqual(new_evicted2, 36)
+        self.assertEqual(new_evicted2, 32)
 
-        # pre_len=104 -> raw=40 -> aligned=40
-        new_evicted3 = max(36, 104 - self.sliding_window)
+        # pre_len=104 → raw=36 → aligned=36
+        new_evicted3 = max(32, 104 - self.sliding_window - page_size)
         new_evicted3 = (new_evicted3 // page_size) * page_size
-        self.assertEqual(new_evicted3, 40)
+        self.assertEqual(new_evicted3, 36)
 
     # 20
     def test_evict_within_window_noop(self):
@@ -463,7 +463,7 @@ class TestSWAEviction(CustomTestCase):
         swa_before = self.alloc.swa_available_size()
 
         self._evict(req, 128)
-        expected_freed = 128 - self.sliding_window  # 64
+        expected_freed = 128 - self.sliding_window - self.page_size  # 63
         self.assertEqual(self.alloc.swa_available_size(), swa_before + expected_freed)
 
 
@@ -529,12 +529,21 @@ class TestSWAOverlapSafety(CustomTestCase):
 
     def _make_batch(self, req, *, enable_overlap, forward_mode, prefix_lens=None, chunked_req=None):
         from sgl_jax.srt.managers.schedule_batch import ScheduleBatch
+        from sgl_jax.srt.mem_cache.chunk_cache import ChunkCache
+
+        # Use ChunkCache for extend tests to match upstream behavior
+        # (SWA eviction during extend only happens for ChunkCache)
+        tree_cache = ChunkCache(
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.alloc,
+            page_size=self.page_size,
+        ) if forward_mode.is_extend() else None
 
         batch = ScheduleBatch(
             reqs=[req],
             req_to_token_pool=self.req_to_token_pool,
             token_to_kv_pool_allocator=self.alloc,
-            tree_cache=None,
+            tree_cache=tree_cache,
             is_hybrid=True,
             model_config=SimpleNamespace(sliding_window=self.sliding_window),
             forward_mode=forward_mode,
@@ -580,7 +589,7 @@ class TestSWAOverlapSafety(CustomTestCase):
         swa_before = self.alloc.swa_available_size()
         batch.maybe_evict_swa()
 
-        expected = req.seqlen - 1 - self.sliding_window
+        expected = req.seqlen - 1 - self.sliding_window - self.page_size
         self.assertEqual(req.swa_evicted_seqlen, expected)
         self.assertEqual(self.alloc.swa_available_size(), swa_before + expected)
 
@@ -642,7 +651,7 @@ class TestSWAOverlapSafety(CustomTestCase):
                 # len_{N-2} = max(0, cumulative - chunked_prefill_size).
                 in_flight_low = max(
                     0,
-                    cumulative - self.chunked_prefill_size - self.sliding_window,
+                    cumulative - self.chunked_prefill_size - self.sliding_window - self.page_size,
                 )
                 self.assertLessEqual(
                     req.swa_evicted_seqlen,

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -28,7 +28,10 @@ class TestSWARadixCache(CustomTestCase):
     def setUp(self):
         # Keep KV sizes small to make tests light-weight
         self.devices = jax.devices()
-        self.mesh = Mesh([self.devices[0]], axis_names=("tensor",))
+        self.mesh = Mesh(
+            np.array([self.devices[0]]).reshape(1, 1),
+            axis_names=("data", "tensor"),
+        )
 
         # Small buffers to avoid heavy allocations
         self.kv_head_num = 1
@@ -317,6 +320,115 @@ class TestSWARadixCache(CustomTestCase):
         np.testing.assert_array_equal(
             np.asarray(match_plain.device_indices), np.asarray(match_radix.device_indices)
         )
+
+
+    def test_delete_leaf_updates_swa_evictable_size(self):
+        cache = self.cache
+        indices = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), indices)
+        self.assertEqual(cache.swa_evictable_size_, 10)
+        cache.evict(10, 0)
+        self.assertEqual(cache.swa_evictable_size_, 0)
+        self.assertEqual(cache.full_evictable_size_, 0)
+
+    def test_tombstone_internal_updates_swa_evictable_size(self):
+        cache = self.cache
+        indices_a = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), indices_a)
+        indices_b = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), indices_b)
+        initial_swa = cache.swa_evictable_size_
+        cache.evict(0, 10)
+        self.assertEqual(cache.swa_evictable_size_, initial_swa - 10)
+
+    def test_insert_tombstone_full_revive(self):
+        """swa_evicted_seqlen=0 -> fully revive tombstone."""
+        cache = self.cache
+        idx1 = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx1)
+        idx2 = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
+        cache.evict(0, 10)  # tombstone the shared prefix
+        swa_after = cache.swa_evictable_size_
+        new_idx = self._alloc_indices(10)
+        cache.insert(
+            RadixKey(list(range(10)), None),
+            new_idx,
+            prev_prefix_len=0,
+            swa_evicted_seqlen=0,
+        )
+        self.assertEqual(cache.swa_evictable_size_, swa_after + 10)
+
+    def test_insert_tombstone_no_revive(self):
+        """swa_evicted_seqlen past node -> keep tombstone."""
+        cache = self.cache
+        idx1 = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx1)
+        idx2 = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
+        cache.evict(0, 10)
+        swa_after = cache.swa_evictable_size_
+        new_idx = self._alloc_indices(10)
+        cache.insert(
+            RadixKey(list(range(10)), None),
+            new_idx,
+            prev_prefix_len=0,
+            swa_evicted_seqlen=10,
+        )
+        self.assertEqual(cache.swa_evictable_size_, swa_after)
+
+    def test_new_node_all_swa_evicted(self):
+        """All in evicted range -> don't create node (no tombstone leaf)."""
+        cache = self.cache
+        idx = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=10)
+        self.assertEqual(cache.full_evictable_size_, 0)
+
+    def test_new_node_split_at_eviction_boundary(self):
+        """Eviction boundary in middle -> front tombstone + back live."""
+        cache = self.cache
+        idx = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=5)
+        self.assertEqual(cache.full_evictable_size_, 10)
+        self.assertEqual(cache.swa_evictable_size_, 5)
+
+    def test_evictable_size_returns_min(self):
+        cache = self.cache
+        indices = self._alloc_indices(10)
+        cache.insert(RadixKey(list(range(10)), None), indices)
+        self.assertEqual(cache.evictable_size(), 10)
+
+    def test_insert_then_evict_then_reinsert_cycle(self):
+        """Full cycle: insert -> tombstone -> re-insert with swa_evicted_seqlen."""
+        cache = self.cache
+        idx1 = self._alloc_indices(15)
+        cache.insert(RadixKey(list(range(15)), None), idx1)
+        idx2 = self._alloc_indices(5)
+        cache.insert(RadixKey(list(range(10)) + list(range(200, 205)), None), idx2)
+        cache.evict(0, 10)  # tombstone shared prefix
+        new_idx = self._alloc_indices(15)
+        cache.insert(
+            RadixKey(list(range(15)), None),
+            new_idx,
+            prev_prefix_len=0,
+            swa_evicted_seqlen=5,
+        )
+        cache.sanity_check()
+
+    def test_sanity_check_after_complex_operations(self):
+        cache = self.cache
+        for i in range(5):
+            idx = self._alloc_indices(10)
+            cache.insert(RadixKey(list(range(i * 3, i * 3 + 10)), None), idx)
+        cache.evict(5, 5)
+        for i in range(3):
+            idx = self._alloc_indices(8)
+            cache.insert(
+                RadixKey(list(range(i * 3, i * 3 + 8)), None),
+                idx,
+                swa_evicted_seqlen=3,
+            )
+        cache.sanity_check()
 
 
 class TestSchedulerCacheInit(CustomTestCase):

--- a/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
+++ b/python/sgl_jax/test/mem_cache/test_swa_radix_cache.py
@@ -81,6 +81,86 @@ class TestSWARadixCache(CustomTestCase):
         self.assertEqual(len(idx), n)
         return idx
 
+    # ------------------------------------------------------------------ #
+    #  Helpers for tombstone / size-consistency tests                      #
+    # ------------------------------------------------------------------ #
+
+    def _find_node_by_key_prefix(self, start_token):
+        """Walk tree from root to find the node whose key starts with start_token."""
+        root = self.cache.root_node
+        child_key = self.cache.get_child_key_fn(
+            RadixKey([start_token], None)
+        )
+        if child_key in root.children:
+            return root.children[child_key]
+        return None
+
+    def _make_small_cache(self, sliding_window_size=4):
+        """Create a cache with a small sliding window for tombstone tests."""
+        return SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=sliding_window_size,
+            page_size=1,
+            disable=False,
+        )
+
+    def _verify_size_consistency_for(self, cache, msg: str = ""):
+        """Walk the tree and verify that tracked sizes match actual tree content."""
+        full_total = 0
+        swa_total = 0
+        stack = [cache.root_node]
+        while stack:
+            node = stack.pop()
+            if node != cache.root_node and node.value is not None:
+                full_total += len(node.value)
+                if not node.swa_tombstone:
+                    swa_total += len(node.value)
+            stack.extend(node.children.values())
+
+        actual_full = cache.full_evictable_size_ + cache.full_protected_size_
+        actual_swa = cache.swa_evictable_size_ + cache.swa_protected_size_
+        self.assertEqual(
+            full_total, actual_full,
+            f"full size mismatch: tree={full_total}, tracked={actual_full}. {msg}",
+        )
+        self.assertEqual(
+            swa_total, actual_swa,
+            f"swa size mismatch: tree={swa_total}, tracked={actual_swa}. {msg}",
+        )
+
+    def _make_tree_with_tombstone(self):
+        """
+        Helper: insert two sequences that share a prefix into a small-window cache,
+        then SWA-evict the shared prefix so it becomes a tombstone.
+
+        Tree structure after setup:
+          root → [0..9] (internal, tombstone after evict)
+                    ├→ [10..14] (leaf A suffix)
+                    └→ [20..24] (leaf B suffix)
+
+        Returns (cache, key_a, val_a, key_b, val_b).
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        shared = list(range(0, 10))
+        key_a = shared + list(range(10, 15))
+        key_b = shared + list(range(20, 25))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        # SWA-evict: evict the shared internal node (LRU, oldest access)
+        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+
+        return cache, key_a, val_a, key_b, val_b
+
+    # ------------------------------------------------------------------ #
+    #  Original tests (preserved from local)                               #
+    # ------------------------------------------------------------------ #
+
     def test_insert_and_match_exact(self):
         """Insert a single sequence and match the same key."""
         key = list(range(100, 110))
@@ -321,114 +401,599 @@ class TestSWARadixCache(CustomTestCase):
             np.asarray(match_plain.device_indices), np.asarray(match_radix.device_indices)
         )
 
-
-    def test_delete_leaf_updates_swa_evictable_size(self):
-        cache = self.cache
-        indices = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), indices)
-        self.assertEqual(cache.swa_evictable_size_, 10)
-        cache.evict(10, 0)
-        self.assertEqual(cache.swa_evictable_size_, 0)
-        self.assertEqual(cache.full_evictable_size_, 0)
-
-    def test_tombstone_internal_updates_swa_evictable_size(self):
-        cache = self.cache
-        indices_a = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), indices_a)
-        indices_b = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), indices_b)
-        initial_swa = cache.swa_evictable_size_
-        cache.evict(0, 10)
-        self.assertEqual(cache.swa_evictable_size_, initial_swa - 10)
-
-    def test_insert_tombstone_full_revive(self):
-        """swa_evicted_seqlen=0 -> fully revive tombstone."""
-        cache = self.cache
-        idx1 = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx1)
-        idx2 = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
-        cache.evict(0, 10)  # tombstone the shared prefix
-        swa_after = cache.swa_evictable_size_
-        new_idx = self._alloc_indices(10)
-        cache.insert(
-            RadixKey(list(range(10)), None),
-            new_idx,
-            prev_prefix_len=0,
-            swa_evicted_seqlen=0,
-        )
-        self.assertEqual(cache.swa_evictable_size_, swa_after + 10)
-
-    def test_insert_tombstone_no_revive(self):
-        """swa_evicted_seqlen past node -> keep tombstone."""
-        cache = self.cache
-        idx1 = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx1)
-        idx2 = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(100, 105)), None), idx2)
-        cache.evict(0, 10)
-        swa_after = cache.swa_evictable_size_
-        new_idx = self._alloc_indices(10)
-        cache.insert(
-            RadixKey(list(range(10)), None),
-            new_idx,
-            prev_prefix_len=0,
-            swa_evicted_seqlen=10,
-        )
-        self.assertEqual(cache.swa_evictable_size_, swa_after)
-
-    def test_new_node_all_swa_evicted(self):
-        """All in evicted range -> don't create node (no tombstone leaf)."""
-        cache = self.cache
-        idx = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=10)
-        self.assertEqual(cache.full_evictable_size_, 0)
-
-    def test_new_node_split_at_eviction_boundary(self):
-        """Eviction boundary in middle -> front tombstone + back live."""
-        cache = self.cache
-        idx = self._alloc_indices(10)
-        cache.insert(RadixKey(list(range(10)), None), idx, swa_evicted_seqlen=5)
-        self.assertEqual(cache.full_evictable_size_, 10)
-        self.assertEqual(cache.swa_evictable_size_, 5)
-
     def test_evictable_size_returns_min(self):
         cache = self.cache
         indices = self._alloc_indices(10)
         cache.insert(RadixKey(list(range(10)), None), indices)
         self.assertEqual(cache.evictable_size(), 10)
 
-    def test_insert_then_evict_then_reinsert_cycle(self):
-        """Full cycle: insert -> tombstone -> re-insert with swa_evicted_seqlen."""
-        cache = self.cache
-        idx1 = self._alloc_indices(15)
-        cache.insert(RadixKey(list(range(15)), None), idx1)
-        idx2 = self._alloc_indices(5)
-        cache.insert(RadixKey(list(range(10)) + list(range(200, 205)), None), idx2)
-        cache.evict(0, 10)  # tombstone shared prefix
-        new_idx = self._alloc_indices(15)
-        cache.insert(
-            RadixKey(list(range(15)), None),
-            new_idx,
-            prev_prefix_len=0,
-            swa_evicted_seqlen=5,
-        )
-        cache.sanity_check()
+    # ------------------------------------------------------------------ #
+    #  T1-T12: Tombstone / protected-prefix correctness tests             #
+    # ------------------------------------------------------------------ #
 
-    def test_sanity_check_after_complex_operations(self):
-        cache = self.cache
-        for i in range(5):
-            idx = self._alloc_indices(10)
-            cache.insert(RadixKey(list(range(i * 3, i * 3 + 10)), None), idx)
-        cache.evict(5, 5)
-        for i in range(3):
-            idx = self._alloc_indices(8)
+    def test_tombstone_creation(self):
+        """T1: SWA evict creates tombstone on internal node, swa_evictable_size_ decreases."""
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        shared = list(range(0, 10))
+        key_a = shared + list(range(10, 15))
+        key_b = shared + list(range(20, 25))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        full_before, swa_before = cache.total_size()
+        self.assertEqual(full_before, swa_before)  # no tombstones yet
+        swa_evictable_before = cache.swa_evictable_size()
+
+        # SWA evict the shared prefix
+        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+
+        full_after, swa_after = cache.total_size()
+        # Full tokens unchanged (tombstone keeps full), SWA tokens decreased
+        self.assertEqual(full_after, full_before)
+        self.assertLess(swa_after, swa_before)
+
+        # swa_evictable_size_ should have decreased
+        swa_evictable_after = cache.swa_evictable_size()
+        self.assertLess(swa_evictable_after, swa_evictable_before)
+
+        # Walk the tree to find the shared internal node and verify tombstone
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        internal_node = cache.root_node.children[child_key]
+        self.assertTrue(internal_node.swa_tombstone)
+        self.assertEqual(len(internal_node.value), 10)
+
+        self._verify_size_consistency_for(cache, "after tombstone creation")
+
+    def test_tombstone_prefix_match(self):
+        """T2: Tombstone node does not affect prefix matching results when sliding window is satisfied."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # With sliding_window_size=4 and suffix length=5 (>4), matching should still work
+        match_a = cache.match_prefix(key_a)
+        self.assertEqual(len(match_a.device_indices), len(key_a))
+
+        match_b = cache.match_prefix(key_b)
+        self.assertEqual(len(match_b.device_indices), len(key_b))
+
+    def test_tombstone_healing_branch1(self):
+        """T3: swa_evicted_seqlen <= node_start → full revive of tombstone."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # Verify shared prefix is tombstone by walking tree
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        tombstone_node = cache.root_node.children[child_key]
+        self.assertTrue(tombstone_node.swa_tombstone)
+
+        # Re-insert key_a with swa_evicted_seqlen=0 (Branch 1: not evicted)
+        new_val = self._alloc_indices(len(key_a))
+        cache.insert(
+            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0
+        )
+
+        # The tombstone should be healed (revived)
+        healed_node = cache.root_node.children[child_key]
+        self.assertFalse(healed_node.swa_tombstone)
+
+        self._verify_size_consistency_for(cache, "after branch 1 healing")
+
+    def test_tombstone_healing_branch2(self):
+        """T4: swa_evicted_seqlen in middle of tombstone node → split and partial revive."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # Verify shared prefix is tombstone
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        tombstone_node = cache.root_node.children[child_key]
+        self.assertTrue(tombstone_node.swa_tombstone)
+
+        # Re-insert with swa_evicted_seqlen=5 (in the middle of shared[0:10])
+        # Branch 2: split at position 5, revive [5:10], keep [0:5] as tombstone
+        new_val = self._alloc_indices(len(key_a))
+        cache.insert(
+            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=5
+        )
+
+        # Walk tree: root → [0:5] (tombstone) → [5:10] (revived) → {[10:15], [20:24]}
+        front_node = cache.root_node.children[child_key]
+        self.assertTrue(front_node.swa_tombstone)
+        self.assertEqual(len(front_node.value), 5)
+
+        # The back node [5:10] should have been revived
+        # It should be a child of front_node
+        self.assertGreater(len(front_node.children), 0)
+        # Find the child whose key starts with token 5
+        back_child_key = cache.get_child_key_fn(RadixKey([5], None))
+        self.assertIn(back_child_key, front_node.children)
+        back_node = front_node.children[back_child_key]
+        self.assertFalse(back_node.swa_tombstone)
+        self.assertEqual(len(back_node.value), 5)
+
+        self._verify_size_consistency_for(cache, "after branch 2 healing")
+
+    def test_tombstone_healing_branch3(self):
+        """T5: swa_evicted_seqlen >= node_end → keep tombstone."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # Verify shared prefix is tombstone
+        child_key = cache.get_child_key_fn(RadixKey([0], None))
+        self.assertTrue(cache.root_node.children[child_key].swa_tombstone)
+
+        # Re-insert with swa_evicted_seqlen=15 (>= node_end=10)
+        # Branch 3: entire node already evicted → keep tombstone
+        new_val = self._alloc_indices(len(key_a))
+        cache.insert(
+            key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=15
+        )
+
+        # The shared prefix should still be tombstone
+        self.assertTrue(cache.root_node.children[child_key].swa_tombstone)
+
+        self._verify_size_consistency_for(cache, "after branch 3 (keep tombstone)")
+
+    def test_cascade_delete_tombstone(self):
+        """T6: Leaf delete cascades to tombstone parent."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        full_before, _ = cache.total_size()
+
+        # Evict enough full tokens to delete all leaves, which cascade to tombstone parent
+        cache.evict(full_num_tokens=full_before, swa_num_tokens=0)
+
+        full_after, swa_after = cache.total_size()
+        self.assertEqual(full_after, 0)
+        self.assertEqual(swa_after, 0)
+
+        self._verify_size_consistency_for(cache, "after cascade delete")
+
+    def test_size_tracking_consistency(self):
+        """T7: Insert/evict/delete cycle — sizes match actual tree at every step."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        keys = [list(range(i * 100, i * 100 + 20)) for i in range(5)]
+        vals = [self._alloc_indices(20) for _ in range(5)]
+
+        # Insert all
+        for k, v in zip(keys, vals):
+            cache.insert(k, value=v, prev_prefix_len=0)
+            self._verify_size_consistency_for(cache, f"after insert {k[0]}")
+
+        # SWA evict some
+        cache.evict(full_num_tokens=0, swa_num_tokens=20)
+        self._verify_size_consistency_for(cache, "after swa evict 20")
+
+        # Full evict some
+        cache.evict(full_num_tokens=20, swa_num_tokens=0)
+        self._verify_size_consistency_for(cache, "after full evict 20")
+
+        # Insert more (reuse prefix)
+        new_key = keys[0] + [999, 998, 997]
+        new_val = self._alloc_indices(len(new_key))
+        cache.insert(new_key, value=new_val, prev_prefix_len=0)
+        self._verify_size_consistency_for(cache, "after re-insert with extension")
+
+        # Evict everything
+        full_total, _ = cache.total_size()
+        cache.evict(full_num_tokens=full_total, swa_num_tokens=0)
+        self._verify_size_consistency_for(cache, "after evict all")
+
+    def test_protected_prefix_basic(self):
+        """T8: The protected tree prefix prevents swa_evicted_seqlen from corrupting tree slots during insert."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 20))
+        val_first = self._alloc_indices(len(key))
+
+        # First insert: puts everything into tree
+        cache.insert(key, value=val_first, prev_prefix_len=0)
+
+        # Match to confirm
+        match = cache.match_prefix(key)
+        self.assertEqual(len(match.device_indices), 20)
+
+        # SWA-evict to create tombstone
+        cache.evict(full_num_tokens=0, swa_num_tokens=20)
+
+        # Second insert with protected_prefix_len=10 (prev_prefix_len) and swa_evicted_seqlen=5
+        # Branch 2 applies: swa_evicted_seqlen(5) < node_end(20), split at 5, revive [5:20]
+        val_second = self._alloc_indices(len(key))
+        cache.insert(
+            key, value=val_second, prev_prefix_len=10, swa_evicted_seqlen=5
+        )
+
+        # Match should still return 20 tokens (sliding_window=4, suffix > 4)
+        match2 = cache.match_prefix(key)
+        self.assertEqual(len(match2.device_indices), 20)
+
+        self._verify_size_consistency_for(cache, "after protected prefix insert")
+
+    def test_new_node_tombstone_split(self):
+        """T9: New node crossing swa_evicted_seqlen boundary → correct split."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 20))
+        val = self._alloc_indices(len(key))
+
+        # Insert with swa_evicted_seqlen=10 → new node should be split:
+        # [0:10] as tombstone + [10:20] as non-tombstone
+        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10)
+
+        full_total, swa_total = cache.total_size()
+        self.assertEqual(full_total, 20)
+        self.assertEqual(swa_total, 10)  # only [10:20] has SWA
+
+        # Verify tree structure: root should have one child (tombstone [0:10])
+        # which has one child (non-tombstone [10:20])
+        root = cache.root_node
+        self.assertEqual(len(root.children), 1)
+        child_key = list(root.children.keys())[0]
+        tombstone_node = root.children[child_key]
+        self.assertTrue(tombstone_node.swa_tombstone)
+        self.assertEqual(len(tombstone_node.value), 10)
+
+        self.assertEqual(len(tombstone_node.children), 1)
+        leaf_key = list(tombstone_node.children.keys())[0]
+        leaf_node = tombstone_node.children[leaf_key]
+        self.assertFalse(leaf_node.swa_tombstone)
+        self.assertEqual(len(leaf_node.value), 10)
+
+        # Match should return all 20 tokens (sliding_window=4, non-tombstone suffix=10 > 4)
+        match = cache.match_prefix(key)
+        self.assertEqual(len(match.device_indices), 20)
+
+        self._verify_size_consistency_for(cache, "after new node tombstone split")
+
+    def test_evict_both_pools(self):
+        """T10: Phase 1 (leaf) + Phase 2 (tombstone) interleaved eviction."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        shared = list(range(0, 8))
+        key_a = shared + list(range(10, 18))
+        key_b = shared + list(range(20, 28))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        full_before, swa_before = cache.total_size()
+        self.assertEqual(full_before, swa_before)
+
+        # Phase 2 SWA evict: should tombstone the shared prefix
+        cache.evict(full_num_tokens=0, swa_num_tokens=len(shared))
+        full_mid, swa_mid = cache.total_size()
+        self.assertEqual(full_mid, full_before)  # full unchanged
+        self.assertLess(swa_mid, swa_before)  # SWA decreased
+        self._verify_size_consistency_for(cache, "after phase 2 evict")
+
+        # Phase 1 full evict: should delete leaf + cascade tombstone
+        cache.evict(full_num_tokens=8, swa_num_tokens=0)
+        full_after, swa_after = cache.total_size()
+        self.assertLess(full_after, full_mid)
+        self._verify_size_consistency_for(cache, "after phase 1 evict")
+
+    def test_insert_after_tombstone_evict_cycle(self):
+        """T11: Multiple insert→evict→insert cycles — no size leaks."""
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        for cycle in range(5):
+            key = list(range(cycle * 100, cycle * 100 + 16))
+            val = self._alloc_indices(len(key))
+            cache.insert(key, value=val, prev_prefix_len=0)
+            self._verify_size_consistency_for(cache, f"cycle {cycle} insert")
+
+            # SWA evict some
+            cache.evict(full_num_tokens=0, swa_num_tokens=8)
+            self._verify_size_consistency_for(cache, f"cycle {cycle} swa evict")
+
+            # Re-insert with new values (simulating healing)
+            new_val = self._alloc_indices(len(key))
             cache.insert(
-                RadixKey(list(range(i * 3, i * 3 + 8)), None),
-                idx,
-                swa_evicted_seqlen=3,
+                key, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=0
             )
-        cache.sanity_check()
+            self._verify_size_consistency_for(cache, f"cycle {cycle} re-insert")
+
+        # Final full evict
+        full_total, _ = cache.total_size()
+        cache.evict(full_num_tokens=full_total + 100, swa_num_tokens=0)
+        full_final, swa_final = cache.total_size()
+        self.assertEqual(full_final, 0, "full size should be 0 after evict all")
+        self.assertEqual(swa_final, 0, "swa size should be 0 after evict all")
+        self._verify_size_consistency_for(cache, "after final evict all")
+
+    def test_size_tracking_fuzz(self):
+        """T12: Random operations, verify size consistency at each step."""
+        import random
+
+        rng = random.Random(42)
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        for step in range(50):
+            op = rng.choice(["insert", "evict_swa", "evict_full"])
+            if op == "insert":
+                length = rng.randint(4, 32)
+                start = rng.randint(0, 500)
+                key = list(range(start, start + length))
+                val = self._alloc_indices(length)
+                swa_evicted = rng.choice([0, 0, 0, rng.randint(0, length)])
+                cache.insert(
+                    key, value=val, prev_prefix_len=0,
+                    swa_evicted_seqlen=swa_evicted,
+                )
+            elif op == "evict_swa":
+                amount = rng.randint(1, 16)
+                cache.evict(full_num_tokens=0, swa_num_tokens=amount)
+            else:
+                amount = rng.randint(1, 16)
+                cache.evict(full_num_tokens=amount, swa_num_tokens=0)
+
+            self._verify_size_consistency_for(cache, f"fuzz step {step} op={op}")
+
+    # ------------------------------------------------------------------ #
+    #  T13-T22: Gap fix verification tests                                #
+    # ------------------------------------------------------------------ #
+
+    def test_tombstone_reset_unconditional(self):
+        """T13: _match_prefix_helper resets match_len_since_tombstone even when
+        sliding window check fails.
+
+        Scenario: Two consecutive tombstone nodes on the path. Before the fix,
+        the second tombstone would NOT reset match_len_since_tombstone because
+        the first tombstone already set it to 0 (< sliding_window_size), so the
+        condition was False and the reset was skipped. After the fix, the reset
+        is unconditional.
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        # Build a tree: root → [0..4] → [5..9] → [10..14] (leaf)
+        # We insert two sequences to force a split so the shared prefixes become
+        # internal nodes that we can tombstone independently.
+        shared1 = list(range(0, 5))
+        shared2 = list(range(5, 10))
+        suffix_a = list(range(10, 15))
+        suffix_b = list(range(20, 25))
+
+        key_a = shared1 + shared2 + suffix_a
+        key_b = shared1 + shared2 + suffix_b
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        # SWA-evict both shared prefixes: first [0..4], then [5..9]
+        # This creates two consecutive tombstone nodes
+        cache.evict(full_num_tokens=0, swa_num_tokens=10)
+
+        # Walk tree to verify two tombstones
+        child_key_0 = cache.get_child_key_fn(RadixKey([0], None))
+        node_0_4 = cache.root_node.children[child_key_0]
+        self.assertTrue(node_0_4.swa_tombstone, "First shared prefix should be tombstone")
+
+        # Match should still work: suffix (5 tokens) > sliding_window (4)
+        match_a = cache.match_prefix(key_a)
+        # Even with two consecutive tombstones, the suffix after the last tombstone
+        # should be enough to match if it exceeds sliding_window_size
+        self.assertGreater(len(match_a.device_indices), 0)
+
+        self._verify_size_consistency_for(cache, "after double tombstone match")
+
+    def test_new_leaf_never_tombstone(self):
+        """T14: When swa_evicted_seqlen >= total_prefix_length + len(key),
+        all remaining tokens are SWA-evicted. No node is created (can't be
+        non-tombstone because SWA is gone, can't be tombstone leaf because
+        of the leaf-must-not-be-tombstone invariant). Value is freed and
+        insert returns early.
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 10))
+        val = self._alloc_indices(len(key))
+
+        # Insert with swa_evicted_seqlen=20 (>> total_prefix_length + len(key) = 10)
+        # Upstream behavior: free value, return early, no node created
+        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=20)
+
+        full_total, swa_total = cache.total_size()
+        # No node created → tree is empty
+        self.assertEqual(full_total, 0)
+        self.assertEqual(swa_total, 0)
+
+        # Root should have no children
+        self.assertEqual(len(cache.root_node.children), 0)
+
+        self._verify_size_consistency_for(cache, "after all-evicted insert")
+
+    def test_new_leaf_never_tombstone_exact_boundary(self):
+        """T15: swa_evicted_seqlen == total_prefix_length + len(key) boundary case.
+
+        When swa_evicted_seqlen exactly equals total_prefix_length + len(key),
+        all tokens are SWA-evicted. No node is created, value is freed.
+        """
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 10))
+        val = self._alloc_indices(len(key))
+
+        # swa_evicted_seqlen == total_prefix_length(0) + len(key)(10) = 10
+        cache.insert(key, value=val, prev_prefix_len=0, swa_evicted_seqlen=10)
+
+        full_total, swa_total = cache.total_size()
+        # No node created → tree is empty
+        self.assertEqual(full_total, 0)
+        self.assertEqual(swa_total, 0)
+
+        # Root should have no children
+        self.assertEqual(len(cache.root_node.children), 0)
+
+        self._verify_size_consistency_for(cache, "after exact boundary insert")
+
+    def test_delete_leaf_uses_child_key_fn(self):
+        """T17: _delete_leaf correctly removes nodes using get_child_key_fn lookup."""
+        cache = self._make_small_cache(sliding_window_size=4)
+
+        # Insert two sequences sharing a prefix to create internal + leaf structure
+        shared = list(range(0, 5))
+        key_a = shared + list(range(10, 15))
+        key_b = shared + list(range(20, 25))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        cache.insert(key_b, value=val_b, prev_prefix_len=0)
+
+        full_before, swa_before = cache.total_size()
+        self.assertEqual(full_before, 15)  # 5 shared + 5 suffix_a + 5 suffix_b
+
+        # The tree has: root → [0..4] (internal) → {[10..14] (leaf A), [20..24] (leaf B)}
+        # Evict one leaf by full eviction
+        cache.evict(full_num_tokens=5, swa_num_tokens=0)
+
+        full_after, swa_after = cache.total_size()
+        self.assertLess(full_after, full_before)
+
+        # Verify tree is still consistent
+        self._verify_size_consistency_for(cache, "after leaf delete via child_key_fn")
+
+    def test_delete_tombstone_leaf_uses_child_key_fn(self):
+        """T18: _delete_tombstone_leaf correctly removes tombstone nodes using get_child_key_fn."""
+        cache, key_a, val_a, key_b, val_b = self._make_tree_with_tombstone()
+
+        # At this point: shared prefix is tombstone, two leaves exist
+        full_before, _ = cache.total_size()
+
+        # Full evict everything — should cascade delete tombstone parent via _delete_tombstone_leaf
+        cache.evict(full_num_tokens=full_before, swa_num_tokens=0)
+
+        full_after, swa_after = cache.total_size()
+        self.assertEqual(full_after, 0)
+        self.assertEqual(swa_after, 0)
+
+        # Root should have no children
+        self.assertEqual(len(cache.root_node.children), 0)
+        self._verify_size_consistency_for(cache, "after tombstone cascade delete via child_key_fn")
+
+    def test_evict_req_swa_uses_locked_tree_boundary(self):
+        """T19: Request SWA eviction derives its protected boundary from the locked tree path."""
+        cache = self._make_small_cache(sliding_window_size=4)
+        key = list(range(0, 20))
+        tree_indices = self._alloc_indices(len(key))
+        cache.insert(key, value=tree_indices, prev_prefix_len=0)
+        match = cache.match_prefix(key)
+
+        tail_indices = self._alloc_indices(10)
+        req_indices = np.concatenate([tree_indices, tail_indices])
+        self.req_pool.req_to_token[0, :30] = req_indices
+
+        class MockReq:
+            def __init__(self, last_node):
+                self.swa_evicted_seqlen = 3
+                self.req_pool_idx = 0
+                self.last_node = last_node
+
+        req = MockReq(match.last_device_node)
+        swa_before = self.allocator.swa_available_size()
+
+        cache.evict_req_swa(req, pre_len=30)
+
+        # Protected prefix is 20, so only uncached tail slots [20:25) are reclaimed.
+        self.assertEqual(req.swa_evicted_seqlen, 25)
+        self.assertEqual(self.allocator.swa_available_size(), swa_before + 5)
+        self.assertEqual(self.allocator.count_swa_mapped(tree_indices), len(tree_indices))
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[:5]), 0)
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[5:]), 5)
+
+    def test_evict_req_swa_page_alignment_uses_tree_boundary(self):
+        """T20: Request SWA eviction aligns by page size using the tree-derived protected boundary."""
+        paged_cache = SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=4,
+            page_size=4,
+            disable=False,
+        )
+
+        key = list(range(0, 8))
+        tree_indices = self._alloc_indices(len(key))
+        paged_cache.insert(key, value=tree_indices, prev_prefix_len=0)
+        match = paged_cache.match_prefix(key)
+
+        tail_indices = self._alloc_indices(12)
+        req_indices = np.concatenate([tree_indices, tail_indices])
+        self.req_pool.req_to_token[0, :20] = req_indices
+
+        class MockReq:
+            def __init__(self, last_node):
+                self.swa_evicted_seqlen = 0
+                self.req_pool_idx = 0
+                self.last_node = last_node
+
+        req = MockReq(match.last_device_node)
+
+        paged_cache.evict_req_swa(req, pre_len=20)
+
+        # Protected prefix is 8. The eviction frontier is 20 - 4 - 4 = 12, already aligned.
+        self.assertEqual(req.swa_evicted_seqlen, 12)
+        self.assertEqual(self.allocator.count_swa_mapped(tree_indices), len(tree_indices))
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[:4]), 0)
+        self.assertEqual(self.allocator.count_swa_mapped(tail_indices[4:]), 8)
+
+    def test_swa_evicted_seqlen_page_alignment_assertion(self):
+        """T21: _insert_helper asserts swa_evicted_seqlen % page_size == 0 when handling tombstones."""
+        # Create a paged cache with page_size=4
+        paged_cache = SWARadixCache(
+            req_to_token_pool=self.req_pool,
+            token_to_kv_pool_allocator=self.allocator,
+            sliding_window_size=64,
+            page_size=4,
+            disable=False,
+        )
+
+        # Insert then tombstone: create a sequence, evict its SWA to make tombstone
+        shared = list(range(0, 8))
+        key_a = shared + list(range(10, 18))
+        key_b = shared + list(range(20, 28))
+        val_a = self._alloc_indices(len(key_a))
+        val_b = self._alloc_indices(len(key_b))
+
+        paged_cache.insert(key_a, value=val_a, prev_prefix_len=0)
+        paged_cache.insert(key_b, value=val_b, prev_prefix_len=0)
+        paged_cache.evict(full_num_tokens=0, swa_num_tokens=8)
+
+        # Re-inserting with non-page-aligned swa_evicted_seqlen should assert
+        new_val = self._alloc_indices(len(key_a))
+        with self.assertRaises(AssertionError):
+            paged_cache.insert(
+                key_a, value=new_val, prev_prefix_len=0, swa_evicted_seqlen=3
+            )
+
+    def test_cache_unfinished_req_writeback_range(self):
+        """T22: cache_unfinished_req writes back from last_matched_prefix_len, not len(prefix_indices)."""
+        cache = self._make_small_cache(sliding_window_size=64)
+
+        # Simulate first insert (initial request)
+        key_part1 = list(range(0, 10))
+        val1 = self._alloc_indices(len(key_part1))
+        cache.insert(key_part1, value=val1, prev_prefix_len=0)
+
+        # After first insert, match should return all 10 tokens
+        match1 = cache.match_prefix(key_part1)
+        self.assertEqual(len(match1.device_indices), 10)
+
+        # Insert extended sequence (simulating cache_unfinished_req)
+        key_full = list(range(0, 20))
+        val2 = self._alloc_indices(len(key_full))
+        new_prefix_len = cache.insert(
+            key_full, value=val2, prev_prefix_len=10, swa_evicted_seqlen=0
+        )
+
+        # Match the full key
+        match2 = cache.match_prefix(key_full)
+        self.assertEqual(len(match2.device_indices), 20)
+
+        # Verify old cached indices are preserved (not overwritten)
+        np.testing.assert_array_equal(
+            np.asarray(match2.device_indices[:10]),
+            np.asarray(match1.device_indices),
+        )
+
+        self._verify_size_consistency_for(cache, "after simulated cache_unfinished_req")
 
 
 class TestSchedulerCacheInit(CustomTestCase):

--- a/test/srt/run_suite.py
+++ b/test/srt/run_suite.py
@@ -517,6 +517,7 @@ suites = {
         TestFile("test/srt/openai_server/features/test_structural_tag.py", 2),
         TestFile("test/srt/test_srt_engine.py", 1),
         TestFile("test/srt/test_logprobs.py", 3),
+        TestFile("test/srt/test_penalty.py", 12),
         TestFile("test/srt/test_qwen1_5_models_dummy.py", 3),
         TestFile("test/srt/lora/test_bgmv_backend.py", 6),
         TestFile("test/srt/lora/test_dynamic_lora.py", 10),

--- a/test/srt/test_penalty.py
+++ b/test/srt/test_penalty.py
@@ -1,0 +1,227 @@
+"""
+Functional tests for penalty parameters (frequency / presence / combined).
+
+Ports sglang PR #11931 to sgl-jax (aligned with the evolved upstream form
+that uses vocabulary diversity + fixed seeds for stability). Validates that
+penalty params actually shape token output distribution, not merely that
+the server accepts them.
+
+Note: sgl-jax does not currently implement repetition_penalty
+(no BatchedRepetitionPenalizer in penaltylib/), so no test here passes
+repetition_penalty.
+
+Usage:
+    python3 -m unittest test_penalty.TestPenalty -v
+"""
+
+import re
+import unittest
+
+import requests
+
+from sgl_jax.srt.utils import kill_process_tree
+from sgl_jax.test.test_utils import (
+    DEFAULT_SMALL_MODEL_NAME_FOR_TEST,
+    DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    popen_launch_server,
+)
+
+
+class TestPenalty(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEFAULT_SMALL_MODEL_NAME_FOR_TEST
+        cls.base_url = DEFAULT_URL_FOR_TEST
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            device="tpu",
+            other_args=[
+                "--trust-remote-code",
+                "--skip-server-warmup",
+                "--random-seed",
+                "3",
+                "--mem-fraction-static",
+                "0.65",
+                "--max-prefill-tokens",
+                "8192",
+                "--download-dir",
+                "/dev/shm/",
+                "--dtype",
+                "bfloat16",
+                "--attention-backend",
+                "fa",
+                "--page-size",
+                "64",
+                "--max-running-requests",
+                "64",
+            ],
+            env={
+                "JAX_COMPILATION_CACHE_DIR": "/tmp/jax_compilation_cache",
+            },
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def run_generate_with_prompt(self, prompt, sampling_params, max_tokens=100, seed=None):
+        """POST to /v1/chat/completions with the given prompt and params."""
+        sampling_params = sampling_params.copy()
+        sampling_params.setdefault("temperature", 0.05)
+        sampling_params.setdefault("top_p", 1.0)
+        if seed is not None:
+            sampling_params["seed"] = seed
+
+        response = requests.post(
+            self.base_url + "/v1/chat/completions",
+            json={
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+                **sampling_params,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        content = result["choices"][0]["message"]["content"]
+        return content
+
+    def _get_vocab_diversity(self, text):
+        """Calculate vocabulary diversity as unique_words / total_words.
+
+        Higher values mean more diverse (less repetitive) text.
+        """
+        words = re.findall(r"\b\w+\b", text.lower())
+        if not words:
+            return 1.0
+        return len(set(words)) / len(words)
+
+    def _test_penalty_effect(
+        self,
+        prompt,
+        baseline_params,
+        penalty_params,
+        expected_reduction=True,
+        max_tokens=150,
+    ):
+        """Generic test for penalty effects using vocabulary diversity.
+
+        Measures unique_words/total_words ratio instead of counting a specific
+        word, because penalties affect ALL token probabilities -- the model may
+        avoid some repeated tokens while using others more.
+        """
+        # Use higher temperature so penalties can actually affect token selection.
+        # The default temperature (0.05) is near-greedy, making penalty adjustments
+        # to logits ineffective since the top token still dominates.
+        baseline_params = baseline_params.copy()
+        penalty_params = penalty_params.copy()
+        baseline_params.setdefault("temperature", 0.8)
+        penalty_params.setdefault("temperature", 0.8)
+
+        base_seed = 42
+        baseline_diversities = []
+        penalty_diversities = []
+
+        for i in range(5):
+            seed = base_seed + i
+            baseline_output = self.run_generate_with_prompt(
+                prompt, baseline_params, max_tokens, seed=seed
+            )
+            penalty_output = self.run_generate_with_prompt(
+                prompt, penalty_params, max_tokens, seed=seed
+            )
+
+            baseline_diversities.append(self._get_vocab_diversity(baseline_output))
+            penalty_diversities.append(self._get_vocab_diversity(penalty_output))
+
+        avg_baseline = sum(baseline_diversities) / len(baseline_diversities)
+        avg_penalty = sum(penalty_diversities) / len(penalty_diversities)
+
+        if expected_reduction:
+            self.assertGreater(
+                avg_penalty,
+                avg_baseline,
+                f"Penalty should increase vocab diversity: "
+                f"{avg_baseline:.3f} -> {avg_penalty:.3f}",
+            )
+        else:
+            self.assertLess(
+                avg_penalty,
+                avg_baseline,
+                f"Negative penalty should decrease vocab diversity: "
+                f"{avg_baseline:.3f} -> {avg_penalty:.3f}",
+            )
+
+    def test_frequency_penalty_reduces_word_repetition(self):
+        """frequency_penalty should increase vocabulary diversity."""
+        prompt = (
+            "Write exactly 10 very small sentences, each containing the word "
+            "'data'. Use the word 'data' as much as possible."
+        )
+        baseline_params = {"frequency_penalty": 0.0}
+        penalty_params = {"frequency_penalty": 1.99}
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
+
+    def test_presence_penalty_reduces_topic_repetition(self):
+        """presence_penalty should increase vocabulary diversity."""
+        prompt = (
+            "Write the word 'machine learning' exactly 20 times in a row, " "separated by spaces."
+        )
+        baseline_params = {"presence_penalty": 0.0}
+        penalty_params = {"presence_penalty": 1.99}
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
+
+    def test_combined_penalties_reduce_repetition(self):
+        """Combined frequency + presence penalties should increase vocab diversity."""
+        prompt = (
+            "Write exactly 10 short sentences, each containing the word 'data'. "
+            "Use the word 'data' as much as possible."
+        )
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        penalty_params = {
+            "frequency_penalty": 1.99,
+            "presence_penalty": 1.99,
+        }
+        self._test_penalty_effect(prompt, baseline_params, penalty_params)
+
+    def test_penalty_edge_cases_negative_penalty_values(self):
+        """Negative penalty values should decrease vocabulary diversity."""
+        prompt = "Write the word 'test' exactly 15 times in a row, separated by spaces."
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        negative_penalty_params = {
+            "frequency_penalty": -0.5,
+            "presence_penalty": -0.25,
+        }
+        self._test_penalty_effect(
+            prompt,
+            baseline_params,
+            negative_penalty_params,
+            expected_reduction=False,
+        )
+
+    def test_penalty_edge_cases_extreme_penalty_values(self):
+        """Extreme penalty values should strongly increase vocabulary diversity."""
+        prompt = "Write the word 'extreme' exactly 20 times in a row, separated by spaces."
+        baseline_params = {
+            "frequency_penalty": 0.0,
+            "presence_penalty": 0.0,
+        }
+        extreme_penalty_params = {
+            "frequency_penalty": 2.0,
+            "presence_penalty": 2.0,
+        }
+        self._test_penalty_effect(prompt, baseline_params, extreme_penalty_params)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
> **TODO**: Rebase after dp attention (#950) merges, then convert to ready-for-review.

## Summary

This PR adds sliding-window attention (SWA) support to the radix cache, enabling KV prefix reuse for hybrid models (e.g., MiMo) that mix full-attention and sliding-window-attention layers.

Previously, SWA was only supported with `ChunkCache` (`--disable-radix-cache`). This PR extends support to the radix tree cache (`SWARadixCache`), allowing prefix sharing across requests while correctly managing the dual-pool (full + SWA) KV memory.

## Core Changes

| Area | Change |
|------|--------|
| `SWARadixCache.evict_req_swa` | Per-request SWA eviction with tree-owned prefix protection. Uses `_node_prefix_len(req.last_node)` to derive the protected boundary, preventing eviction of tree-cached SWA slots. |
| `_evict_swa` safety margin | Eviction formula changed from `pre_len - sliding_window` to `pre_len - sliding_window - page_size`. The extra `- page_size` margin prevents `swa_evicted_seqlen` from reaching the live leaf boundary, ensuring `_insert_helper` can always create a non-tombstone leaf. |
| `_insert_helper` tombstone logic | Two sets of tombstone branch handling: (1) **Existing tombstone healing** (while loop) — 3 branches based on `swa_evicted_seqlen` vs `[node_start, node_end)`: full revive, split+partial revive, keep tombstone. (2) **New node tombstone split** (after while loop) — 3 cases ensuring leaf-must-not-be-tombstone invariant. |
| `_match_prefix_helper` | Stops at tombstone nodes to prevent returning SWA-freed slots as valid prefix. Unconditionally resets tombstone counter on each call. |
| Phase 2 SWA-only eviction | Uses `swa_lru_list` to find LRU nodes. Internal nodes become tombstones (SWA freed, full retained). Leaf nodes are fully deleted (both pools) to preserve the leaf-must-not-be-tombstone invariant, with cascade delete on parent. |
| Extend path gating | `isinstance(self.tree_cache, ChunkCache)` check — SWA eviction during extend only fires for `ChunkCache`, not `SWARadixCache`. For radix cache, SWA reclamation is deferred to tree-level Phase 2 eviction. |

## Tombstone Healing (3 Branches)

When `_insert_helper` walks through an existing tombstone node beyond `update_kv_after_len`, it checks `swa_evicted_seqlen` against `[node_start, node_end)`:

| Branch | Condition | Action |
|--------|-----------|--------|
| 1 | `swa_evicted <= node_start` | Revive entire node (re-allocate SWA slots) |
| 2 | `node_start < swa_evicted < node_end` | Split node, revive back half only |
| 3 | `swa_evicted >= node_end` | Keep tombstone, free incoming SWA value |

## Test Coverage

| Category | Tests | Description |
|----------|-------|-------------|
| Tombstone lifecycle | 6 | Creation, prefix match, 3-branch healing, cascade delete |
| Size tracking | 3 | Consistency checks, fuzz testing (50-step random ops) |
| Protected prefix | 3 | Tree boundary protection, page alignment, `evict_req_swa` |
| New node invariants | 3 | Tombstone split, leaf-never-tombstone, exact boundary |
| Delete correctness | 2 | `get_child_key_fn` usage for O(1) delete |
| Writeback | 1 | `cache_unfinished_req` writeback range |
| Allocator safety margin | 5 | Updated expectations for `- page_size` formula |
| **Total new/updated** | **23** | |

## Design Document

Added `docs/design/swa_eviction_and_lru_strategy.md` covering:
- Dual-pool architecture (full pool + SWA pool)
- Per-request SWA eviction (ChunkCache vs SWARadixCache paths)
- Extend phase behavior (proactive vs deferred)
- Tree-level eviction (Phase 1 full delete + Phase 2 SWA-only tombstone)
- Tombstone insert logic (existing healing + new node split)
- LRU policy (dual lists: `full_lru_list` + `swa_lru_list`)

## Motivation

SWA layers only need recent tokens within the sliding window, but without radix cache support, every request allocated full-length SWA KV buffers with no prefix reuse. This wastes significant memory for models with many SWA layers (e.g., MiMo-V2-Flash has 39 SWA layers out of 48 total).

With this PR, SWA slots outside the window are freed progressively (per-request during decode, tree-level Phase 2 under memory pressure), while full KV remains in the tree for prefix matching. This reduces SWA memory usage to approximately `sliding_window + page_size` tokens per request for SWA layers.