### PR TITLE
refactor: move eagle draft prefill

### DIFF
--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -1,3 +1,5 @@
+import functools
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -19,10 +21,9 @@ from sgl_jax.srt.utils.jax_utils import device_array
 
 
 class EagleDraftWorker(ModelWorker, BaseDraftWorker):
-    def __init__(self, server_args, target_worker: ModelWorker, capture_for_decode=None):
+    def __init__(self, server_args, target_worker: ModelWorker):
         self.server_args = server_args
         self._target_worker = target_worker
-        self._capture_for_decode = capture_for_decode
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
@@ -57,14 +58,6 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
     @property
     def target_worker(self):
         return self._target_worker
-
-    @property
-    def mesh(self):
-        return self.target_worker.mesh
-
-    @mesh.setter
-    def mesh(self, value):
-        self._mesh = value
 
     @property
     def draft_model_runner(self):
@@ -160,9 +153,27 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
         return forward_batch.spec_info
 
     def capture_for_decode(self, logits_output, draft_input: EagleDraftInput):
-        if self._capture_for_decode is None:
-            raise NotImplementedError
-        self._capture_for_decode(logits_output, draft_input)
+        topk_p, topk_index = _topk_probs_from_logits(logits_output.next_token_logits, self.topk)
+        draft_input.topk_p = topk_p
+        draft_input.topk_index = topk_index
+        draft_input.hidden_states = logits_output.hidden_states
 
     def draft_extend_for_decode(self, model_worker_batch, batch_output):
         raise NotImplementedError
+
+
+@functools.partial(jax.jit, static_argnames=["topk"])
+def _topk_probs_from_logits(
+    logits: jax.Array, topk: int, axis: int = -1
+) -> tuple[jax.Array, jax.Array]:
+    """Return top-k probabilities without materializing the full softmax tensor."""
+    working_logits = jnp.moveaxis(logits, axis, -1) if axis != -1 else logits
+    topk_logits, topk_index = jax.lax.top_k(working_logits, topk)
+    logsumexp = jax.nn.logsumexp(working_logits, axis=-1, keepdims=True)
+    topk_probs = jnp.exp(topk_logits - logsumexp)
+
+    if axis != -1:
+        topk_probs = jnp.moveaxis(topk_probs, -1, axis)
+        topk_index = jnp.moveaxis(topk_index, -1, axis)
+
+    return topk_probs, topk_index

--- a/python/sgl_jax/srt/speculative/eagle_draft_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_draft_worker.py
@@ -1,8 +1,17 @@
 import jax
+import jax.numpy as jnp
+import numpy as np
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from sgl_jax.srt.layers.logits_processor import LogitsMetadata
+from sgl_jax.srt.managers.schedule_batch import ModelWorkerBatch
 from sgl_jax.srt.managers.tp_worker import ModelWorker
+from sgl_jax.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
 from sgl_jax.srt.speculative.base_spec_worker import BaseDraftWorker
 from sgl_jax.srt.speculative.eagle_util import EagleDraftInput
 from sgl_jax.srt.speculative.spec_info import SpeculativeAlgorithm
@@ -10,9 +19,10 @@ from sgl_jax.srt.utils.jax_utils import device_array
 
 
 class EagleDraftWorker(ModelWorker, BaseDraftWorker):
-    def __init__(self, server_args, target_worker: ModelWorker):
+    def __init__(self, server_args, target_worker: ModelWorker, capture_for_decode=None):
         self.server_args = server_args
         self._target_worker = target_worker
+        self._capture_for_decode = capture_for_decode
         self.topk = server_args.speculative_eagle_topk
         self.speculative_num_steps = server_args.speculative_num_steps
         self.speculative_num_draft_tokens = server_args.speculative_num_draft_tokens
@@ -47,6 +57,18 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
     @property
     def target_worker(self):
         return self._target_worker
+
+    @property
+    def mesh(self):
+        return self.target_worker.mesh
+
+    @mesh.setter
+    def mesh(self, value):
+        self._mesh = value
+
+    @property
+    def draft_model_runner(self):
+        return self.model_runner
 
     def _init_embed_and_head(self):
         embed, head = self.target_worker.model_runner.model.get_embed_and_head()
@@ -88,8 +110,59 @@ class EagleDraftWorker(ModelWorker, BaseDraftWorker):
     def draft(self, model_worker_batch):
         raise NotImplementedError
 
