### PR TITLE
fix(weight-loader): backport QKV split 1-D + 2-D non-block scale fixes from main

### DIFF
--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2516,6 +2516,35 @@ class WeightLoader:
                 v_bias = jnp.reshape(v_bias, (self.num_kv_heads * v_head_dim_padded,))
 
             splits = [q_bias, k_bias, v_bias]
+        elif "scale" in hf_key and weight.ndim == 1:
+            # Per-channel weight_scale (e.g. compressed-tensors W8A16): 1-D
+            # shape [Q_out + K_out + V_out,]. Splits along the single axis with
+            # the same Q/K/V offsets the bias branch uses; applies per-head pad
+            # the same way if mapping.head_dim_padding is set. Falls through to
+            # the 2-D scale branch below for block-quant scales (ndim == 2).
+            q_dim = self.num_heads * self.head_dim_original
+            k_dim = self.num_kv_heads * self.head_dim_original
+            v_dim = self.num_kv_heads * v_head_dim
+
+            q_scale = weight[:q_dim]
+            k_scale = weight[q_dim : q_dim + k_dim]
+            v_scale = weight[q_dim + k_dim : q_dim + k_dim + v_dim]
+
+            if mapping.head_dim_padding and self.head_dim_pad > 0:
+                q_scale = jnp.reshape(q_scale, (self.num_heads, self.head_dim_original))
+                q_scale = jnp.pad(q_scale, ((0, 0), (0, self.head_dim_pad)))
+                q_scale = jnp.reshape(q_scale, (self.num_heads * self.head_dim,))
+
+                k_scale = jnp.reshape(k_scale, (self.num_kv_heads, self.head_dim_original))
+                k_scale = jnp.pad(k_scale, ((0, 0), (0, self.head_dim_pad)))
+                k_scale = jnp.reshape(k_scale, (self.num_kv_heads * self.head_dim,))
+
+            if mapping.head_dim_padding and v_head_dim_pad > 0:
+                v_scale = jnp.reshape(v_scale, (self.num_kv_heads, v_head_dim))
+                v_scale = jnp.pad(v_scale, ((0, 0), (0, v_head_dim_pad)))
+                v_scale = jnp.reshape(v_scale, (self.num_kv_heads * v_head_dim_padded,))
+
+            splits = [q_scale, k_scale, v_scale]
         elif "scale" in hf_key and weight.ndim == 2:
             # Block-quant scale: split along block dimension, not element dimension.
             # The fused QKV scale has shape [total_blocks, in_blocks] where blocks

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2546,36 +2546,82 @@ class WeightLoader:
 
             splits = [q_scale, k_scale, v_scale]
         elif "scale" in hf_key and weight.ndim == 2:
-            # Block-quant scale: split along block dimension, not element dimension.
-            # The fused QKV scale has shape [total_blocks, in_blocks] where blocks
-            # are computed per Q/K/V segment independently.
+            # 2-D scale in a fused QKV weight. Two formats land here:
+            #   (a) block-quant scale [total_blocks, in_blocks] — split along
+            #       block dimension (the original case this branch was written
+            #       for; introduced in #978 for MiMo-V2.5-Pro day0 support).
+            #   (b) channel-wise / per-tensor scale stored as 2-D, e.g.
+            #       compressed-tensors W8A16 on Ling-2.6-1T where some scales
+            #       arrive shaped [Q_out+K_out+V_out, inner] instead of 1-D.
+            # Distinguish by whether the quantization_config has weight_block_size.
             import math
 
             quant_cfg = getattr(self.model_config, "quantization_config", None)
-            block_size = int(quant_cfg.weight_block_size[0]) if quant_cfg else 128
+            weight_block_size = getattr(quant_cfg, "weight_block_size", None) if quant_cfg else None
 
-            q_dim = self.num_heads * self.head_dim_original
-            k_dim = self.num_kv_heads * self.head_dim_original
+            if weight_block_size is None:
+                # Path (b): element-wise split along axis 0, same Q/K/V offsets
+                # as the 1-D branch above. Padding mirrors the 1-D path with an
+                # extra inner axis preserved.
+                logger.warning(
+                    "Splitting 2-D non-block scale %s shape=%s element-wise "
+                    "(quant_cfg has no weight_block_size)",
+                    hf_key,
+                    weight.shape,
+                )
+                q_dim = self.num_heads * self.head_dim_original
+                k_dim = self.num_kv_heads * self.head_dim_original
+                v_dim = self.num_kv_heads * v_head_dim
 
