### PR TITLE
refactor: add speculative input contracts

### DIFF
--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -415,6 +415,7 @@ class EagleDraftInput(SpecInput):
         SpecInput.__init__(self, SpecInputType.EAGLE_DRAFT)
 
     def get_spec_adjust_token_coefficient(self) -> tuple[int, int]:
+        """Draft input advances one logical token per request."""
         return 1, 1
 
     def tree_flatten(self):
@@ -708,6 +709,7 @@ class EagleVerifyInput(SpecInput):
         SpecInput.__init__(self, SpecInputType.EAGLE_VERIFY)
 
     def get_spec_adjust_token_coefficient(self) -> tuple[int, int]:
+        """Verify input expands each request into draft_token_num target tokens."""
         return self.draft_token_num, self.draft_token_num
 
     def tree_flatten(self):

--- a/python/sgl_jax/srt/speculative/eagle_util.py
+++ b/python/sgl_jax/srt/speculative/eagle_util.py
@@ -42,6 +42,7 @@ from sgl_jax.srt.mem_cache.common import (
     alloc_token_slots,
 )
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sgl_jax.srt.speculative.spec_info import SpecInput, SpecInputType
 
 logger = logging.getLogger(__name__)
 
@@ -370,7 +371,9 @@ def build_tree_kernel_efficient(
 
 @register_pytree_node_class
 @dataclass
-class EagleDraftInput:
+class EagleDraftInput(SpecInput):
+    """Cross-round draft state kept in draft-local request order."""
+
     # Constant: alloc length per decode step
     ALLOC_LEN_PER_DECODE: ClassVar[int] = None
 
@@ -408,6 +411,12 @@ class EagleDraftInput:
     new_seq_lens: np.ndarray | None = None
     # verify_done: Optional[torch.cuda.Event] = None
 
+    def __post_init__(self):
+        SpecInput.__init__(self, SpecInputType.EAGLE_DRAFT)
+
+    def get_spec_adjust_token_coefficient(self) -> tuple[int, int]:
+        return 1, 1
+
     def tree_flatten(self):
         accept_length_cpu_arr = (
             jnp.empty((0,), dtype=jnp.int32)
@@ -441,6 +450,7 @@ class EagleDraftInput:
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         obj = cls.__new__(cls)
+        obj.spec_input_type = SpecInputType.EAGLE_DRAFT
         obj.capture_hidden_mode = aux_data["capture_hidden_mode"]
         obj.topk_p = children[0]
         obj.topk_index = children[1]
@@ -674,7 +684,9 @@ class EagleVerifyOutput:
 
 @register_pytree_node_class
 @dataclass
-class EagleVerifyInput:
+class EagleVerifyInput(SpecInput):
+    """Target verify input; fields define the explicit verify token/layout boundary."""
+
     # container type for pytree
     draft_token: jax.Array
     custom_mask: jax.Array
@@ -691,6 +703,12 @@ class EagleVerifyInput:
     seq_lens_sum: int
     capture_hidden_mode: CaptureHiddenMode
     # grammar: BaseGrammarObject = None
+
+    def __post_init__(self):
+        SpecInput.__init__(self, SpecInputType.EAGLE_VERIFY)
+
+    def get_spec_adjust_token_coefficient(self) -> tuple[int, int]:
+        return self.draft_token_num, self.draft_token_num
 
     def tree_flatten(self):
         seq_lens_sum_arr = _as_int32_array(self.seq_lens_sum, fallback=0)
@@ -718,6 +736,7 @@ class EagleVerifyInput:
     @classmethod
     def tree_unflatten(cls, aux_data, children):
         obj = cls.__new__(cls)
+        obj.spec_input_type = SpecInputType.EAGLE_VERIFY
         obj.spec_steps = aux_data["spec_steps"]
         obj.topk = aux_data["topk"]
         obj.draft_token_num = aux_data["draft_token_num"]

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -1,4 +1,5 @@
 import logging
+from abc import ABC, abstractmethod
 from enum import IntEnum, auto
 
 import jax
@@ -6,6 +7,26 @@ import jax
 from sgl_jax.srt.layers.logits_processor import LogitsProcessorOutput
 
 logger = logging.getLogger(__name__)
+
+
+class SpecInputType(IntEnum):
+    EAGLE_DRAFT = auto()
+    EAGLE_VERIFY = auto()
+
+
+class SpecInput(ABC):
+    def __init__(self, spec_input_type: SpecInputType):
+        self.spec_input_type = spec_input_type
+
+    def is_draft_input(self) -> bool:
+        return self.spec_input_type == SpecInputType.EAGLE_DRAFT
+
+    def is_verify_input(self) -> bool:
+        return self.spec_input_type == SpecInputType.EAGLE_VERIFY
+
+    @abstractmethod
+    def get_spec_adjust_token_coefficient(self) -> tuple[int, int]:
+        raise NotImplementedError
 
 
 class SpeculativeAlgorithm(IntEnum):

--- a/python/sgl_jax/srt/speculative/spec_info.py
+++ b/python/sgl_jax/srt/speculative/spec_info.py
@@ -26,6 +26,7 @@ class SpecInput(ABC):
 
     @abstractmethod
     def get_spec_adjust_token_coefficient(self) -> tuple[int, int]:
+        """Return multipliers for scheduler token accounting and logprob token accounting."""
         raise NotImplementedError
 
 

--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -1,0 +1,45 @@
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyInput
+from sgl_jax.srt.speculative.spec_info import SpecInput, SpecInputType
+
+
+def test_eagle_draft_input_is_spec_input():
+    draft_input = EagleDraftInput.create_idle_input(
+        hidden_size=16,
+        dtype=np.float32,
+        topk=1,
+        capture_hidden_mode=CaptureHiddenMode.LAST,
+    )
+
+    assert isinstance(draft_input, SpecInput)
+    assert draft_input.spec_input_type == SpecInputType.EAGLE_DRAFT
+    assert draft_input.is_draft_input()
+    assert not draft_input.is_verify_input()
+    assert draft_input.get_spec_adjust_token_coefficient() == (1, 1)
+
+
+def test_eagle_verify_input_is_spec_input():
+    verify_input = EagleVerifyInput(
+        draft_token=jnp.empty((0,), dtype=jnp.int32),
+        custom_mask=jnp.empty((0,), dtype=jnp.bool_),
+        positions=jnp.empty((0,), dtype=jnp.int32),
+        retrive_index=jnp.empty((0, 0), dtype=jnp.int32),
+        retrive_next_token=jnp.empty((0, 0), dtype=jnp.int32),
+        retrive_next_sibling=jnp.empty((0, 0), dtype=jnp.int32),
+        retrive_cum_len=None,
+        seq_lens_cpu=np.empty((0,), dtype=np.int32),
+        spec_steps=3,
+        topk=1,
+        draft_token_num=4,
+        seq_lens_sum=0,
+        capture_hidden_mode=CaptureHiddenMode.FULL,
+    )
+
+    assert isinstance(verify_input, SpecInput)
+    assert verify_input.spec_input_type == SpecInputType.EAGLE_VERIFY
+    assert not verify_input.is_draft_input()
+    assert verify_input.is_verify_input()
+    assert verify_input.get_spec_adjust_token_coefficient() == (4, 4)


### PR DESCRIPTION
## Summary
- Add `SpecInputType` and `SpecInput` as shared speculative input contracts.
- Mark EAGLE draft and verify inputs with explicit draft/verify types and token accounting coefficients.
- Add focused contract tests for draft/verify input semantics.

## Test plan
- [x] Pod `niu-overlap-demo-p4nmt`: `PYTHONPATH=/tmp/sglang-jax-task2/.testdeps:python python3 -m pytest python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py python/sgl_jax/test/speculative/test_base_spec_worker.py -q` (`5 passed`)
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)