### PR TITLE
fix: support newer Pallas TPU memory space API

### DIFF
--- a/python/sgl_jax/srt/kernels/speculative/build_eagle_tree_structure_kernel.py
+++ b/python/sgl_jax/srt/kernels/speculative/build_eagle_tree_structure_kernel.py
@@ -8,6 +8,18 @@ from jax.experimental.pallas import tpu as pltpu
 from jax.sharding import PartitionSpec as P
 
 
+def _get_any_memory_space():
+    memory_space = getattr(pltpu, "MemorySpace", None)
+    if hasattr(pltpu, "ANY"):
+        return pltpu.ANY
+    if memory_space is not None:
+        return getattr(memory_space, "ANY", memory_space.HBM)
+    return pltpu.HBM
+
+
+_ANY_MEMORY_SPACE = _get_any_memory_space()
+
+
 def _build_eagle_tree_structure_kernel(
     # Prefetch
     parents_ref,  # shape: (bs, topk * (depth-1) + 1)
@@ -344,14 +356,14 @@ def build_eagle_tree_structure_pallas_call(
 
     in_specs = [
         # all zero array
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=_ANY_MEMORY_SPACE),
         # all one array
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=_ANY_MEMORY_SPACE),
     ]
 
     out_specs = [
         # tree mask, shape: (draft_token_num, tree_mask_capacity, 128)
-        pl.BlockSpec(memory_space=pltpu.ANY),
+        pl.BlockSpec(memory_space=_ANY_MEMORY_SPACE),
         # positions, shape: (bs*draft_token_num,)
         pl.BlockSpec(memory_space=pltpu.SMEM),
         # retrive_index, shape: (bs, draft_token_num)


### PR DESCRIPTION
## Summary
- Add a compatibility helper for Pallas TPU memory-space APIs.
- Keep using `pltpu.ANY` when available, otherwise fall back through `MemorySpace.ANY` to HBM.
- Fix `test_eagle_tree_build.py` failures on the pod's newer JAX/Pallas version.

## Investigation
- Project optional dependencies pin JAX extras to `jax[*]==0.8.1` in `python/pyproject.toml`.
- Pod test deps currently resolve to `jax 0.10.0`.
- In that version, `jax.experimental.pallas.tpu.ANY` is absent; `MemorySpace` exists but has no `ANY`, so HBM is the compatible fallback.

## Test plan
- [x] `git diff --check`
- [x] Pod `niu-overlap-demo-p4nmt`: `PYTHONPATH=/tmp/sglang-jax-task5/.testdeps:python python3 -m pytest python/sgl_jax/test/speculative/test_eagle_tree_build.py -q` (`3 passed`)
- [x] Pod focused tests: `PYTHONPATH=/tmp/sglang-jax-task5/.testdeps:python python3 -m pytest python/sgl_jax/test/speculative/test_base_spec_worker.py python/sgl_jax/test/speculative/test_eagle_worker_refactor_contract.py python/sgl_jax/test/speculative/test_eagle_utils.py python/sgl_jax/test/speculative/test_eagle_tree_build.py -q` (`28 passed`)
- [x] Spec compliance review: APPROVED
- [x] Code quality review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)