### PR TITLE
demo: single-thread overlap via JAX async dispatch

### DIFF
--- a/scripts/demo_overlap.py
+++ b/scripts/demo_overlap.py
@@ -1,0 +1,261 @@
+"""
+对比 sglang-jax 当前双线程 overlap vs 单线程 async dispatch overlap。
+严格对齐真实 scheduler 的调用顺序。
+包含正确性校验 + 性能对比 + JAX profiling。
+"""
+
+import os
+import threading
+import time
+from queue import Queue
+
+os.environ.setdefault("JAX_PLATFORMS", "tpu")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+# ---------- 模拟 model forward ----------
+
+
+@jax.jit
+@jax.named_scope("model_forward")
+def model_forward(input_ids, weight):
+    # embedding lookup: 不同 token id → 不同初始向量 → 不同计算结果
+    x = weight[input_ids % weight.shape[0]]  # (bs, dim)
+    for _ in range(100):
+        x = x @ weight + x
+    return jnp.argmax(x, axis=-1).astype(jnp.int32)
+
+
+# ---------- future token ID 操作 ----------
+
+
+@jax.jit
+@jax.named_scope("set_future")
+def set_future_token_ids(future_map, start, next_token_ids):
+    return jax.lax.dynamic_update_slice(future_map, next_token_ids, (start + 1,))
+
+
+@jax.jit
+@jax.named_scope("resolve_future")
+def resolve_future_token_ids(input_ids, future_map):
+    return jnp.where(
+        input_ids < 0,
+        future_map[jnp.clip(-input_ids, min=0)],
+        input_ids,
+    )
+
+
+# ---------- 模拟 CPU 调度工作 ----------
+
+
+def cpu_scheduling(ms: float = 3.0):
+    end = time.perf_counter() + ms / 1000.0
+    while time.perf_counter() < end:
+        pass
+
+
+# =====================================================================
+# 方式 A: 双线程 overlap (对齐真实 scheduler 流程)
+#
+# 真实 scheduler 每轮循环 (scheduler.py:565-601):
+#   1. run_batch(batch_N)
+#        → forward_batch_generation(): input_queue.put + 返回 future token ids
+#   2. process_batch_result(batch_N-1)
+#        → resolve_last_batch_result(): output_queue.get + device_get
+#        → CPU 工作: 处理结果, 攒批, 准备下一个 batch
+#
+# 重叠: step 2 的 CPU 工作 与 forward thread 计算 batch_N 重叠
+#
+# forward thread (tp_worker_overlap_thread.py:94-128):
+#   input_queue.get() → resolve_future → forward → set_future → output_queue.put
+#   (全部 async dispatch, 不做 device_get)
+# =====================================================================
+
+
+def run_two_thread(weight, steps, cpu_ms):
+    bs = weight.shape[0]
+    future_map = jnp.zeros((bs * (steps + 5),), dtype=jnp.int32)
+    future_ct = 0
+
+    input_queue = Queue()
+    output_queue = Queue()
+
+    fwd_step = [0]  # mutable counter for forward thread
+
+    def forward_thread_func():
+        nonlocal future_map
+        while True:
+            item = input_queue.get()
+            if item is None:
+                break
+            input_ids, ft_ct = item
+            with jax.profiler.TraceAnnotation(f"fwd_thread_batch_{fwd_step[0]}"):
+                resolved = resolve_future_token_ids(input_ids, future_map)
+                tokens = model_forward(resolved, weight)
+                future_map = set_future_token_ids(future_map, ft_ct, tokens)
+            output_queue.put(tokens)
+            fwd_step[0] += 1
+
+    t = threading.Thread(target=forward_thread_func, daemon=True)
+    t.start()
+
+    times = []
+    results = []
+    input_ids = jnp.arange(bs, dtype=jnp.int32) + 1
+
+    for step in range(steps):
+        t0 = time.perf_counter()
+
+        # ---- Step 1: run_batch(batch_N) ----
+        with jax.profiler.TraceAnnotation(f"send_batch_{step}"):
+            input_queue.put((input_ids, future_ct))
+            future_indices = -(future_ct + 1 + np.arange(bs))
+            future_ct += bs
+            input_ids = jnp.array(future_indices, dtype=jnp.int32)
+
+        # ---- Step 2: process_batch_result(batch_N-1) ----
+        if step > 0:
+            with jax.profiler.TraceAnnotation(f"resolve_batch_{step - 1}"):
+                result_device = output_queue.get()
+                result_np = np.array(jax.device_get(result_device))
+                results.append(result_np)
+
+            with jax.profiler.TraceAnnotation(f"cpu_work_batch_{step - 1}"):
+                cpu_scheduling(cpu_ms)
+
+        times.append(time.perf_counter() - t0)
+
+    # drain 最后一个 batch 的结果
+    with jax.profiler.TraceAnnotation(f"resolve_batch_{steps - 1}"):
+        result_device = output_queue.get()
+        results.append(np.array(jax.device_get(result_device)))
+
+    input_queue.put(None)
+    t.join(timeout=5)
+    return times, results
+
+
+# =====================================================================
+# 方式 B: 单线程 + future token ID (async dispatch 数据依赖链)
+#
+# 同样的调用顺序, 但去掉 forward thread:
+#   1. dispatch resolve + forward + set_future (async, 立即返回)
+#   2. device_get 上一步 + CPU 调度 (与 TPU 计算重叠)
+#
+# TPU 时间线上通过 future_map 数据依赖自动串联:
+#   set_future[N] → resolve_future[N+1] → forward[N+1] → set_future[N+1] → ...
+# =====================================================================
+
+
+def run_single_thread(weight, steps, cpu_ms):
+    bs = weight.shape[0]
+    future_map = jnp.zeros((bs * (steps + 5),), dtype=jnp.int32)
+    future_ct = 0
+    prev_tokens = None
+
+    input_ids = jnp.arange(bs, dtype=jnp.int32) + 1
+
+    times = []
+    results = []
+    for step in range(steps):
+        t0 = time.perf_counter()
+
+        # ---- Step 1: dispatch batch_N (对应 run_batch) ----
+        with jax.profiler.TraceAnnotation(f"dispatch_batch_{step}"):
+            resolved = resolve_future_token_ids(input_ids, future_map)
+            tokens = model_forward(resolved, weight)
+            future_map = set_future_token_ids(future_map, future_ct, tokens)
+
+        future_indices = -(future_ct + 1 + np.arange(bs))
+        future_ct += bs
+        input_ids = jnp.array(future_indices, dtype=jnp.int32)
+
+        # ---- Step 2: 处理上一步结果 (对应 process_batch_result) ----
+        if prev_tokens is not None:
+            with jax.profiler.TraceAnnotation(f"resolve_batch_{step - 1}"):
+                result_np = np.array(jax.device_get(prev_tokens))
+                results.append(result_np)
+            with jax.profiler.TraceAnnotation(f"cpu_work_batch_{step - 1}"):
+                cpu_scheduling(cpu_ms)
+
+        prev_tokens = tokens
+        times.append(time.perf_counter() - t0)
+
+    # drain 最后一步
+    if prev_tokens is not None:
+        with jax.profiler.TraceAnnotation(f"resolve_batch_{steps - 1}"):
+            results.append(np.array(jax.device_get(prev_tokens)))
+
+    return times, results
+
+
+# ---------- Main ----------
+
+
+def main():
+    print(f"Platform: {jax.default_backend()}, devices: {jax.device_count()}")
+
+    dim = 4096
+    steps = 30
+    cpu_ms = 3.0
+    weight = jax.random.normal(jax.random.PRNGKey(42), (dim, dim), dtype=jnp.bfloat16) * 0.001
+
+    # warmup
+    print("Warming up...")
+    run_two_thread(weight, 5, cpu_ms)
+    run_single_thread(weight, 5, cpu_ms)
+    print("Done.\n")
+
+    # === 正确性校验 ===
+    print("=" * 50)
+    print("正确性校验")
+    print("=" * 50)
+    _, results_2t = run_two_thread(weight, steps, 3)
+    _, results_1t = run_single_thread(weight, steps, 3)
+
+    all_match = True
+    for i in range(min(len(results_2t), len(results_1t))):
+        if not np.array_equal(results_2t[i], results_1t[i]):
+            print(f"  step {i}: MISMATCH! 双线程={results_2t[i]}, 单线程={results_1t[i]}")
+            all_match = False
+
+    if all_match:
+        print(f"  全部 {len(results_2t)} 步结果完全一致 ✓")
+    print()
+
+    # === 性能对比 ===
+    print("=" * 50)
+    print("性能对比")
+    print("=" * 50)
+    t_2t, _ = run_two_thread(weight, steps, cpu_ms)
+    t_1t, _ = run_single_thread(weight, steps, cpu_ms)
+
+    avg_2t = np.mean(t_2t[3:]) * 1000
+    avg_1t = np.mean(t_1t[3:]) * 1000
+    print(f"  双线程 overlap: {avg_2t:.2f}ms/step")
+    print(f"  单线程 overlap: {avg_1t:.2f}ms/step")
+    print(f"  差异:           {(avg_2t - avg_1t) / avg_2t * 100:.1f}%")
+    print()
+
+    # === Profiling ===
+    profile_dir = "/tmp/jax_profile"
+    print(f"Profiling → {profile_dir}")
+
+    with jax.profiler.trace(profile_dir):
+        with jax.profiler.TraceAnnotation("two_thread"):
+            run_two_thread(weight, 10, cpu_ms)
+        with jax.profiler.TraceAnnotation("single_thread"):
+            run_single_thread(weight, 10, cpu_ms)
+
+    print(f"Profile 已保存到 {profile_dir}")
+    print("用 tensorboard --logdir /tmp/jax_profile 查看")
+    print()
+    print("在 trace viewer 中应该能看到:")
+    print("  TPU: resolve_future → model_forward → set_future → resolve_future → ...")
+    print("  CPU: dispatch(快) + device_get(上一步) + cpu_scheduling")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/overlap-demo-job.yaml
+++ b/scripts/overlap-demo-job.yaml
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: niu-overlap-demo
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      nodeSelector:
+        cloud.google.com/gke-tpu-topology: 2x2
+        cloud.google.com/gke-tpu-accelerator: tpu-v6e-slice
+      containers:
+      - name: demo
+        image: python:3.11-slim
+        command:
+        - bash
+        - -c
+        - |
+          set -ex
+          pip install -U --pre jax jaxlib libtpu \
+            -i https://us-python.pkg.dev/ml-oss-artifacts-published/jax/simple/ \
+            -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+          python -c 'import jax; print("TPU devices:", jax.device_count())'
+          echo "Ready. Use: kubectl exec -it <pod> -- bash"
+          sleep infinity
+        resources:
+          limits:
+            google.com/tpu: "4"
+          requests:
+            google.com/tpu: "4"
+        securityContext:
+          privileged: true
+        volumeMounts:
+        - name: dshm
+          mountPath: /dev/shm
+      volumes:
+      - name: dshm
+        emptyDir:
+          medium: Memory


