### PR TITLE
[Bench] Update the bench content for speculative decoding

### DIFF
--- a/python/sgl_jax/bench_serving.py
+++ b/python/sgl_jax/bench_serving.py
@@ -90,6 +90,7 @@ class RequestFuncInput:
     lora_name: str
     image_data: list[str] | None
     extra_request_body: dict[str, Any]
+    tokenizer: PreTrainedTokenizerBase | None = None
     timestamp: float | None = None
     routing_key: str | None = None
 
@@ -101,6 +102,7 @@ class RequestFuncOutput:
     latency: float = 0.0
     ttft: float = 0.0  # Time to first token
     itl: list[float] = field(default_factory=list)  # List of inter-token latencies
+    adjusted_itl: list[float] = field(default_factory=list)
     text_chunks: list[str] = field(default_factory=list)
     prompt_len: int = 0
     error: str = ""
@@ -258,6 +260,7 @@ async def async_request_openai_completions(
         st = time.perf_counter()
         output.start_time = st
         most_recent_timestamp = st
+        last_output_len = 0
         try:
             async with session.post(url=api_url, json=payload, headers=headers) as response:
                 if response.status == 200:
@@ -276,23 +279,41 @@ async def async_request_openai_completions(
                             # NOTE: Some completion API might have a last
                             # usage summary response without a token so we
                             # want to check a token was generated
-                            if data["choices"][0]["text"]:
+                            text = data["choices"][0]["text"]
+                            if text:
                                 timestamp = time.perf_counter()
+                                generated_text += text
+                                if request_func_input.tokenizer is None:
+                                    new_output_len = (data.get("usage") or {}).get(
+                                        "completion_tokens", output_len
+                                    )
+                                else:
+                                    new_output_len = len(
+                                        request_func_input.tokenizer.encode(
+                                            generated_text, add_special_tokens=False
+                                        )
+                                    )
+                                num_new_tokens = new_output_len - last_output_len
+                                output_len = new_output_len
+
                                 # First token
                                 if ttft == 0.0:
-                                    ttft = time.perf_counter() - st
+                                    ttft = timestamp - st
                                     output.ttft = ttft
 
                                 # Decoding phase
                                 else:
-                                    output.text_chunks.append(data["choices"][0]["text"])
-                                    output.itl.append(timestamp - most_recent_timestamp)
+                                    raw_itl = timestamp - most_recent_timestamp
+                                    output.text_chunks.append(text)
+                                    output.itl.append(raw_itl)
+                                    if num_new_tokens > 0:
+                                        adjusted_itl = raw_itl / num_new_tokens
+                                        output.adjusted_itl.extend(
+                                            [adjusted_itl] * num_new_tokens
+                                        )
 
                                 most_recent_timestamp = timestamp
-                                generated_text += data["choices"][0]["text"]
-                                output_len = (data.get("usage") or {}).get(
-                                    "completion_tokens", output_len
-                                )
+                                last_output_len = new_output_len
 
                     output.generated_text = generated_text
                     output.success = True
@@ -907,6 +928,12 @@ class BenchmarkMetrics:
     p95_itl_ms: float
     p99_itl_ms: float
     max_itl_ms: float
+    mean_adjusted_itl_ms: float
+    median_adjusted_itl_ms: float
+    std_adjusted_itl_ms: float
+    p95_adjusted_itl_ms: float
+    p99_adjusted_itl_ms: float
+    max_adjusted_itl_ms: float
     mean_e2e_latency_ms: float
     median_e2e_latency_ms: float
     std_e2e_latency_ms: float
@@ -1945,6 +1972,7 @@ def calculate_metrics(
     total_input_vision = 0
     completed = 0
     itls: list[float] = []
+    adjusted_itls: list[float] = []
     tpots: list[float] = []
     ttfts: list[float] = []
     e2e_latencies: list[float] = []
@@ -1979,6 +2007,7 @@ def calculate_metrics(
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
             else:
                 itls += outputs[i].itl
+            adjusted_itls += outputs[i].adjusted_itl or outputs[i].itl
             ttfts.append(outputs[i].ttft)
 
             e2e_latencies.append(outputs[i].latency)
@@ -2084,6 +2113,12 @@ def calculate_metrics(
         p95_itl_ms=np.percentile(itls or 0, 95) * 1000,
         p99_itl_ms=np.percentile(itls or 0, 99) * 1000,
         max_itl_ms=np.max(itls or 0) * 1000,
+        mean_adjusted_itl_ms=np.mean(adjusted_itls or 0) * 1000,
+        median_adjusted_itl_ms=np.median(adjusted_itls or 0) * 1000,
+        std_adjusted_itl_ms=np.std(adjusted_itls or 0) * 1000,
+        p95_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 95) * 1000,
+        p99_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 99) * 1000,
+        max_adjusted_itl_ms=np.max(adjusted_itls or 0) * 1000,
         mean_e2e_latency_ms=np.mean(e2e_latencies) * 1000,
         median_e2e_latency_ms=np.median(e2e_latencies) * 1000,
         std_e2e_latency_ms=np.std(e2e_latencies) * 1000,
@@ -2216,6 +2251,7 @@ async def benchmark(
         lora_name=lora_name,
         image_data=test_request.image_data,
         extra_request_body=extra_request_body,
+        tokenizer=tokenizer,
     )
 
     # Run warmup requests
@@ -2319,6 +2355,7 @@ async def benchmark(
             lora_name=lora_name,
             image_data=request.image_data,
             extra_request_body=extra_request_body,
+            tokenizer=tokenizer,
             timestamp=request.timestamp,
             routing_key=request.routing_key,
         )
@@ -2433,6 +2470,12 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
     print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
     print("{:<40} {:<10.2f}".format("Max ITL (ms):", metrics.max_itl_ms))
+    print("{s:{c}^{n}}".format(s="Adjusted Inter-Token Latency", n=50, c="-"))
+    print("{:<40} {:<10.2f}".format("Mean Adjusted ITL (ms):", metrics.mean_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("Median Adjusted ITL (ms):", metrics.median_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("P95 Adjusted ITL (ms):", metrics.p95_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("P99 Adjusted ITL (ms):", metrics.p99_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("Max Adjusted ITL (ms):", metrics.max_adjusted_itl_ms))
     print("=" * 50)
 
     resp = requests.get(base_url + "/get_server_info", headers=get_auth_headers())
@@ -2486,6 +2529,11 @@ async def benchmark(
             "std_itl_ms": metrics.std_itl_ms,
             "p95_itl_ms": metrics.p95_itl_ms,
             "p99_itl_ms": metrics.p99_itl_ms,
+            "mean_adjusted_itl_ms": metrics.mean_adjusted_itl_ms,
+            "median_adjusted_itl_ms": metrics.median_adjusted_itl_ms,
+            "std_adjusted_itl_ms": metrics.std_adjusted_itl_ms,
+            "p95_adjusted_itl_ms": metrics.p95_adjusted_itl_ms,
+            "p99_adjusted_itl_ms": metrics.p99_adjusted_itl_ms,
             "concurrency": metrics.concurrency,
             "accept_length": accept_length,
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
@@ -2516,6 +2564,7 @@ async def benchmark(
         "output_lens": output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],
+        "adjusted_itls": [output.adjusted_itl for output in outputs],
         "generated_texts": [output.generated_text for output in outputs],
         "errors": [output.error for output in outputs],
     }

--- a/python/sgl_jax/bench_serving.py
+++ b/python/sgl_jax/bench_serving.py
@@ -90,7 +90,6 @@ class RequestFuncInput:
     lora_name: str
     image_data: list[str] | None
     extra_request_body: dict[str, Any]
-    tokenizer: PreTrainedTokenizerBase | None = None
     timestamp: float | None = None
     routing_key: str | None = None
 
@@ -102,7 +101,6 @@ class RequestFuncOutput:
     latency: float = 0.0
     ttft: float = 0.0  # Time to first token
     itl: list[float] = field(default_factory=list)  # List of inter-token latencies
-    adjusted_itl: list[float] = field(default_factory=list)
     text_chunks: list[str] = field(default_factory=list)
     prompt_len: int = 0
     error: str = ""
@@ -260,7 +258,6 @@ async def async_request_openai_completions(
         st = time.perf_counter()
         output.start_time = st
         most_recent_timestamp = st
-        last_output_len = 0
         try:
             async with session.post(url=api_url, json=payload, headers=headers) as response:
                 if response.status == 200:
@@ -279,41 +276,23 @@ async def async_request_openai_completions(
                             # NOTE: Some completion API might have a last
                             # usage summary response without a token so we
                             # want to check a token was generated
-                            text = data["choices"][0]["text"]
-                            if text:
+                            if data["choices"][0]["text"]:
                                 timestamp = time.perf_counter()
-                                generated_text += text
-                                if request_func_input.tokenizer is None:
-                                    new_output_len = (data.get("usage") or {}).get(
-                                        "completion_tokens", output_len
-                                    )
-                                else:
-                                    new_output_len = len(
-                                        request_func_input.tokenizer.encode(
-                                            generated_text, add_special_tokens=False
-                                        )
-                                    )
-                                num_new_tokens = new_output_len - last_output_len
-                                output_len = new_output_len
-
                                 # First token
                                 if ttft == 0.0:
-                                    ttft = timestamp - st
+                                    ttft = time.perf_counter() - st
                                     output.ttft = ttft
 
                                 # Decoding phase
                                 else:
-                                    raw_itl = timestamp - most_recent_timestamp
-                                    output.text_chunks.append(text)
-                                    output.itl.append(raw_itl)
-                                    if num_new_tokens > 0:
-                                        adjusted_itl = raw_itl / num_new_tokens
-                                        output.adjusted_itl.extend(
-                                            [adjusted_itl] * num_new_tokens
-                                        )
+                                    output.text_chunks.append(data["choices"][0]["text"])
+                                    output.itl.append(timestamp - most_recent_timestamp)
 
                                 most_recent_timestamp = timestamp
-                                last_output_len = new_output_len
+                                generated_text += data["choices"][0]["text"]
+                                output_len = (data.get("usage") or {}).get(
+                                    "completion_tokens", output_len
+                                )
 
                     output.generated_text = generated_text
                     output.success = True
@@ -928,12 +907,6 @@ class BenchmarkMetrics:
     p95_itl_ms: float
     p99_itl_ms: float
     max_itl_ms: float
-    mean_adjusted_itl_ms: float
-    median_adjusted_itl_ms: float
-    std_adjusted_itl_ms: float
-    p95_adjusted_itl_ms: float
-    p99_adjusted_itl_ms: float
-    max_adjusted_itl_ms: float
     mean_e2e_latency_ms: float
     median_e2e_latency_ms: float
     std_e2e_latency_ms: float
@@ -1972,7 +1945,6 @@ def calculate_metrics(
     total_input_vision = 0
     completed = 0
     itls: list[float] = []
-    adjusted_itls: list[float] = []
     tpots: list[float] = []
     ttfts: list[float] = []
     e2e_latencies: list[float] = []
@@ -2007,7 +1979,6 @@ def calculate_metrics(
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
             else:
                 itls += outputs[i].itl
-            adjusted_itls += outputs[i].adjusted_itl or outputs[i].itl
             ttfts.append(outputs[i].ttft)
 
             e2e_latencies.append(outputs[i].latency)
@@ -2113,12 +2084,6 @@ def calculate_metrics(
         p95_itl_ms=np.percentile(itls or 0, 95) * 1000,
         p99_itl_ms=np.percentile(itls or 0, 99) * 1000,
         max_itl_ms=np.max(itls or 0) * 1000,
-        mean_adjusted_itl_ms=np.mean(adjusted_itls or 0) * 1000,
-        median_adjusted_itl_ms=np.median(adjusted_itls or 0) * 1000,
-        std_adjusted_itl_ms=np.std(adjusted_itls or 0) * 1000,
-        p95_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 95) * 1000,
-        p99_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 99) * 1000,
-        max_adjusted_itl_ms=np.max(adjusted_itls or 0) * 1000,
         mean_e2e_latency_ms=np.mean(e2e_latencies) * 1000,
         median_e2e_latency_ms=np.median(e2e_latencies) * 1000,
         std_e2e_latency_ms=np.std(e2e_latencies) * 1000,
@@ -2251,7 +2216,6 @@ async def benchmark(
         lora_name=lora_name,
         image_data=test_request.image_data,
         extra_request_body=extra_request_body,
-        tokenizer=tokenizer,
     )
 
     # Run warmup requests
@@ -2355,7 +2319,6 @@ async def benchmark(
             lora_name=lora_name,
             image_data=request.image_data,
             extra_request_body=extra_request_body,
-            tokenizer=tokenizer,
             timestamp=request.timestamp,
             routing_key=request.routing_key,
         )
@@ -2470,12 +2433,6 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
     print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
     print("{:<40} {:<10.2f}".format("Max ITL (ms):", metrics.max_itl_ms))
-    print("{s:{c}^{n}}".format(s="Adjusted Inter-Token Latency", n=50, c="-"))
-    print("{:<40} {:<10.2f}".format("Mean Adjusted ITL (ms):", metrics.mean_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("Median Adjusted ITL (ms):", metrics.median_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("P95 Adjusted ITL (ms):", metrics.p95_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("P99 Adjusted ITL (ms):", metrics.p99_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("Max Adjusted ITL (ms):", metrics.max_adjusted_itl_ms))
     print("=" * 50)
 
     resp = requests.get(base_url + "/get_server_info", headers=get_auth_headers())
@@ -2529,11 +2486,6 @@ async def benchmark(
             "std_itl_ms": metrics.std_itl_ms,
             "p95_itl_ms": metrics.p95_itl_ms,
             "p99_itl_ms": metrics.p99_itl_ms,
-            "mean_adjusted_itl_ms": metrics.mean_adjusted_itl_ms,
-            "median_adjusted_itl_ms": metrics.median_adjusted_itl_ms,
-            "std_adjusted_itl_ms": metrics.std_adjusted_itl_ms,
-            "p95_adjusted_itl_ms": metrics.p95_adjusted_itl_ms,
-            "p99_adjusted_itl_ms": metrics.p99_adjusted_itl_ms,
             "concurrency": metrics.concurrency,
             "accept_length": accept_length,
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
@@ -2564,7 +2516,6 @@ async def benchmark(
         "output_lens": output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],
-        "adjusted_itls": [output.adjusted_itl for output in outputs],
         "generated_texts": [output.generated_text for output in outputs],
         "errors": [output.error for output in outputs],
     }

--- a/python/sgl_jax/bench_serving.py
+++ b/python/sgl_jax/bench_serving.py
@@ -2131,6 +2131,25 @@ def wrap_multi_turn_request_func(request_func: Callable, backend: str) -> Callab
     return f
 
 
+def _read_vllm_spec_counters(base_url: str):
+    """Read spec decode counters from vllm /metrics endpoint. Returns (drafts, accepted) or None."""
+    try:
+        resp = requests.get(base_url + "/metrics", timeout=5)
+        if resp.status_code != 200:
+            return None
+        drafts = accepted = None
+        for line in resp.text.splitlines():
+            if line.startswith("vllm:spec_decode_num_drafts_total"):
+                drafts = float(line.split()[-1])
+            elif line.startswith("vllm:spec_decode_num_accepted_tokens_total"):
+                accepted = float(line.split()[-1])
+        if drafts is not None and accepted is not None:
+            return (drafts, accepted)
+    except Exception:
+        pass
+    return None
+
+
 async def benchmark(
     backend: str,
     api_url: str,
@@ -2265,6 +2284,9 @@ async def benchmark(
             if profile_output.success:
                 print("Profiler started")
 
+    # Snapshot spec decode counters before benchmark (for vllm /metrics)
+    _spec_before = _read_vllm_spec_counters(base_url) if "sgl-jax" not in backend else None
+
     # Run all requests
     benchmark_start_time = time.perf_counter()
     tasks: list[asyncio.Task] = []
@@ -2347,22 +2369,27 @@ async def benchmark(
     if pbar is not None:
         pbar.close()
 
+    accept_length = None
     if "sgl-jax" in backend:
-        server_info = requests.get(base_url + "/get_server_info")
-        if server_info.status_code == 200:
-            server_info_json = server_info.json()
-            if "decode" in server_info_json:
-                server_info_json = server_info_json["decode"][0]
-            if "internal_states" in server_info_json and server_info_json["internal_states"]:
-                accept_length = server_info_json["internal_states"][0].get(
-                    "avg_spec_accept_length", None
-                )
-            else:
-                accept_length = None
-        else:
-            accept_length = None
+        try:
+            server_info = requests.get(base_url + "/get_server_info")
+            if server_info.status_code == 200:
+                server_info_json = server_info.json()
+                if "decode" in server_info_json:
+                    server_info_json = server_info_json["decode"][0]
+                if "internal_states" in server_info_json and server_info_json["internal_states"]:
+                    accept_length = server_info_json["internal_states"][0].get(
+                        "avg_spec_accept_length", None
+                    )
+        except Exception:
+            pass
     else:
-        accept_length = None
+        _spec_after = _read_vllm_spec_counters(base_url)
+        if _spec_before and _spec_after:
+            d_drafts = _spec_after[0] - _spec_before[0]
+            d_accepted = _spec_after[1] - _spec_before[1]
+            if d_drafts > 0:
+                accept_length = (d_accepted + d_drafts) / d_drafts
 
     # Compute metrics and print results
     benchmark_duration = time.perf_counter() - benchmark_start_time

--- a/python/sgl_jax/bench_serving.py
+++ b/python/sgl_jax/bench_serving.py
@@ -102,7 +102,7 @@ class RequestFuncOutput:
     latency: float = 0.0
     ttft: float = 0.0  # Time to first token
     itl: list[float] = field(default_factory=list)  # List of inter-token latencies
-    spec_itl: list[float] = field(default_factory=list)
+    adjusted_itl: list[float] = field(default_factory=list)
     text_chunks: list[str] = field(default_factory=list)
     prompt_len: int = 0
     error: str = ""
@@ -307,9 +307,9 @@ async def async_request_openai_completions(
                                     output.text_chunks.append(text)
                                     output.itl.append(raw_itl)
                                     if num_new_tokens > 0:
-                                        spec_itl = raw_itl / num_new_tokens
-                                        output.spec_itl.extend(
-                                            [spec_itl] * num_new_tokens
+                                        adjusted_itl = raw_itl / num_new_tokens
+                                        output.adjusted_itl.extend(
+                                            [adjusted_itl] * num_new_tokens
                                         )
 
                                 most_recent_timestamp = timestamp
@@ -928,12 +928,12 @@ class BenchmarkMetrics:
     p95_itl_ms: float
     p99_itl_ms: float
     max_itl_ms: float
-    mean_spec_itl_ms: float
-    median_spec_itl_ms: float
-    std_spec_itl_ms: float
-    p95_spec_itl_ms: float
-    p99_spec_itl_ms: float
-    max_spec_itl_ms: float
+    mean_adjusted_itl_ms: float
+    median_adjusted_itl_ms: float
+    std_adjusted_itl_ms: float
+    p95_adjusted_itl_ms: float
+    p99_adjusted_itl_ms: float
+    max_adjusted_itl_ms: float
     mean_e2e_latency_ms: float
     median_e2e_latency_ms: float
     std_e2e_latency_ms: float
@@ -1972,7 +1972,7 @@ def calculate_metrics(
     total_input_vision = 0
     completed = 0
     itls: list[float] = []
-    spec_itls: list[float] = []
+    adjusted_itls: list[float] = []
     tpots: list[float] = []
     ttfts: list[float] = []
     e2e_latencies: list[float] = []
@@ -2007,7 +2007,7 @@ def calculate_metrics(
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
             else:
                 itls += outputs[i].itl
-            spec_itls += outputs[i].spec_itl or outputs[i].itl
+            adjusted_itls += outputs[i].adjusted_itl or outputs[i].itl
             ttfts.append(outputs[i].ttft)
 
             e2e_latencies.append(outputs[i].latency)
@@ -2113,12 +2113,12 @@ def calculate_metrics(
         p95_itl_ms=np.percentile(itls or 0, 95) * 1000,
         p99_itl_ms=np.percentile(itls or 0, 99) * 1000,
         max_itl_ms=np.max(itls or 0) * 1000,
-        mean_spec_itl_ms=np.mean(spec_itls or 0) * 1000,
-        median_spec_itl_ms=np.median(spec_itls or 0) * 1000,
-        std_spec_itl_ms=np.std(spec_itls or 0) * 1000,
-        p95_spec_itl_ms=np.percentile(spec_itls or 0, 95) * 1000,
-        p99_spec_itl_ms=np.percentile(spec_itls or 0, 99) * 1000,
-        max_spec_itl_ms=np.max(spec_itls or 0) * 1000,
+        mean_adjusted_itl_ms=np.mean(adjusted_itls or 0) * 1000,
+        median_adjusted_itl_ms=np.median(adjusted_itls or 0) * 1000,
+        std_adjusted_itl_ms=np.std(adjusted_itls or 0) * 1000,
+        p95_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 95) * 1000,
+        p99_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 99) * 1000,
+        max_adjusted_itl_ms=np.max(adjusted_itls or 0) * 1000,
         mean_e2e_latency_ms=np.mean(e2e_latencies) * 1000,
         median_e2e_latency_ms=np.median(e2e_latencies) * 1000,
         std_e2e_latency_ms=np.std(e2e_latencies) * 1000,
@@ -2470,12 +2470,12 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
     print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
     print("{:<40} {:<10.2f}".format("Max ITL (ms):", metrics.max_itl_ms))
-    print("{s:{c}^{n}}".format(s="Spec Inter-Token Latency", n=50, c="-"))
-    print("{:<40} {:<10.2f}".format("Mean Spec ITL (ms):", metrics.mean_spec_itl_ms))
-    print("{:<40} {:<10.2f}".format("Median Spec ITL (ms):", metrics.median_spec_itl_ms))
-    print("{:<40} {:<10.2f}".format("P95 Spec ITL (ms):", metrics.p95_spec_itl_ms))
-    print("{:<40} {:<10.2f}".format("P99 Spec ITL (ms):", metrics.p99_spec_itl_ms))
-    print("{:<40} {:<10.2f}".format("Max Spec ITL (ms):", metrics.max_spec_itl_ms))
+    print("{s:{c}^{n}}".format(s="Adjusted Inter-Token Latency", n=50, c="-"))
+    print("{:<40} {:<10.2f}".format("Mean Adjusted ITL (ms):", metrics.mean_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("Median Adjusted ITL (ms):", metrics.median_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("P95 Adjusted ITL (ms):", metrics.p95_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("P99 Adjusted ITL (ms):", metrics.p99_adjusted_itl_ms))
+    print("{:<40} {:<10.2f}".format("Max Adjusted ITL (ms):", metrics.max_adjusted_itl_ms))
     print("=" * 50)
 
     resp = requests.get(base_url + "/get_server_info", headers=get_auth_headers())
@@ -2529,11 +2529,11 @@ async def benchmark(
             "std_itl_ms": metrics.std_itl_ms,
             "p95_itl_ms": metrics.p95_itl_ms,
             "p99_itl_ms": metrics.p99_itl_ms,
-            "mean_spec_itl_ms": metrics.mean_spec_itl_ms,
-            "median_spec_itl_ms": metrics.median_spec_itl_ms,
-            "std_spec_itl_ms": metrics.std_spec_itl_ms,
-            "p95_spec_itl_ms": metrics.p95_spec_itl_ms,
-            "p99_spec_itl_ms": metrics.p99_spec_itl_ms,
+            "mean_adjusted_itl_ms": metrics.mean_adjusted_itl_ms,
+            "median_adjusted_itl_ms": metrics.median_adjusted_itl_ms,
+            "std_adjusted_itl_ms": metrics.std_adjusted_itl_ms,
+            "p95_adjusted_itl_ms": metrics.p95_adjusted_itl_ms,
+            "p99_adjusted_itl_ms": metrics.p99_adjusted_itl_ms,
             "concurrency": metrics.concurrency,
             "accept_length": accept_length,
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
@@ -2564,7 +2564,7 @@ async def benchmark(
         "output_lens": output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],
-        "spec_itls": [output.spec_itl for output in outputs],
+        "adjusted_itls": [output.adjusted_itl for output in outputs],
         "generated_texts": [output.generated_text for output in outputs],
         "errors": [output.error for output in outputs],
     }

--- a/python/sgl_jax/bench_serving.py
+++ b/python/sgl_jax/bench_serving.py
@@ -102,7 +102,7 @@ class RequestFuncOutput:
     latency: float = 0.0
     ttft: float = 0.0  # Time to first token
     itl: list[float] = field(default_factory=list)  # List of inter-token latencies
-    adjusted_itl: list[float] = field(default_factory=list)
+    spec_itl: list[float] = field(default_factory=list)
     text_chunks: list[str] = field(default_factory=list)
     prompt_len: int = 0
     error: str = ""
@@ -307,9 +307,9 @@ async def async_request_openai_completions(
                                     output.text_chunks.append(text)
                                     output.itl.append(raw_itl)
                                     if num_new_tokens > 0:
-                                        adjusted_itl = raw_itl / num_new_tokens
-                                        output.adjusted_itl.extend(
-                                            [adjusted_itl] * num_new_tokens
+                                        spec_itl = raw_itl / num_new_tokens
+                                        output.spec_itl.extend(
+                                            [spec_itl] * num_new_tokens
                                         )
 
                                 most_recent_timestamp = timestamp
@@ -928,12 +928,12 @@ class BenchmarkMetrics:
     p95_itl_ms: float
     p99_itl_ms: float
     max_itl_ms: float
-    mean_adjusted_itl_ms: float
-    median_adjusted_itl_ms: float
-    std_adjusted_itl_ms: float
-    p95_adjusted_itl_ms: float
-    p99_adjusted_itl_ms: float
-    max_adjusted_itl_ms: float
+    mean_spec_itl_ms: float
+    median_spec_itl_ms: float
+    std_spec_itl_ms: float
+    p95_spec_itl_ms: float
+    p99_spec_itl_ms: float
+    max_spec_itl_ms: float
     mean_e2e_latency_ms: float
     median_e2e_latency_ms: float
     std_e2e_latency_ms: float
@@ -1972,7 +1972,7 @@ def calculate_metrics(
     total_input_vision = 0
     completed = 0
     itls: list[float] = []
-    adjusted_itls: list[float] = []
+    spec_itls: list[float] = []
     tpots: list[float] = []
     ttfts: list[float] = []
     e2e_latencies: list[float] = []
@@ -2007,7 +2007,7 @@ def calculate_metrics(
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
             else:
                 itls += outputs[i].itl
-            adjusted_itls += outputs[i].adjusted_itl or outputs[i].itl
+            spec_itls += outputs[i].spec_itl or outputs[i].itl
             ttfts.append(outputs[i].ttft)
 
             e2e_latencies.append(outputs[i].latency)
@@ -2113,12 +2113,12 @@ def calculate_metrics(
         p95_itl_ms=np.percentile(itls or 0, 95) * 1000,
         p99_itl_ms=np.percentile(itls or 0, 99) * 1000,
         max_itl_ms=np.max(itls or 0) * 1000,
-        mean_adjusted_itl_ms=np.mean(adjusted_itls or 0) * 1000,
-        median_adjusted_itl_ms=np.median(adjusted_itls or 0) * 1000,
-        std_adjusted_itl_ms=np.std(adjusted_itls or 0) * 1000,
-        p95_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 95) * 1000,
-        p99_adjusted_itl_ms=np.percentile(adjusted_itls or 0, 99) * 1000,
-        max_adjusted_itl_ms=np.max(adjusted_itls or 0) * 1000,
+        mean_spec_itl_ms=np.mean(spec_itls or 0) * 1000,
+        median_spec_itl_ms=np.median(spec_itls or 0) * 1000,
+        std_spec_itl_ms=np.std(spec_itls or 0) * 1000,
+        p95_spec_itl_ms=np.percentile(spec_itls or 0, 95) * 1000,
+        p99_spec_itl_ms=np.percentile(spec_itls or 0, 99) * 1000,
+        max_spec_itl_ms=np.max(spec_itls or 0) * 1000,
         mean_e2e_latency_ms=np.mean(e2e_latencies) * 1000,
         median_e2e_latency_ms=np.median(e2e_latencies) * 1000,
         std_e2e_latency_ms=np.std(e2e_latencies) * 1000,
@@ -2470,12 +2470,12 @@ async def benchmark(
     print("{:<40} {:<10.2f}".format("P95 ITL (ms):", metrics.p95_itl_ms))
     print("{:<40} {:<10.2f}".format("P99 ITL (ms):", metrics.p99_itl_ms))
     print("{:<40} {:<10.2f}".format("Max ITL (ms):", metrics.max_itl_ms))
-    print("{s:{c}^{n}}".format(s="Adjusted Inter-Token Latency", n=50, c="-"))
-    print("{:<40} {:<10.2f}".format("Mean Adjusted ITL (ms):", metrics.mean_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("Median Adjusted ITL (ms):", metrics.median_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("P95 Adjusted ITL (ms):", metrics.p95_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("P99 Adjusted ITL (ms):", metrics.p99_adjusted_itl_ms))
-    print("{:<40} {:<10.2f}".format("Max Adjusted ITL (ms):", metrics.max_adjusted_itl_ms))
+    print("{s:{c}^{n}}".format(s="Spec Inter-Token Latency", n=50, c="-"))
+    print("{:<40} {:<10.2f}".format("Mean Spec ITL (ms):", metrics.mean_spec_itl_ms))
+    print("{:<40} {:<10.2f}".format("Median Spec ITL (ms):", metrics.median_spec_itl_ms))
+    print("{:<40} {:<10.2f}".format("P95 Spec ITL (ms):", metrics.p95_spec_itl_ms))
+    print("{:<40} {:<10.2f}".format("P99 Spec ITL (ms):", metrics.p99_spec_itl_ms))
+    print("{:<40} {:<10.2f}".format("Max Spec ITL (ms):", metrics.max_spec_itl_ms))
     print("=" * 50)
 
     resp = requests.get(base_url + "/get_server_info", headers=get_auth_headers())
@@ -2529,11 +2529,11 @@ async def benchmark(
             "std_itl_ms": metrics.std_itl_ms,
             "p95_itl_ms": metrics.p95_itl_ms,
             "p99_itl_ms": metrics.p99_itl_ms,
-            "mean_adjusted_itl_ms": metrics.mean_adjusted_itl_ms,
-            "median_adjusted_itl_ms": metrics.median_adjusted_itl_ms,
-            "std_adjusted_itl_ms": metrics.std_adjusted_itl_ms,
-            "p95_adjusted_itl_ms": metrics.p95_adjusted_itl_ms,
-            "p99_adjusted_itl_ms": metrics.p99_adjusted_itl_ms,
+            "mean_spec_itl_ms": metrics.mean_spec_itl_ms,
+            "median_spec_itl_ms": metrics.median_spec_itl_ms,
+            "std_spec_itl_ms": metrics.std_spec_itl_ms,
+            "p95_spec_itl_ms": metrics.p95_spec_itl_ms,
+            "p99_spec_itl_ms": metrics.p99_spec_itl_ms,
             "concurrency": metrics.concurrency,
             "accept_length": accept_length,
             "max_output_tokens_per_s": metrics.max_output_tokens_per_s,
@@ -2564,7 +2564,7 @@ async def benchmark(
         "output_lens": output_lens,
         "ttfts": [output.ttft for output in outputs],
         "itls": [output.itl for output in outputs],
-        "adjusted_itls": [output.adjusted_itl for output in outputs],
+        "spec_itls": [output.spec_itl for output in outputs],
         "generated_texts": [output.generated_text for output in outputs],
         "errors": [output.error for output in outputs],
     }

--- a/python/sgl_jax/srt/managers/scheduler.py
+++ b/python/sgl_jax/srt/managers/scheduler.py
@@ -1179,6 +1179,11 @@ class Scheduler(
         ret["new_token_ratio"] = self.new_token_ratio
         ret["init_new_token_ratio"] = self.init_new_token_ratio
 
+        if self.spec_num_total_forward_ct > 0:
+            ret["avg_spec_accept_length"] = (
+                self.spec_num_total_accepted_tokens / self.spec_num_total_forward_ct
+            )
+
         return GetInternalStateReqOutput(internal_state=ret)
 
     def set_internal_state(self, recv_req: SetInternalStateReq):

--- a/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
@@ -131,6 +131,8 @@ class SchedulerMetricsMixin:
         if running_batch.spec_algorithm is not None and not running_batch.spec_algorithm.is_none():
             accept_ratio = (self.accept_token - self.spec_num_forward_ct) / (self.draft_token - self.spec_num_forward_ct)
             accept_len = self.accept_token / self.spec_num_forward_ct
+            self.spec_num_total_accepted_tokens += self.accept_token
+            self.spec_num_total_forward_ct += self.spec_num_forward_ct
             self.accept_token = 0
             self.draft_token = 0
             self.spec_num_forward_ct = 0

--- a/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
+++ b/python/sgl_jax/srt/managers/scheduler_metrics_mixin.py
@@ -129,7 +129,7 @@ class SchedulerMetricsMixin:
             msg += f"#running-req per DP: {per_dp_running}, "
 
         if running_batch.spec_algorithm is not None and not running_batch.spec_algorithm.is_none():
-            accept_ratio = self.accept_token / self.draft_token
+            accept_ratio = (self.accept_token - self.spec_num_forward_ct) / (self.draft_token - self.spec_num_forward_ct)
             accept_len = self.accept_token / self.spec_num_forward_ct
             self.accept_token = 0
             self.draft_token = 0


### PR DESCRIPTION
## Content
- Change the cal of accept rate the same to sglang
<img width="1531" height="148" alt="image" src="https://github.com/user-attachments/assets/344435a8-18b3-413a-8038-aec32bc62b50" />

- Add accept length statistics

## Test

```bash
python3 -m sgl_jax.bench_serving \
    --backend sgl-jax \
    --host 127.0.0.1 --port 8000 \
    --dataset-name random \
    --num-prompts 3 \
    --random-input 1024 \
    --random-output 1024 \
    --max-concurrency 1 \
    --random-range-ratio 1 \
    --warmup-requests 0
```
<img width="1462" height="153" alt="image" src="https://github.com/user-attachments/assets/d4f08391-f3ba-46a4-bf2c-a6fb3ea517bd" />

<img width="471" height="438" alt="image" src="https://github.com/user-attachments/assets/b289bca9-ef65-4fe5-ac8f-4eb59ee377e5" />