-            q_blocks = math.ceil(q_dim / block_size)
-            k_blocks = math.ceil(k_dim / block_size)
-            # V gets remaining blocks (may include padding to head_dim_original)
-            v_blocks = weight.shape[0] - q_blocks - k_blocks
+                q_scale = weight[:q_dim, :]
+                k_scale = weight[q_dim : q_dim + k_dim, :]
+                v_scale = weight[q_dim + k_dim : q_dim + k_dim + v_dim, :]
 
-            logger.info(
-                "Splitting QKV scale %s shape=%s into Q=%d K=%d V=%d blocks",
-                hf_key,
-                weight.shape,
-                q_blocks,
-                k_blocks,
-                v_blocks,
-            )
+                if mapping.head_dim_padding and self.head_dim_pad > 0:
+                    inner = weight.shape[1]
+                    q_scale = jnp.reshape(q_scale, (self.num_heads, self.head_dim_original, inner))
+                    q_scale = jnp.pad(q_scale, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    q_scale = jnp.reshape(q_scale, (self.num_heads * self.head_dim, inner))
 
-            q_scale = weight[:q_blocks, :]
-            k_scale = weight[q_blocks : q_blocks + k_blocks, :]
-            v_scale = weight[q_blocks + k_blocks :, :]
+                    k_scale = jnp.reshape(
+                        k_scale, (self.num_kv_heads, self.head_dim_original, inner)
+                    )
+                    k_scale = jnp.pad(k_scale, ((0, 0), (0, self.head_dim_pad), (0, 0)))
+                    k_scale = jnp.reshape(k_scale, (self.num_kv_heads * self.head_dim, inner))
 
-            splits = [q_scale, k_scale, v_scale]
+                if mapping.head_dim_padding and v_head_dim_pad > 0:
+                    inner = weight.shape[1]
+                    v_scale = jnp.reshape(v_scale, (self.num_kv_heads, v_head_dim, inner))
+                    v_scale = jnp.pad(v_scale, ((0, 0), (0, v_head_dim_pad), (0, 0)))
+                    v_scale = jnp.reshape(v_scale, (self.num_kv_heads * v_head_dim_padded, inner))
+
+                splits = [q_scale, k_scale, v_scale]
+            else:
+                # Path (a): block-quant scale, original behavior.
+                block_size = int(weight_block_size[0])
+
+                q_dim = self.num_heads * self.head_dim_original
+                k_dim = self.num_kv_heads * self.head_dim_original
+
+                q_blocks = math.ceil(q_dim / block_size)
+                k_blocks = math.ceil(k_dim / block_size)
+                # V gets remaining blocks (may include padding to head_dim_original)
+                v_blocks = weight.shape[0] - q_blocks - k_blocks
+
+                logger.info(
+                    "Splitting QKV scale %s shape=%s into Q=%d K=%d V=%d blocks",
+                    hf_key,
+                    weight.shape,
+                    q_blocks,
+                    k_blocks,
+                    v_blocks,
+                )
+
+                q_scale = weight[:q_blocks, :]
+                k_scale = weight[q_blocks : q_blocks + k_blocks, :]
+                v_scale = weight[q_blocks + k_blocks :, :]
+
+                splits = [q_scale, k_scale, v_scale]
         else:
             q_dim = self.num_heads * self.head_dim_original
             k_dim = self.num_kv_heads * self.head_dim_original

--- a/python/sgl_jax/srt/utils/weight_utils.py
+++ b/python/sgl_jax/srt/utils/weight_utils.py
@@ -2563,7 +2563,7 @@ class WeightLoader:
                 # Path (b): element-wise split along axis 0, same Q/K/V offsets
                 # as the 1-D branch above. Padding mirrors the 1-D path with an
                 # extra inner axis preserved.
-                logger.warning(
+                logger.info(
                     "Splitting 2-D non-block scale %s shape=%s element-wise "
                     "(quant_cfg has no weight_block_size)",
                     hf_key,

--- a/python/sgl_jax/test/test_weight_loader_qkv_split.py
+++ b/python/sgl_jax/test/test_weight_loader_qkv_split.py
@@ -1,0 +1,192 @@
+"""Unit tests for WeightLoader._split_qkv_weight 1-D scale handling.
+
+Pre-fix, a 1-D per-channel `weight_scale` (HF shape `[Q_out+K_out+V_out,]`,
+as produced by compressed-tensors W8A16) fell through the bias / 2-D-scale
+branches into the 2-D weight else branch, where `weight[:q_dim, :]` on a
+1-D tensor raises IndexError. The fix adds a dedicated 1-D scale branch
+that splits along the single axis using the same Q/K/V offsets as bias.
+"""
+
+import jax.numpy as jnp
+import pytest
+
+from sgl_jax.srt.utils.weight_utils import WeightLoader, WeightMapping
+
+
+class _CaptureParam:
+    """Stand-in for nnx.Param: exposes settable `value` so the loader's
+    `model_param.value = ...` assignment lands here and we can read it back."""
+
+    def __init__(self, dtype=jnp.float32):
+        self._v = jnp.zeros((), dtype=dtype)
+
+    @property
+    def value(self):
+        return self._v
+
+    @value.setter
+    def value(self, v):
+        self._v = v
+
+
+def _make_loader(
+    *,
+    num_heads: int = 4,
+    num_kv_heads: int = 4,
+    head_dim_original: int = 8,
+    v_head_dim: int | None = None,
+):
+    """Construct a WeightLoader bypassing __init__, with just enough state to
+    drive _split_qkv_weight; mock the assignment-side helpers to identity."""
+    loader = object.__new__(WeightLoader)
+    loader.num_heads = num_heads
+    loader.num_kv_heads = num_kv_heads
+    loader.head_dim_original = head_dim_original
+    loader.head_dim_pad = (head_dim_original + 127) // 128 * 128 - head_dim_original
+    loader.head_dim = head_dim_original + loader.head_dim_pad
+    loader.v_head_dim = v_head_dim if v_head_dim is not None else head_dim_original
+    loader.hidden_size = num_heads * head_dim_original
+    loader.sharding_size = 1
+    loader.dummy_mode = False
+
+    captured: dict[str, _CaptureParam] = {}
+
+    def _get_param(_params, path):
+        p = _CaptureParam()
+        captured[path] = p
+        return p
+
+    loader._shard_weight = lambda w, sharding: w
+    loader._get_param = _get_param
+    loader._maybe_expand_linear_block_scale = lambda w, _model_param, _path: w
+    loader._apply_kv_head_padding = lambda w, _key: w
+
+    return loader, captured
+
+
+def _qkv_mapping(suffix: str, *, head_dim_padding: bool = False) -> WeightMapping:
+    return WeightMapping(
+        target_path=[
+            f"model.layers.0.self_attn.q_proj.{suffix}",
+            f"model.layers.0.self_attn.k_proj.{suffix}",
+            f"model.layers.0.self_attn.v_proj.{suffix}",
+        ],
+        sharding=("tensor", None),
+        transpose=False,
+        head_dim_padding=head_dim_padding,
+    )
+
+
+def test_1d_per_channel_scale_splits_at_correct_offsets():
+    """Most common case: GLA/MHA with num_kv_heads == num_heads and no padding.
+    The pre-fix code IndexError'd here; the fix should split [0..32, 32..64, 64..96]."""
+    loader, captured = _make_loader(num_heads=4, num_kv_heads=4, head_dim_original=8)
+    mapping = _qkv_mapping("weight_scale")
+
+    weight = jnp.arange(96, dtype=jnp.float32)  # 3 * 4 * 8
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_scale",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_scale"].value
+    k = captured["model.layers.0.self_attn.k_proj.weight_scale"].value
+    v = captured["model.layers.0.self_attn.v_proj.weight_scale"].value
+
+    assert q.shape == (32,)
+    assert k.shape == (32,)
+    assert v.shape == (32,)
+    assert jnp.array_equal(q, jnp.arange(0, 32, dtype=jnp.float32))
+    assert jnp.array_equal(k, jnp.arange(32, 64, dtype=jnp.float32))
+    assert jnp.array_equal(v, jnp.arange(64, 96, dtype=jnp.float32))
+
+
+def test_1d_per_channel_scale_gqa_offsets():
+    """GQA: num_kv_heads < num_heads. Offsets become asymmetric."""
+    loader, captured = _make_loader(num_heads=8, num_kv_heads=2, head_dim_original=4)
+    mapping = _qkv_mapping("weight_scale")
+
+    # Q: 8*4=32, K: 2*4=8, V: 2*4=8. Total: 48.
+    weight = jnp.arange(48, dtype=jnp.float32)
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_scale",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_scale"].value
+    k = captured["model.layers.0.self_attn.k_proj.weight_scale"].value
+    v = captured["model.layers.0.self_attn.v_proj.weight_scale"].value
+
+    assert jnp.array_equal(q, jnp.arange(0, 32, dtype=jnp.float32))
+    assert jnp.array_equal(k, jnp.arange(32, 40, dtype=jnp.float32))
+    assert jnp.array_equal(v, jnp.arange(40, 48, dtype=jnp.float32))
+
+
+def test_1d_per_channel_scale_head_dim_padding():
+    """Qwen-style head_dim=96 case: each per-head slice gets padded to 128
+    along the (only) axis. Validates that the 1-D scale branch mirrors the
+    bias branch's reshape+pad+flatten when head_dim_padding=True."""
+    loader, captured = _make_loader(num_heads=2, num_kv_heads=2, head_dim_original=96)
+    mapping = _qkv_mapping("weight_scale", head_dim_padding=True)
+
+    # Unpadded: 3 * 2 * 96 = 576
+    weight = jnp.arange(576, dtype=jnp.float32)
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_scale",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_scale"].value
+    # Padded per-head 96 -> 128. Per-projection length: 2 * 128 = 256.
+    assert q.shape == (256,)
+
+    # Within each padded head, the first 96 elements are the original slice
+    # and the last 32 are zero.
+    q_reshaped = q.reshape(2, 128)
+    assert jnp.array_equal(q_reshaped[0, :96], jnp.arange(0, 96, dtype=jnp.float32))
+    assert jnp.all(q_reshaped[0, 96:] == 0)
+    assert jnp.array_equal(q_reshaped[1, :96], jnp.arange(96, 192, dtype=jnp.float32))
+    assert jnp.all(q_reshaped[1, 96:] == 0)
+
+
+def test_pre_fix_else_branch_still_handles_2d_weight():
+    """Regression guard: the 2-D weight else branch must keep working unchanged.
+    A 2-D weight (transpose=False) with shape [Q+K+V, hidden] should split
+    along axis 0."""
+    loader, captured = _make_loader(num_heads=4, num_kv_heads=4, head_dim_original=8)
+    mapping = WeightMapping(
+        target_path=[
+            "model.layers.0.self_attn.q_proj.weight_q",
+            "model.layers.0.self_attn.k_proj.weight_q",
+            "model.layers.0.self_attn.v_proj.weight_q",
+        ],
+        sharding=("tensor", None),
+        transpose=False,
+    )
+
+    # 3 * 4 * 8 = 96 rows, hidden = 32 cols
+    weight = jnp.arange(96 * 32, dtype=jnp.float32).reshape(96, 32)
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_q",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_q"].value
+    assert q.shape == (32, 32)
+    assert jnp.array_equal(q, weight[:32])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-xvs"])

