### PR TITLE
refactor: simplify eagle worker orchestration

### DIFF
--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -158,10 +158,12 @@ def test_task6_eagle_worker_does_not_own_draft_extend_after_verify():
 
 
 def test_task7_eagle_worker_is_orchestration_only():
+    assert EAGLEWorker.__bases__ == (BaseSpecWorker,)
+    assert ModelWorker not in EAGLEWorker.__mro__
+
     source = inspect.getsource(EAGLEWorker)
 
     forbidden = (
-        "ModelWorker)",
         "is_draft_worker=True",
         "self.draft_model_runner.forward",
         "build_tree_kernel_efficient(",

--- a/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
+++ b/python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py
@@ -157,6 +157,29 @@ def test_task6_eagle_worker_does_not_own_draft_extend_after_verify():
     assert not hasattr(EAGLEWorker, "draft_extend_after_verify")
 
 
+def test_task7_eagle_worker_is_orchestration_only():
+    source = inspect.getsource(EAGLEWorker)
+
+    forbidden = (
+        "ModelWorker)",
+        "is_draft_worker=True",
+        "self.draft_model_runner.forward",
+        "build_tree_kernel_efficient(",
+        "select_top_k_tokens(",
+    )
+    for text in forbidden:
+        assert text not in source
+
+    required = (
+        "self.draft_worker.draft_extend_for_prefill",
+        "self.draft_worker.draft(",
+        "self.draft_worker.draft_extend_for_decode",
+        "self.target_worker.forward_batch_generation",
+    )
+    for text in required:
+        assert text in source
+
+
 def test_task5_eagle_draft_worker_does_not_define_local_topk_helper():
     source = inspect.getsource(eagle_draft_worker)
 


### PR DESCRIPTION
## Summary
- Add a contract test that keeps `EAGLEWorker` as an orchestration-only `BaseSpecWorker`.
- Assert draft prefill, draft decode, and draft extend are delegated to `EagleDraftWorker`.
- Guard against draft/model-worker internals returning to `EAGLEWorker`.

## Test plan
- [x] `git diff --check HEAD~1..HEAD`
- [x] Pod `niu-overlap-demo-p4nmt`: `PYTHONPATH=/tmp/sglang-jax-task5/.testdeps:python python3 -m pytest python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py -q` (`16 passed`)
- [x] Spec compliance review: APPROVED
- [x] Code quality review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)