-    def draft_extend_for_prefill(self, model_worker_batch, target_hidden_states, next_token_ids):
-        raise NotImplementedError
+    def draft_extend_for_prefill(
+        self,
+        model_worker_batch: ModelWorkerBatch,
+        target_hidden_states: jax.Array,
+        next_token_ids: jax.Array,
+    ) -> EagleDraftInput:
+        # FIXME(pc) move this all prepare to prepare_for_extend_after_target_prefill
+        model_worker_batch.spec_info = EagleDraftInput(
+            hidden_states=target_hidden_states,
+            verified_id=next_token_ids[: model_worker_batch.real_bs],
+            num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
+            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=jnp.int32),
+            allocate_lens=model_worker_batch.seq_lens,
+        )
+        model_worker_batch.return_hidden_states = False
+        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
+            model_worker_batch=model_worker_batch
+        )
+        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
+        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
+        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
+        forward_batch.return_logprob = False
+
+        # Set forward_metadata for draft_model_runner's attention backend
+        forward_metadata = self.draft_model_runner.attn_backend.get_eagle_forward_metadata(
+            model_worker_batch
+        )
+
+        self.draft_model_runner.attn_backend.forward_metadata = forward_metadata
+        forward_batch.forward_mode = ForwardMode.EXTEND
+        # last_idx = np.cumsum(model_worker_batch.extend_seq_lens, axis=0) - 1
+
+        logits_output, _, _ = self.draft_model_runner.forward(
+            forward_batch,
+            logits_metadata=LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh),
+        )
+        logits_output.next_token_logits = logits_output.next_token_logits[
+            : model_worker_batch.real_bs, :
+        ]
+        if len(logits_output.hidden_states.shape) == 1:
+            logits_output.hidden_states = jnp.expand_dims(logits_output.hidden_states, axis=0)
+        assert isinstance(forward_batch.spec_info, EagleDraftInput)
+        forward_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
+            : model_worker_batch.real_bs
+        ]
+
+        self.capture_for_decode(logits_output, forward_batch.spec_info)
+        return forward_batch.spec_info
+
+    def capture_for_decode(self, logits_output, draft_input: EagleDraftInput):
+        if self._capture_for_decode is None:
+            raise NotImplementedError
+        self._capture_for_decode(logits_output, draft_input)
 
     def draft_extend_for_decode(self, model_worker_batch, batch_output):
         raise NotImplementedError

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -50,7 +50,7 @@ class EAGLEWorker(BaseSpecWorker):
             server_args.speculative_algorithm
         )
         self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
-        self._draft_worker = EagleDraftWorker(server_args, target_worker, self.capture_for_decode)
+        self._draft_worker = EagleDraftWorker(server_args, target_worker)
         self.precompile_bs_paddings = self._draft_worker.precompile_bs_paddings
         self.precompile_cache_loc_paddings = self._draft_worker.precompile_cache_loc_paddings
         self.precompile_token_paddings = self._draft_worker.precompile_token_paddings

--- a/python/sgl_jax/srt/speculative/eagle_worker.py
+++ b/python/sgl_jax/srt/speculative/eagle_worker.py
@@ -50,7 +50,7 @@ class EAGLEWorker(BaseSpecWorker):
             server_args.speculative_algorithm
         )
         self.req_to_token_pool, self.token_to_kv_pool_allocator = target_worker.get_memory_pool()
-        self._draft_worker = EagleDraftWorker(server_args, target_worker)
+        self._draft_worker = EagleDraftWorker(server_args, target_worker, self.capture_for_decode)
         self.precompile_bs_paddings = self._draft_worker.precompile_bs_paddings
         self.precompile_cache_loc_paddings = self._draft_worker.precompile_cache_loc_paddings
         self.precompile_token_paddings = self._draft_worker.precompile_token_paddings
@@ -117,14 +117,14 @@ class EAGLEWorker(BaseSpecWorker):
                 self.forward_target_extend(model_worker_batch, sampling_metadata)
             )
             # draft extend for Update Draft State