--- a/python/sgl_jax/test/test_weight_loader_qkv_split.py
+++ b/python/sgl_jax/test/test_weight_loader_qkv_split.py
@@ -1,10 +1,11 @@
-"""Unit tests for WeightLoader._split_qkv_weight 1-D scale handling.
+"""Unit tests for WeightLoader._split_qkv_weight scale handling.
 
-Pre-fix, a 1-D per-channel `weight_scale` (HF shape `[Q_out+K_out+V_out,]`,
-as produced by compressed-tensors W8A16) fell through the bias / 2-D-scale
-branches into the 2-D weight else branch, where `weight[:q_dim, :]` on a
-1-D tensor raises IndexError. The fix adds a dedicated 1-D scale branch
-that splits along the single axis using the same Q/K/V offsets as bias.
+Covers the dedicated 1-D per-channel scale branch (compressed-tensors W8A16
+with HF shape [Q_out+K_out+V_out,]) and the 2-D non-block scale branch
+(compressed-tensors per-channel FP8 on Ling-2.6-1T with HF shape
+[Q_out+K_out+V_out, inner=1] and weight_block_size=None). Both must split
+on the same Q/K/V offsets as the bias branch and apply head_dim_padding
+the same way when set.
 """
 
 import jax.numpy as jnp
@@ -186,6 +187,114 @@ def test_pre_fix_else_branch_still_handles_2d_weight():
     q = captured["model.layers.0.self_attn.q_proj.weight_q"].value
     assert q.shape == (32, 32)
     assert jnp.array_equal(q, weight[:32])
+
+
+# ---------------------------------------------------------------------------
+# 2-D non-block scale branch (compressed-tensors per-channel FP8, Ling-2.6-1T)
+# ---------------------------------------------------------------------------
+
+
+class _DummyQuantCfg:
+    """quantization_config with weight_block_size=None — selects the new
+    element-wise fallback inside the 2-D scale branch."""
+
+    weight_block_size = None
+
+
+class _DummyModelConfig:
+    quantization_config = _DummyQuantCfg()
+
+
+def test_2d_non_block_scale_splits_at_correct_offsets():
+    """Ling-2.6-1T compressed-tensors per-channel FP8 stores QKV weight_scale
+    as 2-D shape [Q_out+K_out+V_out, 1] with weight_block_size=None. Should
+    fall back to element-wise axis-0 split on the same Q/K/V offsets as the
+    bias / 1-D branches, preserving the inner axis."""
+    loader, captured = _make_loader(num_heads=4, num_kv_heads=4, head_dim_original=8)
+    loader.model_config = _DummyModelConfig()
+    mapping = _qkv_mapping("weight_scale")
+
+    # 3 * 4 * 8 = 96 rows, inner = 1
+    weight = jnp.arange(96, dtype=jnp.float32).reshape(96, 1)
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_scale",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_scale"].value
+    k = captured["model.layers.0.self_attn.k_proj.weight_scale"].value
+    v = captured["model.layers.0.self_attn.v_proj.weight_scale"].value
+
+    assert q.shape == (32, 1)
+    assert k.shape == (32, 1)
+    assert v.shape == (32, 1)
+    assert jnp.array_equal(q, jnp.arange(0, 32, dtype=jnp.float32).reshape(32, 1))
+    assert jnp.array_equal(k, jnp.arange(32, 64, dtype=jnp.float32).reshape(32, 1))
+    assert jnp.array_equal(v, jnp.arange(64, 96, dtype=jnp.float32).reshape(32, 1))
+
+
+def test_2d_non_block_scale_gqa_offsets():
+    """GQA variant: num_kv_heads < num_heads. Same asymmetric offsets as the
+    1-D GQA case, with the inner axis preserved."""
+    loader, captured = _make_loader(num_heads=8, num_kv_heads=2, head_dim_original=4)
+    loader.model_config = _DummyModelConfig()
+    mapping = _qkv_mapping("weight_scale")
+
+    # Q: 8*4=32, K: 2*4=8, V: 2*4=8. Total: 48. Inner: 1.
+    weight = jnp.arange(48, dtype=jnp.float32).reshape(48, 1)
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_scale",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_scale"].value
+    k = captured["model.layers.0.self_attn.k_proj.weight_scale"].value
+    v = captured["model.layers.0.self_attn.v_proj.weight_scale"].value
+
+    assert q.shape == (32, 1)
+    assert k.shape == (8, 1)
+    assert v.shape == (8, 1)
+    assert jnp.array_equal(q, jnp.arange(0, 32, dtype=jnp.float32).reshape(32, 1))
+    assert jnp.array_equal(k, jnp.arange(32, 40, dtype=jnp.float32).reshape(8, 1))
+    assert jnp.array_equal(v, jnp.arange(40, 48, dtype=jnp.float32).reshape(8, 1))
+
+
+def test_2d_non_block_scale_head_dim_padding():
+    """Qwen-style head_dim=96 case: each per-head slice gets padded to 128
+    along axis 0 with the inner axis preserved. Validates that the 2-D
+    branch's reshape + pad + flatten mirrors the 1-D branch with an extra
+    inner dim."""
+    loader, captured = _make_loader(num_heads=2, num_kv_heads=2, head_dim_original=96)
+    loader.model_config = _DummyModelConfig()
+    mapping = _qkv_mapping("weight_scale", head_dim_padding=True)
+
+    # Unpadded: 3 * 2 * 96 = 576 rows, inner = 1
+    weight = jnp.arange(576, dtype=jnp.float32).reshape(576, 1)
+
+    loader._split_qkv_weight(
+        params=None,
+        hf_key="model.layers.0.attention.query_key_value.weight_scale",
+        weight=weight,
+        mapping=mapping,
+    )
+
+    q = captured["model.layers.0.self_attn.q_proj.weight_scale"].value
+    # Padded per-head 96 -> 128, 2 heads, inner 1 → (256, 1).
+    assert q.shape == (256, 1)
+
+    # Within each padded head, the first 96 elements (along the per-head axis)
+    # are the original slice and the last 32 are zero. Inner axis is preserved.
+    q_reshaped = q.reshape(2, 128, 1)
+    assert jnp.array_equal(q_reshaped[0, :96, 0], jnp.arange(0, 96, dtype=jnp.float32))
+    assert jnp.all(q_reshaped[0, 96:, 0] == 0)
+    assert jnp.array_equal(q_reshaped[1, :96, 0], jnp.arange(96, 192, dtype=jnp.float32))
+    assert jnp.all(q_reshaped[1, 96:, 0] == 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Backport from `sgl-project/sglang-jax` `main` the two weight-loader fixes that handle non-block compressed-tensors FP8 scale shapes in `_split_qkv_weight`. The `feat/fused-moe-v2-server-integration` branch diverged from main at `e2c5f910` (2026-05-11) and missed the May 20 / May 27 cluster of QKV-split PRs — so loading Ling-2.6-1T (per-channel FP8) currently crashes on the `_split_qkv_weight` path.

Three commits cherry-picked onto current `feat/fused-moe-v2-server-integration` head (`bcba7c0e`):

| Commit | Source PR | What it does |
|--------|-----------|--------------|
| `919fe3ea` | sgl-project#1154 | Add 1-D per-channel `weight_scale` branch in `_split_qkv_weight` + new `test_weight_loader_qkv_split.py` (4 cases) |
| `3f9405c9` | sgl-project#1230 (commit 1) | Add 2-D non-block `weight_scale` branch (degenerate `[out_dim, 1]` form, `weight_block_size=None`) — fixes `TypeError: 'NoneType' object is not subscriptable` at weight 6/1565 when loading Ling-2.6-1T |
| `2951c500` | sgl-project#1230 (commit 2) | Add 3 new test cases for the 2-D non-block path; downgrade per-layer log to info |

All three cherry-picks auto-merged with no conflicts. `_split_qkv_weight` now has four branches: `bias` / `1-D scale` (new) / `2-D block-quant scale` / `2-D non-block scale` (new) / generic 2-D weight else.

## Branch context

PR sgl-project#1146 (GLA QKV split, May 20) is also missing from this branch but was **not** backported because it touches `bailing_moe_linear.py` and `test_bailing_moe_linear.py` — both files were removed during the v2 server-integration cleanup. The loader-side `weight_utils.py` change from #1146 (read `head_dim` from `hf_text_config`) is a separate concern not exercised by the 1-D / 2-D scale split paths brought in here.

## Test plan

- [ ] Verify `python -m pytest python/sgl_jax/test/test_weight_loader_qkv_split.py` (7 tests) passes under `JAX_PLATFORMS=cpu` — upstream PR confirms 7/7 pass; cherry-picks are mechanical, no conflicts
- [ ] Load Ling-2.6-1T on a v7x 2x2x4 slice (tp=ep=32, dp=4) and confirm all 1565 regular weights + 80-layer MoE expert weights load to completion (previously crashed at weight 6/1565)

🤖 Generated with [Claude Code](https://claude.com/claude-code)