### PR TITLE
refactor: introduce eagle draft worker

### DIFF
--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -77,7 +77,7 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
                     ),
                 )
         else:
-            if self.hot_token_ids is not None:
+            if self.draft_model_runner.model.hot_token_ids is not None:
                 head = head.clone()
                 self.hot_token_ids = device_array(
                     self.draft_model_runner.model.hot_token_ids,
@@ -89,6 +89,9 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
                 )
                 head.data = head.data[self.hot_token_ids]
             self.draft_model_runner.model.set_embed_and_head(embed, head)
+
+    def generate_model_worker_batch(self, *args, **kwargs):
+        return self.compilation_manager.generate_model_worker_batch(*args, **kwargs)
 
     def draft(self, model_worker_batch):
         raise NotImplementedError

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -1,0 +1,100 @@
+import logging
+
+import jax
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.speculative.base_spec_worker import BaseDraftWorker
+from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
+from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
+from sgl_jax.srt.utils.common_utils import get_bool_env_var
+from sgl_jax.srt.utils.jax_utils import device_array
+
+logger = logging.getLogger(__name__)
+RETURN_ORIGINAL_LOGPROB = get_bool_env_var("RETURN_ORIGINAL_LOGPROB")
+
+
+class EagleDraftWorker(ModelWorker, BaseDraftWorker):
+    def __init__(self, server_args, target_worker: ModelWorker):
+        self.server_args = server_args
+        self._target_worker = target_worker
+        self.topk = server_args.speculative_eagle_topk
+        self.speculative_num_steps = server_args.speculative_num_steps
+        self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
+        self.page_size = server_args.page_size
+        self.speculative_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
+        self.hot_token_ids = None
+        self.num_new_pages_per_topk = None
+        self.extend_lens = None
+
+        ModelWorker.__init__(
+            self,
+            server_args,
+            target_worker.mesh,
+            req_to_token_pool=self.req_to_token_pool,
+            is_draft_worker=True,
+        )
+        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
+            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
+        )
+        self._init_embed_and_head()
+        self.model_runner.initialize_jit()
+        (
+            precompile_token_paddings,
+            precompile_bs_paddings,
+            precompile_cache_loc_paddings,
+        ) = self._target_worker.get_precompile_paddings()
+        self.precompile_bs_paddings = precompile_bs_paddings
+        self.precompile_cache_loc_paddings = precompile_cache_loc_paddings
+        self.precompile_token_paddings = precompile_token_paddings
+
+    @property
+    def target_worker(self):
+        return self._target_worker
+
+    def _init_embed_and_head(self):
+        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+        if self.speculative_algorithm.is_eagle3():
+            if (
+                hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
+                and self.draft_model_runner.model.load_lm_head_from_target
+            ):
+                self.draft_model_runner.model.set_embed_and_head(embed, head)
+            else:
+                self.draft_model_runner.model.set_embed(embed)
+
+            if self.draft_model_runner.model.hot_token_ids is not None:
+                self.hot_token_ids = device_array(
+                    self.draft_model_runner.model.hot_token_ids,
+                    sharding=(
+                        NamedSharding(self.model_runner.mesh, P())
+                        if jax.process_count() == 1
+                        else None
+                    ),
+                )
+        else:
+            if self.hot_token_ids is not None:
+                head = head.clone()
+                self.hot_token_ids = device_array(
+                    self.draft_model_runner.model.hot_token_ids,
+                    sharding=(
+                        NamedSharding(self.model_runner.mesh, P())
+                        if jax.process_count() == 1
+                        else None
+                    ),
+                )
+                head.data = head.data[self.hot_token_ids]
+            self.draft_model_runner.model.set_embed_and_head(embed, head)
+
+    def draft(self, model_worker_batch):
+        raise NotImplementedError
+
+    def draft_extend_for_prefill(self, model_worker_batch, target_hidden_states, next_token_ids):
+        raise NotImplementedError
+
+    def draft_extend_for_decode(self, model_worker_batch, batch_output):
+        raise NotImplementedError

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -1,5 +1,3 @@
-import logging
-
 import jax
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
@@ -8,11 +6,7 @@ from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.speculative.base_spec_worker import BaseDraftWorker
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
-from sgl_jax.srt.utils.common_utils import get_bool_env_var
 from sgl_jax.srt.utils.jax_utils import device_array