-            self.forward_draft_extend(
+            next_draft_input = self.draft_worker.draft_extend_for_prefill(
                 model_worker_batch, logits_output.hidden_states, next_token_ids
             )
             # FIXME(pc) refactor this to batch output
             batch_output = GenerationBatchResult(
                 logits_output=logits_output,
                 next_token_ids=next_token_ids,
-                next_draft_input=model_worker_batch.spec_info,
+                next_draft_input=next_draft_input,
                 allocate_lens=model_worker_batch.seq_lens[: model_worker_batch.real_bs],
                 bid=bid,
                 cache_miss_count=cache_miss_count,
@@ -159,54 +159,6 @@ class EAGLEWorker(BaseSpecWorker):
             model_worker_batch.bid,
             model_worker_batch.seq_lens,
         )
-
-    def forward_draft_extend(
-        self,
-        model_worker_batch: ModelWorkerBatch,
-        hidden_states: jax.Array,
-        next_token_ids: jax.Array,
-    ):
-        # FIXME(pc) move this all prepare to prepare_for_extend_after_target_prefill
-        model_worker_batch.spec_info = EagleDraftInput(
-            hidden_states=hidden_states,
-            verified_id=next_token_ids[: model_worker_batch.real_bs],
-            num_tokens_per_batch=np.asarray(1, dtype=jnp.int32),
-            num_tokens_for_logprob_per_batch=np.asarray(1, dtype=jnp.int32),
-            allocate_lens=model_worker_batch.seq_lens,
-        )
-        model_worker_batch.return_hidden_states = False
-        model_worker_batch.spec_info.prepare_for_extend_after_target_prefill(
-            model_worker_batch=model_worker_batch
-        )
-        model_worker_batch.spec_info.capture_hidden_mode = CaptureHiddenMode.LAST
-        model_worker_batch.capture_hidden_mode = CaptureHiddenMode.LAST
-        forward_batch = ForwardBatch.init_new(model_worker_batch, self.draft_model_runner)
-        forward_batch.return_logprob = False
-
-        # Set forward_metadata for draft_model_runner's attention backend
-        forward_metadata = self.draft_model_runner.attn_backend.get_eagle_forward_metadata(
-            model_worker_batch
-        )
-
-        self.draft_model_runner.attn_backend.forward_metadata = forward_metadata
-        forward_batch.forward_mode = ForwardMode.EXTEND
-        # last_idx = np.cumsum(model_worker_batch.extend_seq_lens, axis=0) - 1
-
-        logits_output, _, _ = self.draft_model_runner.forward(
-            forward_batch,
-            logits_metadata=LogitsMetadata.from_model_worker_batch(model_worker_batch, self.mesh),
-        )
-        logits_output.next_token_logits = logits_output.next_token_logits[
-            : model_worker_batch.real_bs, :
-        ]
-        if len(logits_output.hidden_states.shape) == 1:
-            logits_output.hidden_states = jnp.expand_dims(logits_output.hidden_states, axis=0)
-        assert isinstance(forward_batch.spec_info, EagleDraftInput)
-        forward_batch.spec_info.allocate_lens = model_worker_batch.seq_lens[
-            : model_worker_batch.real_bs
-        ]
-
-        self.capture_for_decode(logits_output, forward_batch.spec_info)
 
     def copy_model_worker_batch_to_cpu(self, model_worker_batch: ModelWorkerBatch):
         model_worker_batch.input_ids = np.array(

--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -85,3 +85,8 @@ def test_eagle_draft_worker_generate_model_worker_batch_delegates_to_compilation
 
     assert result == "batch"
     assert worker.compilation_manager.calls == [((1, "arg"), {"mode": "decode"})]
+
+
+def test_eagle_worker_does_not_own_draft_prefill_method():
+    assert hasattr(EagleDraftWorker, "draft_extend_for_prefill")
+    assert not hasattr(EAGLEWorker, "forward_draft_extend")

--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -1,3 +1,5 @@
+import inspect
+
 import jax.numpy as jnp
 import numpy as np
 
@@ -89,4 +91,18 @@ def test_eagle_draft_worker_generate_model_worker_batch_delegates_to_compilation
 
 def test_eagle_worker_does_not_own_draft_prefill_method():
     assert hasattr(EagleDraftWorker, "draft_extend_for_prefill")
+    assert hasattr(EagleDraftWorker, "capture_for_decode")
     assert not hasattr(EAGLEWorker, "forward_draft_extend")
+
+
+def test_eagle_draft_worker_init_does_not_require_capture_callback():
+    parameters = inspect.signature(EagleDraftWorker.__init__).parameters
+
+    assert "capture_for_decode" not in parameters
+
+
+def test_eagle_worker_constructs_draft_worker_without_capture_callback():
+    source = inspect.getsource(EAGLEWorker.__init__)
+
+    assert "self.capture_for_decode" not in source
+    assert "capture_for_decode" not in source


### PR DESCRIPTION
## Summary
- Move draft prefill execution from `EAGLEWorker` into `EagleDraftWorker.draft_extend_for_prefill`.
- Delegate the EAGLE prefill path through the draft worker and pass the returned `next_draft_input` into `GenerationBatchResult`.
- Add contract coverage that `EAGLEWorker` no longer owns `forward_draft_extend`.

## Test plan
- [x] Pod `niu-overlap-demo-p4nmt`: `PYTHONPATH=/tmp/sglang-jax-task4/.testdeps:python python3 -m pytest python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py -q` (`6 passed`)
- [x] `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)