### PR DESCRIPTION
## Summary

验证 sglang-jax 可以从双线程 overlap 架构（ModelWorkerClient + forward thread）切换为单线程 async dispatch，利用 JAX jit 的异步特性 + future token ID 数据依赖链实现等效 overlap。

## Demo 内容

`scripts/demo_overlap.py` — 对比两种 overlap 方式：
- **方式 A（双线程）**：严格还原 `tp_worker_overlap_thread.py` 的 `ModelWorkerClient` 流程
- **方式 B（单线程）**：去掉 forward thread，直接 async dispatch + deferred `device_get`

两种方式的 device 端操作完全一致：`resolve_future_token_ids → model_forward → set_future_token_ids`

## TPU v6e-4 实验结果

### 正确性
全部 30 步结果完全一致 ✓（forward 真正依赖 input_ids，embedding lookup + random weight）

### 性能
```
双线程 overlap: ~22ms/step
单线程 overlap: ~22ms/step
差异: ~0%
```

### Profiling 分析（关键结论）

**TPU 时间线**：两种方式下 batch 之间完全无缝隙，每个 batch 22.28ms 紧密衔接：
```
resolve_future → model_forward (22.28ms) → set_future → resolve_future → model_forward (22.28ms) → ...
```

**CPU vs TPU overlap**（以双线程 batch 2 为例）：
```
TPU:  [========= model_forward batch 2 (22.28ms) =========]
CPU:  [resolve_1 尾巴] [cpu_work_1 3ms] [send_3] [resolve_2 等18.3ms...]
                        ↑ 与TPU重叠 ↑
```

两种方式都实现了 `cpu_work`（3ms）与 TPU 计算的重叠，效果一致。

## 为什么可以去掉 forward thread

1. **JAX jit 是 async dispatch** — `jit()` 调用立即返回 device array (future)，不阻塞 CPU
2. **Future token ID 机制** — CPU 用负数占位符构造下一步 input，不需要 `device_get` 拿真实 token
3. **XLA 数据依赖** — `set_future[N]` 的输出是 `resolve_future[N+1]` 的输入，XLA 自动保证执行顺序
4. **CPython GIL** — 两个 Python thread 无法真正并行执行 CPU 代码，forward thread 的 dispatch 开销反而是纯额外开销

## 文件

- `scripts/demo_overlap.py` — 完整 demo（正确性校验 + 性能对比 + JAX profiling）
- `scripts/overlap-demo-job.yaml` — TPU v6e-4 Kubernetes Job

## Test plan

- [x] TPU v6e-4 上运行，正确性校验通过
- [x] Profiling 确认 TPU batch 无缝隙
- [x] Profiling 确认 cpu_work 与 TPU 计算重叠

🤖 Generated with [Claude Code](https://claude.com/claude-code)