-
-logger = logging.getLogger(__name__)
-RETURN_ORIGINAL_LOGPROB = get_bool_env_var("RETURN_ORIGINAL_LOGPROB")
 
 
 class EagleDraftWorker(ModelWorker, BaseDraftWorker):
@@ -28,8 +22,6 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
         )
         self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
         self.hot_token_ids = None
-        self.num_new_pages_per_topk = None
-        self.extend_lens = None
 
         ModelWorker.__init__(
             self,

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -21,6 +21,8 @@ from sgl_jax.srt.model_executor.forward_batch_info import (
     ForwardMode,
 )
 from sgl_jax.srt.sampling.sampling_batch_info import SamplingMetadata
+from sgl_jax.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
+from sgl_jax.srt.speculative.eagle_draft_worker import EagleDraftWorker
 from sgl_jax.srt.speculative.eagle_util import (
     EagleDraftInput,
     EagleVerifyInput,
@@ -36,75 +38,60 @@ logger = logging.getLogger(__name__)
 RETURN_ORIGINAL_LOGPROB = get_bool_env_var("RETURN_ORIGINAL_LOGPROB")
 
 
-class EAGLEWorker(ModelWorker):
+class EAGLEWorker(BaseSpecWorker):
     def __init__(self, server_args, target_worker: ModelWorker):
         self.server_args = server_args
-        self.target_worker = target_worker
+        self._target_worker = target_worker
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
-        self.topk = server_args.speculative_eagle_topk
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
         self.page_size = server_args.page_size
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             server_args.speculative_algorithm
         )
         self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
-        self.hot_token_ids = None
+        self._draft_worker = EagleDraftWorker(server_args, target_worker)
+        self.precompile_bs_paddings = self._draft_worker.precompile_bs_paddings
+        self.precompile_cache_loc_paddings = self._draft_worker.precompile_cache_loc_paddings
+        self.precompile_token_paddings = self._draft_worker.precompile_token_paddings
 
-        # Initialize dummy tensors for EAGLE operations
-        self.num_new_pages_per_topk = None
-        self.extend_lens = None
+    @property
+    def target_worker(self) -> ModelWorker:
+        return self._target_worker
 
-        # this must be put at last to make sure model state is correct
-        super().__init__(
-            server_args,
-            target_worker.mesh,
-            req_to_token_pool=self.req_to_token_pool,
-            is_draft_worker=True,
-        )
-        EagleDraftInput.ALLOC_LEN_PER_DECODE = max(
-            self.speculative_num_steps * self.topk, self.speculative_num_draft_tokens
-        )
-        embed, head = self.target_worker.model_runner.model.get_embed_and_head()
+    @property
+    def draft_worker(self) -> BaseDraftWorker:
+        return self._draft_worker
 
-        if self.speculative_algorithm.is_eagle3():
-            # most cases EAGLE3 models don't share lm_head
-            # but some models (e.g. nvidia/gpt-oss-120b-Eagle3) shares
-            if (
-                hasattr(self.draft_model_runner.model, "load_lm_head_from_target")
-                and self.draft_model_runner.model.load_lm_head_from_target
-            ):
-                self.draft_model_runner.model.set_embed_and_head(embed, head)
-            else:
-                self.draft_model_runner.model.set_embed(embed)
+    @property
+    def mesh(self):
+        return self.target_worker.mesh
 
-            # grab hot token ids
-            if self.draft_model_runner.model.hot_token_ids is not None:
-                self.hot_token_ids = device_array(
-                    self.draft_model_runner.model.hot_token_ids,
-                    sharding=(NamedSharding(self.model_runner.mesh, P())),
-                )
-        else:
-            if self.hot_token_ids is not None:
-                head = head.clone()
-                self.hot_token_ids = device_array(
-                    self.draft_model_runner.model.hot_token_ids,
-                    sharding=(NamedSharding(self.model_runner.mesh, P())),
-                )
-                head.data = head.data[self.hot_token_ids]
+    @property
+    def model_config(self):
+        return self.target_worker.model_config
 
-            # Share the embedding and lm_head
-            self.draft_model_runner.model.set_embed_and_head(embed, head)
+    @property
+    def draft_model_runner(self):
+        return self.draft_worker.get_model_runner()
 
-        self.model_runner.initialize_jit()
-        (
-            precompile_token_paddings,
-            precompile_bs_paddings,
-            precompile_cache_loc_paddings,
-        ) = self.target_worker.get_precompile_paddings()
-        self.precompile_bs_paddings = precompile_bs_paddings
-        self.precompile_cache_loc_paddings = precompile_cache_loc_paddings
-        self.precompile_token_paddings = precompile_token_paddings
+    @property
+    def model_runner(self):
+        return self.draft_model_runner
+
+    @property
+    def hot_token_ids(self):
+        return self.draft_worker.hot_token_ids
+
+    @property
+    def max_req_len(self):
+        return self.draft_worker.max_req_len
+
+    def generate_model_worker_batch(self, *args, **kwargs):
+        return self.draft_worker.generate_model_worker_batch(*args, **kwargs)
+
+    def get_max_padded_size(self, *args, **kwargs):
+        return self.draft_worker.get_max_padded_size(*args, **kwargs)
 
     def forward_batch_speculative_generation(
         self,
@@ -258,10 +245,6 @@ class EAGLEWorker(ModelWorker):
             if model_worker_batch.extend_seq_lens is not None
             else None
         )
-
-    @property
-    def draft_model_runner(self):
-        return self.get_model_runner()
 
     def capture_for_decode(
         self, logits_output: LogitsProcessorOutput, draft_input: EagleDraftInput

--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -67,3 +67,21 @@ def test_eagle_worker_implements_base_contract():
         "verify",
     ):
         assert hasattr(EAGLEWorker, name)
+
+
+def test_eagle_draft_worker_generate_model_worker_batch_delegates_to_compilation_manager():
+    class FakeCompilationManager:
+        def __init__(self):
+            self.calls = []
+
+        def generate_model_worker_batch(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+            return "batch"
+
+    worker = EagleDraftWorker.__new__(EagleDraftWorker)
+    worker.compilation_manager = FakeCompilationManager()
+
+    result = worker.generate_model_worker_batch(1, "arg", mode="decode")
+
+    assert result == "batch"
+    assert worker.compilation_manager.calls == [((1, "arg"), {"mode": "decode"})]

--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -1,8 +1,12 @@
 import jax.numpy as jnp
 import numpy as np
 
+from sgl_jax.srt.managers.tp_worker import ModelWorker
 from sgl_jax.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sgl_jax.srt.speculative.base_spec_worker import BaseDraftWorker, BaseSpecWorker
+from sgl_jax.srt.speculative.eagle_draft_worker import EagleDraftWorker
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput, EagleVerifyInput
+from sgl_jax.srt.speculative.eagle_worker import EAGLEWorker
 from sgl_jax.srt.speculative.spec_info import SpecInput, SpecInputType
 
 
@@ -43,3 +47,23 @@ def test_eagle_verify_input_is_spec_input():
     assert not verify_input.is_draft_input()
     assert verify_input.is_verify_input()
     assert verify_input.get_spec_adjust_token_coefficient() == (4, 4)
+
+
+def test_eagle_draft_worker_implements_base_contract():
+    assert issubclass(EagleDraftWorker, BaseDraftWorker)
+    assert EagleDraftWorker.__mro__.index(ModelWorker) < EagleDraftWorker.__mro__.index(
+        BaseDraftWorker
+    )
+    for name in ("draft", "draft_extend_for_prefill", "draft_extend_for_decode"):
+        assert callable(getattr(EagleDraftWorker, name))
+
+
+def test_eagle_worker_implements_base_contract():
+    assert issubclass(EAGLEWorker, BaseSpecWorker)
+    for name in (
+        "target_worker",
+        "draft_worker",
+        "forward_batch_speculative_generation",
+        "verify",
+    ):
+        assert hasattr(EAGLEWorker, name)


### PR DESCRIPTION
## Summary
- Add `EagleDraftWorker` as the draft-side worker shell and initialization owner.
- Convert `EAGLEWorker` to a `BaseSpecWorker` composition wrapper around target and draft workers.
- Add contract coverage for EAGLE worker inheritance, MRO, and precompile batch delegation.

## Test plan
- [x] Pod `niu-overlap-demo-p4nmt`: `PYTHONPATH=/tmp/sglang-jax-task3/.testdeps:python python3 -m pytest python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py -q` (`5 passed`)
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)