### PR TITLE
docs(mimo-v2.5): step-1 prework + step-2 model integration design

### DIFF
--- a/docs/design/mimo_v25_step1_prework.md
+++ b/docs/design/mimo_v25_step1_prework.md
@@ -1,0 +1,277 @@
+# MiMo-V2.5 接入 · 第一步：三项必做前置改造
+
+> **范围**：接入 MiMo-V2.5 前必须先完成的三项前置改造，给出问题背景与具体整改方案。
+> **依据**：以源码为准，分析对象为 sglang-jax 分支 `fix/dp-multimodal-input-embedding`（`/Users/lianfang/primatrix/sglang-jax-fix-dp-mm`）。证据以 `文件:行号` 标注（行号以审读时为准，实施前复核）。
+> **结构**：§0 全流程概览 → 问题 1（入口与多模态标识）→ 问题 2（编码 stage 编译加速）→ 问题 3（编码 stage 模型无关契约）→ 限制/后续（DP>1、batch>1）→ 复盘备查。
+
+---
+
+## 0. 请求处理全流程概览
+
+一条包含图像/音频的对话请求，自进入至返回需经过五个阶段；后续三项改造分别针对其中的特定阶段。
+
+```
+① HTTP 入口          用户 POST /v1/chat/completions（消息含 text + image/video/audio）
+        │
+② 预处理(Tokenizer)   文字 → token id；图/音 → HF 处理器抽取特征；打包为 mm_inputs
+        │             并在 token 序列中为每段媒体保留"占位符 token"（如 image_token）
+        │
+③ 调度(GlobalScheduler) 将请求转为内部 Req 对象，按 stage 配置顺序逐级下发
+        │
+④ 各 stage（每站由 scheduler 调度 + worker 包装 + runner 执行 + model 模型 四层构成）
+        │   ④a 编码 stage：将媒体特征编码为 embedding，并注入 ② 预留的占位符位置
+        │   ④b 生成 stage：大语言模型基于合并后的序列逐 token 生成
+        │
+⑤ 回包(Detokenizer)   将生成的 token 解码为文字，返回用户
+```
+
+**三项前置改造对应的阶段**：
+- **问题 1** → 阶段 **①**（请求入口归属）+ 多模态标识开关。
+- **问题 2** → 阶段 **④a** 编码 stage 的**执行效率**（当前未启用编译、且输出契约脆弱）。
+- **问题 3** → 阶段 **④a** 编码 stage 的**模型适配能力**（装载/输入/注册三处均硬编码为 Qwen 形状，换 MiMo 即失败）。
+
+> **术语**
+> - **token / token id**：模型将文字切分为的最小单位，每个对应一个整数 id。
+> - **embedding**：将 token id 或媒体特征映射为浮点向量；模型实际处理的是向量。
+> - **占位符 token**：图像/音频本身非文字，需在 token 序列中占位——以特殊 token（如 `image_token`）重复 N 次占据 N 个位置，后续将媒体特征注入这 N 个位置。
+> - **JIT（即时编译）**：将逐算子解释执行的代码编译为优化后的计算图，在 TPU/GPU 上显著提速；张量的**分片注解**亦仅在编译后生效。
+> - **mesh / sharding（网格 / 分片）**：将大张量切分到多芯片并行；"网格"描述芯片排布，"分片注解"指定张量沿哪根轴切分。
+
+---
+
+## 问题 1 · 请求入口归属错误，且系统缺少可靠的多模态标识（阶段 ① + 总开关）
+
+包含两个相互独立的基线缺陷。
+
+### 1.1 入口路由重复注册，多模态处理函数为不可达死代码
+
+**现状**
+服务启动时将"URL → 处理函数"登记入路由表，而 `/v1/chat/completions` 被登记了**两次**：
+
+1. 核心模块先登记 `/v1/chat/completions`（`entrypoints/http_server.py:697`）。
+2. 多模态模块为加入自有逻辑，又在**同一 app 对象**上登记了**同名**路由（`multimodal/entrypoint/http_server.py:300`，本意走多模态专用构造 `_extract_openai_prompt → GenerateOmniReqInput`）。
+3. Starlette 的匹配规则为"**先注册者优先、不去重**"。核心路由先注册 → **核心处理函数生效**，多模态处理函数**永不被调用**（已实测确认为死代码）。`/abort_request` 存在同样的重复（核心 `:604` vs 多模态 `:350`）。
+
+**为何当前仍可运行（易误解处）**
+模型执行链路（②③④⑤）由进程启动时的 `launch()` + `set_global_state(...)` 独立拉起，**与 HTTP 路由归属无关**；且 `set_global_state` 将 `tokenizer_manager` 置为多模态版 `MultimodalTokenizer`，故即便请求由核心处理函数接收，仍会转交多模态 tokenizer 处理。**结论：服务可运行，但实际走的是核心（且不完整的）请求构造逻辑，多模态专用构造被跳过；且"谁生效"取决于 import 顺序，稳定性差。**
+
+**整改方案**
+- 仅保留**一条** `/v1/chat/completions`，在其内部按"是否多模态模型"分流至多模态 / 纯文本两套构造；删除多模态侧的重复登记。整改后请求必走正确构造路径，且与 import 顺序无关。
+- 过渡方案（若暂无法合并）：多模态入口在登记自有路由前，**先移除核心的同名路由**，确保自身唯一生效。
+
+### 1.2 多模态标识 `is_multimodal` 恒为 False
+
+**现状**
+核心配置中本应表征"是否多模态"的字段 `is_multimodal` 被**无条件置为 False**（`configs/model_config.py:162`）——无论加载何种模型均返回 False。实际的多模态判定依赖两处带外信号：命令行开关 `server_args.multimodal` 与"启动时 import 了哪个模块"；而下游消费方（`serving_chat.py:66-70`）读取的恰是该恒 False 字段。另有 `multimodal_model_archs` 列表（`model_config.py:791`）已定义但无消费方。
+
+**问题分析**
+核心调度/预处理需要一个可靠字段来判定"是否执行多模态逻辑（如 embedding 注入）"。该字段恒 False，使判定只能依赖命令行参数与 import 副作用隐式进行，难以推理、易出错。
+
+**整改方案**
+- 由模型自身的 `hf_config.model_type / architectures` 推导 `is_multimodal`（MiMo-V2.5 → True，纯文本模型 → False）；核心 serving/scheduler 统一读取该字段。
+
+### 1.3 意义 / 验收 / 风险
+- **意义**：image/video/audio 对话的主入口必须命中正确处理函数；核心需准确识别多模态以执行后续 embedding 注入。二者为后续工作的基础。
+- **验收**：多模态模式下 `/v1/chat/completions` 命中多模态分支；`is_multimodal` 对 MiMo-V2.5 返回 True、对纯文本模型返回 False。
+- **风险**：低，且两缺陷相互独立。注意点：合并为单一处理函数时需确认 `OpenAIServingChat` 可承接多模态请求构造，否则采用上述过渡方案。
+
+---
+
+## 问题 2 · 编码 stage 未启用编译加速、且输出契约脆弱（热路径性能最高优先项）
+
+该项位于**算力消耗最高的热路径**上，整改方案明确、收益直接，且所有多模态模型均受益。（其中"输出写死 3-tuple"亦属问题 3"编码 stage 缺模型无关契约"的一个侧面。）
+
+### 2.0 背景与关键概念
+
+**编码 stage（④a）职责**：将图像/音频经各自 encoder（视觉 ViT、音频 encoder）编码为 embedding，注入 ② 预留的占位符位置，形成"文字 + 媒体"完整序列后交由 ④b 的大语言模型。
+
+**JIT（即时编译）**：未启用 JIT 时代码逐算子解释执行，性能较低；启用后整段计算被编译为优化计算图，TPU 上显著提速，且张量的**分片注解仅在编译后生效**（即大矩阵切分到多芯片）。
+
+**形状分桶（shape bucketing）**：JIT 缓存**以输入张量形状为键**——形状变化即触发一次重编译。多模态输入形状高度可变（图像尺寸→图块数、音频时长→帧数、序列长度均不同），若不处理将导致**频繁重编译**。分桶即将可变尺寸**以补零方式 pad 至少量固定档位**（如 512 / 1024 / 2048…），使 JIT 仅需编译"档位数"次，其余命中缓存。
+
+### 2.1 现状
+
+编码 stage 的执行器 `EmbedModelRunner` 存在三处缺陷：
+
+1. **未启用 JIT**：`embed_model_runner.py:48-102` 中启用 JIT 的代码被**整段注释**（且无说明），`self.jitted_embedding` 实为普通 Python 函数，直接 eager 调用 `self.model(...)`。后果：整段 ViT / 音频 encoder **逐算子解释执行、分片注解失效**——而其余 6 个 stage 执行器均已启用 JIT。
+2. **输出契约写死**：`forward`（`:181`）以 `a, b, c = self.jitted_embedding(...)` **写死"模型须返回 3 个值"**，返回结构变化即失败。
+3. **设备固定为 CPU**：该执行器目前仅服务 Qwen3-Omni，其流水线配置将编码 stage 置为 `device_kind: cpu`（`qwen3_omni_stage_config.yaml:7`）。
+
+**关闭编译的原因分析（避免"仅取消注释"的误判）**
+并非技术上必须关闭——JIT 在 CPU 上同样可编译，同仓 `qwen2_5_vl_stage_config_tp4.yaml` 的视觉 stage 亦位于 CPU 却**启用了 JIT**。更可能的原因为：编码 stage 的输入**形状高度可变**，未分桶时启用 JIT 会**频繁重编译**；叠加"位于 CPU、分片无意义、编译耗时"，遂改为 eager。**根因是缺少形状分桶，CPU 部署只是降低了启用 JIT 的动机。**
+
+### 2.2 整改方案（按改动位置分组）
+
+整改不止"取消注释启用 JIT"，须一并解决"当初关闭的原因"。共五处，标明各自所在文件/函数：
+
+**(A) 启用 JIT + 结构化输出 —— `EmbedModelRunner.initialize_jit`**
+- 沿用同仓已验证的视觉执行器 `vit_model_runner.py:44-102` 的骨架：在外层以 `nnx.split` / `tree_flatten` 拆分"定义 + 权重"，在被 JIT 的函数内以 `tree_unflatten` / `nnx.merge` 合回，外层套 `jax.jit(..., static_argnames=["model_state_def"])`。
+- **结构化输出**：编码模型 `__call__` 返回**带字段名的结构**（如 `EmbedOutput(input_embeds, deepstack_embeds, deepstack_pos_mask)`），执行器**按字段名取用**，不再写死 3-tuple；不同模型可仅填充自身字段（MiMo-V2.5 无 deepstack，仅填 `input_embeds`）。
+
+**(B) 形状分桶 + 补零 —— `EmbedModelRunner._prepare_input`（分桶落点）**
+分桶**全部在 host 侧、JIT 调用前**完成：对每条可变轴定义一组固定档位，将实际尺寸 pad 至"不小于其的最近档位"，同时记录真实长度：
+
+| 输入 | 形状 | 可变轴 | 档位（示例，按真实分布调整） |
+|---|---|---|---|
+| `input_ids` | `[seq]` | 序列长度 seq | 512 / 1024 / 2048 / 4096 |
+| `pixel_values`（图） | `[图块数, patch维]` | 图块数 | 256 / 512 / 1024 / 2048 / 4096 |
+| `input_features`（音频） | `[特征维, 帧数]` | 帧数 | 按音频分段大小的倍数 |
+| `image_grid_thw` | `[图数, 3]` | 图数 | 1 / 2 / 4 / 8（或设为静态） |
+
+`_prepare_input` 改为：计算实际尺寸 → 选定档位 → 补零 pad 至档位尺寸 → 产出 `valid_len / valid_mask`（标识有效数据与补零）→ 连同元信息（真实序列长度等）一并返回。
+> 原理：JIT 以形状为缓存键。补零后所有请求形状仅落在少量档位内，JIT 仅编译档位数次，其余命中缓存，频繁重编译被消除。
+> 网格/位置等辅助量（如视觉 `grid_thw`）仍按视觉执行器做法转为**静态值**，在 host 侧算好辅助数组后再喂入 JIT。
+
+**(C) 屏蔽补零 —— 编码模型内部（正确性，不可省）**
+补零**不得污染计算结果**：
+- **encoder**：视觉/音频 encoder 须忽略补零部分（通过有效段边界 / 注意力 mask / `valid_len`），否则补零将作为有效数据参与注意力。
+- **合并（scatter）**：仅将**有效**特征行注入占位符（按真实计数，而非 pad 后计数），并加入"占位符数量 == 有效特征行数"断言，越界即报错。
+
+**(D) 输出去 pad —— `EmbedModelRunner.forward`**
+JIT 输出的 `input_embeds` 长度为档位长度，须**切回真实序列长度** `input_embeds[:真实seq长度]` 后再写入 `mm_inputs["multimodal_embedding"]`；下游 ④b 按真实序列长度取用该 embedding，长度不一致将导致错位。
+
+**(E) 编码 stage 部署至 TPU —— 流水线配置 yaml**
+MiMo-V2.5 的编码 stage 设 `device_kind: tpu`（**不沿用** Qwen3-Omni 的 `cpu`）。该 stage 承载 729M 视觉塔 + 音频编码，CPU eager 执行性能不可接受；部署至 TPU 后 (A) 的 JIT 与分片方有意义。
+
+### 2.3 整改后流程
+
+```
+EmbedModelRunner.forward(请求):
+  ┌ _prepare_input(请求):                         # host 侧，JIT 之前
+  │    计算实际尺寸 → 选定档位 → 补零 pad(input_ids / pixel_values / 音频)
+  │    产出 valid_len / valid_mask + 元信息(真实seq长度…)
+  │    grid_thw → 静态值 → host 侧算辅助数组(段边界等)
+  ├ out = jitted_embedding(已 pad 的输入, 辅助数组, valid_len)
+  │        # 形状仅落在档位集合内 → 每个档位组合编译一次，其余命中缓存
+  │        └ 模型内：encoder（按 valid_len 屏蔽补零）
+  │                  → 合并（按真实计数将特征 scatter 至占位符）→ 返回 EmbedOutput(带字段名)
+  ├ input_embeds = out.input_embeds[:真实seq长度]            # 去 pad
+  └ 写 mm_inputs["multimodal_embedding"] = input_embeds（deepstack 等按字段名写）
+```
+
+### 2.4 验收 / 风险与注意事项
+- **验收**：编码 stage 于 TPU 成功编译、分片注解生效；档位集合内**不再频繁重编译**（编译次数 ≈ 档位组合数）；补零位置不影响输出（数值与 eager 版一致）；输出长度等于真实序列长度。
+- **风险与注意事项**：
+  1. **档位需覆盖真实输入分布**：过粗导致补零浪费算力，过细导致编译变体过多；建议先粗后调。
+  2. **补零必须被屏蔽**：否则补零进入 encoder/合并将污染结果——属正确性问题而非性能问题。
+  3. **图像布局亦影响形状**：图块数相同但图数/长宽不同时，辅助数组（段边界）长度变化，可能产生额外编译变体；首轮可对"图数"一并分桶或容忍少量变体。
+  4. **去 pad 长度须对齐生成 stage**：编码输出长度须等于真实序列长度，否则下游取用错位。
+
+---
+
+## 问题 3 · 编码 stage 对模型形状硬编码，非 Qwen 模型无法装载（结构性关键项）
+
+该项是 MiMo-V2.5 能否被编码 stage 装载运行的**硬前提**——不整改则模型在启动阶段即抛异常。它与问题 2 中"输出 3-tuple 写死"为同源问题。
+
+### 3.0 概述
+
+编码 stage 执行器（`EmbedModelRunner`）自始仅服务 Qwen-VL / Qwen3-Omni 类模型，从未定义"新 omni 模型接入需实现哪些约定"。因此其在**三个层面**均硬编码了 Qwen 形状：如何从 HF 配置取子配置、forward 接收哪些输入、模型返回哪些输出。MiMo-V2.5 是**首个走此路径的非 Qwen omni 模型**，故三处均受阻。
+
+### 3.1 现状（三处硬编码，均仅适配 Qwen）
+
+1. **config 装载写死 `.thinker_config`（启动即失败处）**：执行器装载模型时直接取 `model_config.thinker_config`（`embed_model_runner.py:39`）。`thinker_config` 为 Qwen3-Omni 特有子配置；**MiMo-V2.5 配置为扁平结构、无 `thinker_config` 属性** → 抛 `AttributeError`、**启动即失败**。
+2. **forward 输入签名写死 Qwen 形状**：被调用的 `forward_model(...)` 入参写死为 `input_features / pixel_values_videos / image_grid_thw …`（`embed_model_runner.py:60-67`），系 Qwen 视觉+音频的输入种类。**MiMo-V2.5 音频走 `audio_codes`**（RVQ 码），无法匹配该签名。
+3. **配置注册表仅含 Qwen**：`config_registry` 按 `model_path` 字符串匹配，**默认维度为 Qwen2.5-VL**（depth32 / hidden3584 / patch14），缺少 `mimovl`（depth28 / hidden1280 / patch16）与 V2.5 音频子配置入口 → 多模态侧配置对象（`mm_config`）无法获取 MiMo 的占位符 token id 与各塔维度。
+
+> 上述三处 + 问题 2.2(A) 的"输出 3-tuple 写死"，恰构成 embed-stage 缺契约的四个层面：**config 提取、输入、输出、注册**。
+
+### 3.2 问题分析与关键澄清
+
+- **本质是缺接口，而非"MiMo 特殊"**：任何非 Qwen 的 omni 模型至此均会同样失败。整改收益是**一次性为后续所有 omni 模型铺路**，而非仅为 MiMo 打补丁。
+- **关键澄清：占位符 token id 本身不缺，不应在核心配置中"补解析"**。易误判为"框架未解析 video/audio token id，需在核心配置补上"——**方向错误**。依据：
+  - 编码 stage 模型读取的是**原始 HF 配置对象**（`embed_model_runner.py:35-39`），而非核心引擎的 `ModelConfig`；编码模型直接使用 `self.config.{image,video,audio}_token_id`。
+  - MiMo-V2.5 的 HF 配置类**已将三个 token id 暴露为属性**：image/video 位于顶层，audio 在构造时由 `processor_config` 复制至 `self`，故 `config.audio_token_id` 可取得。
+  - 核心 `ModelConfig` 中"仅解析 image_token_id"的字段，**唯一消费方是非多模态单栈入口（`tokenizer_manager`）**，omni 链路不经过它。
+  - **结论**：需补的并非"解析 token id"，而是"**令编码 stage 识别 MiMo 的配置结构 / 输入种类 / 在注册表中具备维度**"。
+
+### 3.3 整改方案：将编码 stage 收敛为薄契约
+
+不应以 `if 是MiMo: … else: …` 打补丁——那只会使 MiMo 成为**第二个**硬编码模型，后续 omni 模型继续累积债务。正确做法是抽出一个**模型无关的薄契约**，由模型自行声明，执行器不再识别具体模型：
+
+- **(A) config 提取按模型声明**：移除 `embed_model_runner.py:39` 写死的 `.thinker_config`；由模型声明"如何从 HF 配置获取自身子配置"——MiMo 直接使用配置本体（token id 与 vision/audio 子配置均挂其上），Qwen-Omni 仍取 `.thinker_config`。
+- **(B) 输入按模型声明的输入种类组织**：`forward_model` 不再写死字段，改为按模型声明的输入集合传入（支持 `audio_codes` / `pixel_values` / `image_grid_thw` / … 的并集），模型仅取自身所需。
+- **(C) 注册表新增 MiMo 入口**：在 `config_registry` 注册 `mimovl` 视觉子配置（depth28/hidden1280/patch16…）与 V2.5 音频子配置；其中 audio_tokenizer 为**独立子目录、独立 model_type**，走单独注册入口（不能从主配置的 audio_config 获取）。
+- **(D) 输出结构化（与问题 2 合流）**：模型返回**带字段名的结构**而非 3-tuple，执行器按字段名取用。
+- 综上，编码 stage 契约 = **(config 提取, 输入 spec, 输出字段, 注册维度)** 四项由模型声明，runner 保持通用。
+- **配置类装载**：MiMoV2 配置类经 HF 远程代码加载（auto_map + `trust_remote_code`，默认已开），**不应**纳入核心本地 typed-config 注册表（后者要求本地可导入该类）。
+
+### 3.4 意义 / 验收 / 风险
+- **意义**：此为 MiMo 能被编码 stage 装载运行的硬前提（否则启动 `AttributeError`）；同时将 embed-stage 由"仅适配 Qwen"升级为"面向接口"，后续 omni 模型可直接复用。
+- **验收**：MiMo 配置经 `EmbedModelRunner` 正常装载（无 `AttributeError`）；`audio_codes` 可传入 forward；`config_registry` 返回 `mimovl` / V2.5 音频的正确维度；编码模型读 `self.config.*_token_id` 三者均可取得。
+- **风险**：中。抽取薄契约较加 `if/else` 工作量略大，但可避免"第二个硬编码模型"的债务累积；改动集中于 `embed_model_runner` 与 `config_registry`，不涉及调度/生成 stage。
+
+---
+
+## 限制 / 后续任务项（三项前置之外，各自独立立项）
+
+> 在 **DP=1（不启用数据并行）且单 batch（每批不与纯文本请求混跑）** 下，完成上述三项前置即可使 MiMo-V2.5 完整运行。以下两条为**放开并发规模时触发的正确性硬约束**——不在三项前置范围内，但须明确，否则放开后将静默出错。
+
+### A. DP > 1（数据并行）
+
+> 若首轮需启用 **DP>1（将请求分配至多份模型副本以提升吞吐）**，存在一项必须单独整改的正确性硬约束。
+
+**问题**
+数据并行需要一张将芯片划分为 `[data, tensor]` 两轴的网格：`data` 轴为模型副本数，`tensor` 轴为每副本内部切分数。但当前各 stage 自建网格时写死 `ici_parallelism=[-1, 芯片数]`（`stage.py:98-109`），解析后 **`data` 轴恒为 1**（即仅一份副本）；而核心调度器又按命令行 `dp_size`（可能 >1）交织排布各副本数据（`schedule_batch.py` 的 `_merge_multimodal`，按 `range(dp_size)` 排布）。
+
+**后果**：当 `dp_size>1` 时，host 侧按"多副本"排布数据，而网格仅"一份副本"——二者不一致，张量分片（`input_ids` 标注按 `data` 轴切分，但 `data` 轴大小为 1）与多副本布局冲突，导致形状/分片错误。**DP=1 时该约束休眠**（`data=1` 恰等于 `dp_size=1`，自洽）。
+
+**最小整改（不涉及大重构）**
+- 编码/生成 stage 自建网格时**令 `data` 轴取真实 `dp_size`**：`ici_parallelism=[dp_size, 芯片数 // dp_size]`，来源取命令行 `dp_size`；并在调度器接收外部网格处加入断言 `mesh.shape["data"] == dp_size`，固化该隐式约束。
+- 备选：生成 stage **不自建网格，交由核心调度器按 `[dp_size, tensor]` 构建**。
+- 附带：若同时启用 MoE 专家并行（MiMo-V2.5 为 256 专家），`ep_size` 须同时整除 256 与芯片总数（data×tensor）。
+
+**定位**：此为本分支 `fix/dp-multimodal-input-embedding` 的命题，属**后续任务**。首轮若 **DP=1** 可不动；若需 **DP>1**，则在三项前置之外额外执行此项最小整改。
+
+### B. batch > 1（同批混跑多请求 / 含纯文本请求）
+
+**问题**
+首轮按**单 batch（一次处理一条请求，或同批不混入纯文本）** 运行。编码 stage 合并媒体 embedding 时采用**整段替换**：将该请求完整的"文字 + 媒体" embedding 整段传给生成 stage。单请求时无误——该整段即其自身数据。
+
+**放开 batch>1 时的错误**
+当同批**同时包含"带媒体请求"与"纯文本请求"**时，纯文本请求**不含**媒体 embedding 数据；而整段替换的逻辑为"只要批内有请求带媒体即整批走替换分支"——纯文本请求对应的行将被填为**全零向量**（producer 仅为带媒体请求写入 embedding，纯文本位置为零初始化）。**后果**：同批纯文本请求获得全零 embedding，输出异常。**单 batch / 不混纯文本时该约束休眠**。
+
+**最小整改（放开 batch>1 时执行）**
+- 将"整段替换"改为**按 token 位置的 scatter-merge**：生成 stage 先经文字 embedding 查表得到全部文本向量，再**仅替换媒体占位符所在行**为媒体 embedding；producer 侧同时携带"每个 token 是否为媒体占位符"的位置掩码。
+- 如此，混批中的纯文本请求保留自身文字 embedding，不再被整段覆盖为零。
+
+**定位**：属**后续任务**，与 DP>1 独立。首轮**单 batch** 可不动；需支持**批内混跑/含纯文本**时，额外执行此项 scatter-merge 改造。
+
+---
+
+## 复盘备查：易误判点与潜在缺陷
+
+> 以下为分析过程中**已修正或差点误判**的要点：部分为"表象类似缺陷但实为设计如此"，部分为"表象正常但实为潜在缺陷"。记录以备后续复核。各条格式：现象 → 源码证据 → 结论/建议。
+
+**① pad_value 仅为 radix-cache key，不参与 embedding（最易误判）**
+- 现象：`pad_input_tokens` 会将占位符 token 替换为 `pad_value`，易据此推断"合并时也按 pad_value 定位、故与按 token_id 的合并代码口径不一致、且需 clamp"。
+- 源码：`set_pad_value` 中 `pad_value = hash % (1<<24)`，注释明确 **"used for radix cache differentiation, NOT for embedding lookup"**（`modality_enum.py:226-228`）；`pad_input_tokens` 的返回值赋给**独立字段** `req.cache_input_ids`（`global_scheduler.py:369`），**非**被 embed 的 `input_ids`；合并路径（如 `vit_model_runner._merge_multimodal_embeddings`）使用的是**原始 token_id**。
+- 结论：embed 路径全程使用原始 token_id（位于词表内）、自洽，**合并按 token_id、无需 clamp**。**不应照搬 sglang 上游**——上游为"pad_value 写入被 embed 的 input_ids + clamp"，sglang-jax 为"两个字段、两种用途"，结论相反。
+
+**② 多图共享同一 pad_value，导致 radix cache 区分失效（潜在缺陷）**
+- 现象：多图场景下前缀缓存本应区分不同图，实际无法区分。
+- 源码：`MultimodalDataItem` 为"一 item = 一个模态的全部输入"（`modality_enum.py:174`）；`pad_input_tokens` 中 `image_idx` **从不自增**（`:122-129`，注释"same pad_value for all tokens of an image"）→ 多图落同一 pad_value。
+- 结论：影响 **radix cache 命中率（非正确性）**。恢复 per-image 区分需细化 item 粒度 / 令 idx 随图自增。
+
+**③ VL 合并缺数量校验，存在静默越界风险（潜在缺陷）**
+- 现象：若 ViT 输出的视觉行数 ≠ 占位符数（grid/merge 计算有误等），不报错而静默错位。
+- 源码：`vit_model_runner._merge_multimodal_embeddings`（`:105-139`）以 `cumsum(mask)` 为索引 gather 视觉行，**无**"占位符数 == 特征行数"断言；而 Qwen3-Omni 的合并**有**该校验。
+- 建议：为 VL（及任何新模型的合并）补充数量断言，越界即报错。
+
+**④ embed stage 的 JIT 被注释且无说明，易误判为"取消注释即可"**
+- 现象：`embed_model_runner.py:48-102` 整段 JIT 被注释、`jitted_embedding` 实为 eager，且无任何说明。
+- 反例：同仓 `qwen2_5_vl_stage_config_tp4.yaml` 的视觉 stage 同为 `device_kind: cpu`，却**启用了** JIT（`vit_model_runner.py:64`）。可见 CPU 并不要求 eager。
+- 结论：真因更可能为**可变输入形状导致频繁重编译**（叠加"位于 CPU、分片无意义"），遂改为 eager。**整改须配合形状分桶**，非仅取消注释（见问题 2）。
+
+**⑤ 多模态入口路由为死代码但模型仍可运行，易误判为"路由生效"**
+- 现象：多模态自注册的 `/v1/chat/completions`（`http_server.py:300`）永不执行，但服务仍能处理多模态请求。
+- 源码：核心同名路由先注册（`entrypoints/http_server.py:697`）、Starlette 首个匹配优先；而 `set_global_state` 将 `tokenizer_manager` 置为多模态版，核心处理函数转交其处理。
+- 结论：可运行 ≠ 走正确路径；实际走核心（不完整的）构造，且依赖 import 顺序（见问题 1）。
+
+**⑥ `is_multimodal` 恒为 False，易误判为"系统已识别多模态"**
+- 源码：`configs/model_config.py:162` 无条件 False；`multimodal_model_archs`（`:791`）已定义但无消费方。多模态判定实际依赖 `server_args.multimodal` + import 副作用（见问题 1）。
+
+---
+
+### 附录
+- 本文覆盖三项必做前置（问题 1/2/3）+ 两条后续限制（DP>1、batch>1）+ 复盘备查；问题编号为本文内部编号，独立成文。
+- 全程以源码为准（branch `fix/dp-multimodal-input-embedding`）；`文件:行号` 为审读时所见，实施前请复核（行号可能随提交漂移）。

--- a/docs/design/mimo_v25_step2_model_integration.md
+++ b/docs/design/mimo_v25_step2_model_integration.md
@@ -1,0 +1,246 @@
+# MiMo-V2.5 接入 · 第二步：模型级接入方案
+
+> **前提**：第一步 prework 的三个前置问题已解决——① 入口路由归一 + `is_multimodal` 由 model_type 推导；② 编码 stage 已开 JIT + 形状分桶 + 结构化输出 + 放 TPU；③ 编码 stage 执行器已是**模型无关契约**（config 装载不再写死 `thinker_config`、`_prepare_input` 支持 per-model、注册声明式）。本文在此基础上只讲"MiMo-V2.5 这个模型本身怎么接进来"。
+>
+> **架构前提**：沿用现有 **2-stage `embedding → auto_regressive` 流水线**（不动调度/DP 双栈大重构）。本轮范围 **DP=1、batch=1**；**DP>1 / batch>1 见 §6 限制**。
+>
+> **数据来源（重要）**：以源码为准——分析对象为 sglang-jax 分支 `fix/dp-multimodal-input-embedding`（`/Users/lianfang/primatrix/sglang-jax-fix-dp-mm`）；模型结构数值取自 **MiMo-V2.5 真实 `config.json`（经 ModelScope 镜像读取）** 与 sglang 上游实现。本文自洽、不援引其它设计文档；不确定项进 §6 开放问题。`文件:行号` 为审读时所见，实施前复核。
+
+---
+
+## 1. MiMo-V2.5 的 HF 模型架构梳理
+
+### 1.1 总览
+MiMo-V2.5 是一个**原生 omni 的稀疏 MoE 大模型**：`model_type="mimo_v2"`、`architectures=["MiMoV2ForCausalLM"]`，**单一 checkpoint** 内同时持有：文本 MoE backbone（`self.model`）+ 视觉塔（`self.visual`）+ 音频理解 encoder（`self.audio_encoder`）。三模态全部做**理解**（text/image/video/audio in → text out），**不含**任何生成/vocoder。`config.json` 是**扁平结构**：`vision_config` / `audio_config` 直接挂在顶层，**没有 `thinker_config`** 这层（与 Qwen3-Omni 不同）。
+
+```
+                ┌──────────── MiMoV2ForCausalLM (单 checkpoint) ───────────┐
+ image/video ─► │  self.visual = MiMoVL ViT ─┐                            │
+       audio ─► │  self.audio_encoder ───────┤► 各自出 [N,4096] 特征      │
+                │  self.model = MiMo-V2-Flash MoE LM（文本 + 生成）        │
+        text ─► │  self.model.embed_tokens ──┘  把三模态特征 scatter 进序列 │
+                └──────────────────────────────────────────────────────────┘
+```
+
+### 1.2 LLM backbone = MiMo-V2-Flash（JAX 已有 text-only 实现，主要复用）
+稀疏 MoE + hybrid 滑窗/全局注意力。真实 config 关键字段：
+
+| 项 | 值 |
+|---|---|
+| hidden_size / 层数 | 4096 / 48 层（`moe_layer_freq` → 第 0 层 dense，1–47 MoE） |
+| MoE | `n_routed_experts=256`、`num_experts_per_tok=8`、无 shared expert、gate `scoring_func=sigmoid` + `topk_method=noaux_tc`、`moe_intermediate_size=2048` |
+| 混合注意力 | `hybrid_layer_pattern` 实测 **9 个 Full(GA) + 39 个 SWA**；`sliding_window=128` |
+| heads | `num_attention_heads=64`；**KV：GA=4 / SWA=8**（`num_key_value_heads=4` / `swa_num_key_value_heads=8`）；`head_dim=192`、`v_head_dim=128` |
+| RoPE | **1-D 标准 RoPE**（`rope_scaling.type=default`，**无 mrope**）；`rope_theta`=1e7(GA)/1e4(SWA)；`partial_rotary_factor=0.334` |
+| 其它 | `attention_value_scale=0.707`、`attention_projection_layout=fused_qkv`；**sink bias 仅 SWA 层**（`add_swa_attention_sink_bias=true`、full 层 false） |
+| 量化 | FP8 e4m3，`weight_block_size=[128,128]`；**全部 `o_proj` 排除量化** |
+| MTP | 3 层（投机解码） |
+
+> JAX 现有 `python/sgl_jax/srt/models/mimo_v2_{flash,pro,nextn}.py` 是这套 backbone 的 **text-only** 实现 → **stage1 的 LM 主要复用之**，按上表逐字段对齐即可（详见 §3.2）。
+
+### 1.3 Vision = MiMoVL ViT（JAX 无对应，需新建）
+`vision_model_type="mimovl"`，真实 `vision_config`：
+
+| 项 | 值 |
+|---|---|
+| depth | 28；full-attn 层 `fullatt_block_indexes=[0,9,18,27]`（4 full + 24 窗口） |
+| 窗口注意力 | `vit_window_attn_types`∈{-1,0,1} = full/**行 1-D 窗口**/**列 1-D 窗口**；`window_size=128`、`visual_token_window_size=64`；`use_sink=true` |
+| 维度 | hidden 1280、`num_heads=32` / KV 8（GQA，`num_query_groups=4`）、**head_dim=1280/32=40** |
+| patch | `patch_size=16`、`spatial_merge_size=2`、`temporal_patch_size=2` |
+| 输出 | `out_hidden_size=4096`（== LM hidden；ViT 自带 merger projector，**不需额外 adapter**） |
+
+预处理为 Qwen2.5-VL 风格（`processor_config`：`image_min/max_pixels=8192/8388608`、`merge_size=2`、`patch_size=16`）。
+
+### 1.4 Audio 理解 = 冻结 RVQ tokenizer + 小型 local transformer + projection（JAX 可复用 building blocks）
+**需特别说明**：MiMo-V2.5 的音频理解**并非**"连续 mel→conv→projector encoder"，而是先经一段**冻结的 RVQ 音频 tokenizer**得到**离散码**，再经小型 transformer 与投影。真实 `audio_config` + `processor_config`：
+
+```
+波形 → 24kHz mono → log-mel [1,T,128]                （MiMoAudioProcessor：n_mels128/nfft960/hop240/win960/sr24000）
+ → 冻结 RVQ MiMoAudioTokenizer.encode               （权重在 checkpoint 的 audio_tokenizer/ 子目录）
+       → 离散码 [audio_channels=20, T']             （为 20 通道，即使用全部 RVQ 级；不应沿用 V1 的 8）
+ → per-channel speech_embeddings（20 通道，speech_vocab_size=1280，zeroemb_idx=1024）
+ → input_local_transformer：6 层 FULL-attention Qwen2（dim 1024、heads 16、head_dim 64、intermediate 4096、
+                                                    rope_theta 640000、partial_rotary 1.0、add_post_norm、group_size 4）
+ → projection（projection_layers=2）→ (N, 4096)
+ → scatter 到 audio_token_id=151669 位置
+```
+**无 RVQ 之外的生成路径**（不含 patch_decoder / vocoder）。`feature_attention_mask` 对 V2.5 **恒为 None**——音频 mel 是自描述变长 list，长度由 tokenizer 内部按 `audio_segment_size=6000` 分段，不靠 mask 推。
+
+### 1.5 三模态 token 与位置
+- token id（已核 `config.json`/`processor_config`）：`image=151655`、`video=151656`、`audio=151669`；vision_start/end=151652/151653、video_start/end=151670/151671、audio_start/end=151673/151674；`eos=151645`、`pad=151643`、`vocab_size=152576`、`tie_word_embeddings=false`。
+- 合并方式：LM 先 embed 文本，再把 ViT / audio_encoder 的 4096 维输出 **scatter** 到各自占位符位置（三塔输出都是 4096，无需额外投影）。
+- 位置编码：**1-D RoPE**（processor `use_video_timestamps=true` 强制 `rope_type=rope`），**不是 mrope**；视频按时间戳展开 1-D 位置。
+
+### 1.6 权重布局（用于 weight-mapping）
+单 checkpoint，按权重名**前缀路由**：`visual./vision_model.` → ViT；`audio_*` / `speech_embeddings` → audio_encoder；`model.*` → 文本 backbone。**RVQ tokenizer 权重单独放在 checkpoint 的 `audio_tokenizer/` 子目录**，需单独加载（且冻结）。
+
+---
+
+## 2. 2-stage 架构总览
+
+沿用现有 `embedding → auto_regressive` 线性两段流水线。omni 的"多 encoder 汇入一个 LLM"靠**把三塔塞进 stage0 一个模型内部完成合并**实现（不需要跨 stage 的 DAG）：
+
+```
+请求(text+image+video+audio)  ──ZMQ──▶  GlobalScheduler.convert_omni_request
+  （AutoProcessor 产出 MultimodalDataItem[]：pixel_values / pixel_values_videos / 音频 mel；1-D positions）
+        │  Req(omni_inputs=mm_inputs(dict), pixel_values_images, pixel_values_videos, audio_features, grids…)
+        ▼  current_stage 0 → 1（线性）
+  ┌─ Stage0 = "embedding"（device_kind: tpu，已开 JIT+分桶）────────────────┐
+  │  EmbedScheduler → EmbedModelWorker → EmbedModelRunner（prework 后模型无关）│
+  │    _prepare_input(Req)（含形状分桶/补零）→ MiMoV2_5Embedding(**inputs)│
+  │       visual(MiMoVL ViT) + audio_encoder(RVQ encode+local+proj) + text_embed │
+  │       按 token_id scatter 三模态 → input_embeds[seq,4096]                 │
+  │    反 pad → 写 omni_inputs["multimodal_embedding"]                        │
+  └────────────────────────────────────────────────────────────────────────┘
+        │  to_stage_reqs("auto_regressive")：TokenizedGenerateReqInput.mm_inputs = omni_inputs
+        ▼
+  ┌─ Stage1 = "auto_regressive"（核心 Scheduler，复用 mimo_v2_flash）─────────┐
+  │  handle_generate_request: req.multimodal_embedding = mm_inputs[...]       │
+  │  ScheduleBatch._merge_multimodal：按 dp_rank offset 排进 ForwardBatch     │
+  │       ForwardBatch.input_embedding（MiMo-V2.5 无 mrope/无 deepstack）     │
+  │  MiMoV2_5Generation（MoE LM）：input_embedding hook + 1-D RoPE → 逐 token  │
+  └────────────────────────────────────────────────────────────────────────┘
+        ▼ BatchTokenIDOut → MultimodalDetokenizer → HTTP
+```
+要点：**stage0 由单一模型完成三模态编码与合并、产出 `input_embeds`**；stage1 的 LLM 仅读取 `forward_batch.input_embedding`，不接触原始 pixel/mel。
+
+---
+
+## 3. 接线方案详解
+
+### 3.1 Embed-stage 模型 `MiMoV2_5Embedding`（新建）
+满足现有 `EmbedModelRunner` 的契约（prework 后已模型无关），即可无需改动接入 `EmbedScheduler/Worker/Runner`。参照 `qwen3_omni_thinker_embedding.py`：
+
+- **构造** `__init__(self, config, *, mesh, dtype=jnp.bfloat16, rngs=None)`，持有三塔：
+  - `self.visual` = MiMoVL ViT（§3 新建），调用 `visual(pixel_values.astype(dtype), grid_thw)`，返回 `{"pooler_output":[N,4096], "deepstack_features": None}`（V2.5 无 deepstack）。
+  - `self.audio_encoder` = §1.4 的 RVQ-理解通路，调用 `audio_encoder(mels: list)` → `[N,4096]`（**不**用 `feature_attention_mask`）。
+  - `self.text_embed_tokens` = `Embed(vocab=152576, hidden=4096, kernel_axes=("tensor",None), mesh=mesh)`。
+  - 从 config 读 `image/video/audio_token_id`。
+- **`__call__` 签名**（runner 按 keyword 调用，且 prework 已支持 per-model 输入准备）：embed 文本 → 各塔（present 才跑）→ 按 **token_id** 建 mask（含"占位符数==特征行数"断言）→ `at[mask].set(ravel(feats))` 三模态 scatter。
+- **合并按 token_id、不 clamp**：被 embed 的 `input_ids` 是原始 token_id（在词表内）；`pad_value` 只活在 `cache_input_ids`（radix cache），不进 embed。各模型自管 merge，不抽共享引擎。
+- **结构化输出**（prework 问题 2 已支持）：返回 `EmbedOutput(input_embeds, deepstack=None, pos_mask=None)`，runner 按字段取。
+
+### 3.2 AR stage（`auto_regressive`）模型（复用 mimo_v2_flash）
+
+> 命名说明：stage 名是 **`auto_regressive`（AR）**；模型**类名**用 `*Generation` 后缀是沿用本仓既有约定（`Qwen2_5_VL_Generation`、`Qwen3OmniMoeThinkerTextForConditionalGeneration`），即 HF 风格"用于生成的因果 LM"类名，**不是 stage 名**。
+复用 `models/mimo_v2_flash.py` 的 MoE 解码器，按生成模型契约接三个 hook（参照 `qwen3_omni_thinker.py`，hook 本身无需改）：
+- **input_embedding hook**：`hidden = forward_batch.input_embedding if not None else embed_tokens(input_ids)`——stage0 合并结果由此进入 LM。
+- **位置**：**1-D RoPE**，走 `forward_batch.positions`（**不建 MRotaryEmbedding、不产 mrope_positions**）。
+- **deepstack**：MiMo-V2.5 **无**；`apply_for_deepstack=False`，逐层注入分支 no-op。
+- **MoE/量化**：按 §1.2 对齐——256 experts top-8、hybrid 9Full+39SWA（KV GA=4/SWA=8）、`attention_value_scale=0.707`、`fused_qkv`、sink-bias-仅-SWA、`partial_rotary=0.334`、FP8 `[128,128]`（o_proj 排除）、3 层 MTP。`ep_size` 须整除 256 与设备总数（见 §6）。
+
+### 3.3 Stage 配置（新建 `models/static_configs/mimo_v2.5_stage_config.yaml`）
+```yaml
+model_arch: MiMo-V2.5
+stage_args:
+ - stage_id: 0
+   runtime: { num_tpus: <N>, device_kind: tpu, max_batch_size: 1 }   # 必须 tpu（prework 问题2：重型 encoder + JIT + 分桶）
+   scheduler: embedding
+   model_class: MiMoV2_5Embedding
+   final_output: false
+ - stage_id: 1
+   runtime: { num_tpus: <M>, max_batch_size: 1 }
+   scheduler: auto_regressive
+   model_class: MiMoV2_5Generation
+   precompile_params: { input_embedding: True, deepstack_visual_embedding: False, mrope: False }  # 无 deepstack、1-D rope
+   final_output: true
+```
+并让注册（prework 问题3 的声明式注册）能按 MiMo-V2.5 的 model_path 解析到此 yaml + 两个 model_class + config。
+
+### 3.4 请求流与 Req（基本复用现有 omni 管线）
+- 入口：`GenerateOmniReqInput`（已含 `audio_data`）→ `convert_omni_request`（已拆 image/video/audio mm_items、拼 `req.audio_features/pixel_values_*`）→ Req。**无改动**。
+- 预处理：`multimodal_tokenizer._tokenize_one_request` 走 **`AutoProcessor` 分支**（**不要**落到 `is_mimo_audio` 的旧 `MiMoAudioProcessor` 分支——那是离散码生成路径）；audio key 为 `audio_features`/`input_features`，`feature_attention_mask` 恒 None。
+- 翻译：`to_stage_reqs("auto_regressive")` 把 `omni_inputs`（含 stage0 写入的 `multimodal_embedding`）经 `mm_inputs` 透传给核心。**无改动**。
+- config 装载：经 prework 问题3 的模型无关契约——AR stage 用顶层 config、embed stage 读 `config.vision_config`/`config.audio_config`（不再 `.thinker_config`）。
+
+---
+
+## 4. 三模态具体路径
+
+### 4.1 Image
+- 预处理 Qwen2.5-VL 风格（`Qwen2VLImageProcessor`，patch16、merge_size 2、min/max_pixels 8192/8388608）→ `pixel_values` + `image_grid_thw`。
+- `self.visual`（新建 `mimo_v2_5/vision_mimovl.py`）：相对 Qwen2.5-VL ViT 的差异 = **行/列 1-D 窗口注意力**（按 `vit_window_attn_types` 逐 block 选 full/行/列）、`fullatt_block_indexes=[0,9,18,27]`、window RoPE、**attention sink**（`use_sink`）；head_dim 40、out_hidden 4096（自带 merger）。
+- scatter 到 `image_token_id`；位置用 1-D（processor 按 grid 展开）。
+
+### 4.2 Video
+- 复用同一 MiMoVL ViT，输入 `pixel_values_videos` + `video_grid_thw`（`temporal_patch_size=2`、`video_tokens_per_second=2`、`fps=1.0`、`max_frames=3600`）。scatter 到 `video_token_id`；位置 1-D（`use_video_timestamps=true`，按时间戳展开）。
+- 视频内**交错音轨**（`encode_video_audio`，`video_audio_interleave_length=0.0` 已配置）→ 第一轮**只支持静音/忽略音轨的 basic 视频**；交错音轨与"独立 audio + 带音轨视频同请求"延后（上游对后者本身 NotImplemented）。
+
+### 4.3 Audio（展开）
+**端到端（全在 stage0 内，详见 §1.4）**：mel → 冻结 RVQ `MiMoAudioTokenizer.encode` → 离散码 `[20, T']` → 20 通道 `speech_embeddings`（vocab 1280）→ 6 层 full-attn `input_local_transformer`（dim 1024/heads 16/head_dim 64）→ `projection`(2 层) → `[N,4096]` → scatter 到 `audio_token_id`。
+
+**尽量复用现有 jax `mimo_audio` 组件**（`multimodal/models/mimo_audio/*`）：
+
+| V2.5 omni audio 组件 | 复用来源 | 动作 |
+|---|---|---|
+| RVQ tokenizer（mel→codes，**冻结**） | `mimo_audio_tokenizer.py:AudioEncoder`(`:580-721`) + RVQ(`:106-167`) 的 **encode 半部** | 复用 encode、保留 RVQ；**不**用 decoder/vocoder；权重自 `audio_tokenizer/` 子目录加载 |
+| per-channel `speech_embeddings`（**20 通道**，vocab 1280） | `mimo_audio_backbone.py` 的 speech_embeddings（V1 为 8，**需扩到 20**） | 复用结构，通道/词表按 V2.5 改 |
+| `input_local_transformer`（6 层 full-attn，dim 1024、head_dim 64） | backbone 的 patch_encoder（bidirectional input_local） | 复用结构，去掉 group downcast / patch_decoder |
+| `projection`(2 层) → 4096 | 新增 | 新增 |
+
+- **mel 前端**：复用 `MiMoAudioProcessor`（`multimodal_tokenizer.py:140-250`），已确认与官方 torchaudio 管线逐参数等价，**无需改**（建议加注释 `fmax=12000==torchaudio f_max=None` + 数值回归测试锁定）。
+- **接口**：`audio_encoder(mels: list)` → `[N,4096]`，**不**需 `feature_attention_mask`/audio grid；长度由 tokenizer 内部按 `audio_segment_size=6000` 分段。
+- **权重映射**：复用 `mimo_audio_tokenizer_weights_mapping.py` 的 encoder/conv 部分（conv 轴 `(2,1,0)`）含 RVQ codebook；speech_embeddings/input_local 复用 backbone 映射；新增 projection 映射。
+- **与生成子系统的关系**：本方案仅使用 RVQ tokenizer 的 **encode 半部**完成理解；**不使用** `audio_backbone_scheduler` / `MiMoAudioForCausalLM` / vocoder（该路径属独立 ASR/TTS checkpoint 的生成路径）。
+
+---
+
+## 5. 新增 / 改动文件清单
+
+**新增（模型 / 配置）**
+- `multimodal/models/mimo_v2_5/embedding.py` — `MiMoV2_5Embedding`（三塔 + 按 token_id 合并 + 结构化输出）。
+- `multimodal/models/mimo_v2_5/vision_mimovl.py` — MiMoVL ViT（行/列 1-D 窗口 + sink + merger）。
+- `multimodal/models/mimo_v2_5/audio_encoder.py` — 音频理解通路（RVQ encode + speech_embeddings(20) + input_local(6) + projection(2)）。
+- `multimodal/models/mimo_v2_5/generation.py` — `MiMoV2_5Generation`（复用 mimo_v2_flash MoE + input_embedding/1-D rope hook）。
+- `multimodal/models/mimo_v2_5/*_weights_mapping.py` — ViT / audio / embed 权重映射（含 `audio_tokenizer/` 子目录加载）。
+- `multimodal/models/static_configs/mimo_v2.5_stage_config.yaml` — 2-stage 配置（embed stage `device_kind: tpu`）。
+- `MiMoV2_5Config`（顶层 + `vision_config` + `audio_config`，承接 §1 数值）。
+
+**改动（较少，多数已由 prework 完成）**
+- 注册：在 prework 的声明式注册里加 MiMo-V2.5 一条（model_path → stage yaml + 两 model_class + config 工厂 + token-ids）。
+- `multimodal_tokenizer.py`：仅当 MiMo-V2.5 的 HF processor 需 Qwen 式视频抽帧时，把其类名加入 `_is_qwen_video_processor`（否则无改动）。
+- 复用项确认：`models/mimo_v2_flash.py` 按 §1.2 逐字段对齐 V2.5 config（hybrid 模式/KV 4-8/`attention_value_scale`/`fused_qkv` FP8/sink-SWA/`partial_rotary`/1-D rope/MTP）。
+
+**明确无改动**（prework 已处理或本就支持）：入口路由 / `is_multimodal`（prework 问题1）；`EmbedModelRunner` 的 JIT/分桶/结构化输出/模型无关 config（prework 问题2/3）；`io_struct` / `convert_omni_request` / `to_stage_reqs` / 核心 `_merge_multimodal`（DP=1）。
+
+---
+
+## 6. 里程碑 / 测试 / 风险与开放问题
+
+### 6.1 里程碑（A→B→C→{E,F}→G）
+- **A. LLM backbone 对齐**：`mimo_v2_flash` 适配 V2.5 顶层 config（MoE/hybrid/KV4-8/sink-SWA/FP8/`partial_rotary`/1-D rope/MTP）。验证纯文本与 HF 数值对齐。
+- **B. 配置 + 注册**：`MiMoV2_5Config`、声明式注册条目、AR 用顶层 config / embed 读 vision_config+audio_config。验证服务能识别为多模态并加载两 stage。
+- **C. MiMoVL ViT**：`vision_mimovl.py` + 权重映射；验证单图特征 `[N,4096]` 与 HF `get_image_feature` 数值对齐 + 图文端到端（DP=1）。
+- **E. Video**：复用 ViT + `video_grid_thw` + 1-D 时间戳位置；验证 basic（静音）视频理解端到端。
+- **F. Audio**：`audio_encoder.py`（RVQ encode 冻结 + speech_embeddings(20) + input_local(6) + projection(2)）+ `audio_tokenizer/` 子目录加载 + mel parity；验证音频特征对齐 + 音频理解端到端。
+- **G. 三模态合一**：图+视频+音频混合输入，经 stage0 合并 → stage1 生成端到端。
+- 依赖：A→B→C→{E,F 可并行}→G。
+
+### 6.2 测试
+- **逐塔数值对齐**：text / MiMoVL ViT / audio（mel→codes→input_local→proj）各与 HF/sglang 参考输出对比（bf16/fp8 容差）。
+- **合并正确性**：每模态"占位符数 == 特征行数"断言；多图/多段音频各自 `pad_value`（radix cache 可区分）。
+- **mel parity**：jax `MiMoAudioProcessor` vs torchaudio 参考（容差 ~1e-4）。
+- **端到端 golden**：图文 / 视频 / 音频理解各一组，纳入 `test/srt`。
+
+### 6.3 风险
+- **音频架构需特别注意**：为"冻结 RVQ encode → 离散码 → 小型 transformer"，而非连续 encoder；复用现有 mimo_audio 组件时须将 `speech_embeddings` 由 8 通道**扩至 20**、`input_local` head_dim 取 64、projection 取 2 层。
+- **MiMoVL 窗口注意力**为 JAX 无先例的行/列 1-D 窗口 + sink，需新写并做数值对齐。
+- **形状分桶覆盖度**（prework 问题2）：桶集需覆盖真实图/音长度分布，否则补零浪费或编译变体过多。
+- **backbone 字段易错项**：KV heads GA=4/SWA=8（model card 标注相反）、视觉 head_dim 40（model card 记为 64）——以 config 为准。
+
+### 6.4 开放问题（须以真实 checkpoint 复核）
+- `audio_tokenizer/` 子目录的 RVQ **内部** config（`num_quantizers`（应=20）、`encoder_layers`/heads/`d_model`、`hybrid_attention`/`swa_per_block`、`codebook_size`）受 gating，未直读。
+- MoE `ep_size` 最终取值（须整除 256 且整除设备总数 `data×tensor`）。
+- MiMo-V2.5 的 HF processor 是否需 Qwen 式视频抽帧（决定 `_is_qwen_video_processor` 是否加条目）。
+
+### 6.5 限制 / 后续任务项（超出本轮范围）
+- **DP > 1**：现每 stage 自建网格 `data` 轴恒 1，与核心 `dp_size` 冲突；要开 DP>1 须做 prework 末尾所述的"网格 `data` 轴取 `dp_size` + 启动断言"最小修复。本轮 **DP=1**。
+- **batch > 1**：stage0/stage1 `max_batch_size=1`，编码逐请求、无跨请求批；要提吞吐需引入真正的批处理契约。本轮 **batch=1**。
+- 音频/语音**生成**（ASR/TTS 独立 checkpoint 的 RVQ 生成路径、vocoder）：不在 omni 理解范围，另行立项。
+
+---
+
+### 附录
+- 本文自洽、以源码 + MiMo-V2.5 真实 config 为准，不援引其它设计文档编号；前置依赖见同目录 prework 文档。
+- 结构数值取自真实 `config.json`（ModelScope 镜像）+ sglang 上游；`audio_tokenizer/` 内部细节仍 gated（§6.4）。
+- `文件:行号` 为审读时所见，实施前请复核。


### PR DESCRIPTION
## 概述
为接入 MiMo-V2.5（`XiaomiMiMo/MiMo-V2.5`，omni 理解：text/image/video/audio）补充两份设计文档。以源码为准（base：`fix/dp-multimodal-input-embedding`），结构数值取自 MiMo-V2.5 真实 `config.json`（ModelScope 镜像）+ sglang 上游。仅文档，无代码改动。

## 文档
**`docs/design/mimo_v25_step1_prework.md`** —— 三项前置改造
- 问题 1：入口路由归一 + `is_multimodal` 由 `model_type` 推导。
- 问题 2：编码 stage 启用 JIT + 形状分桶 + 结构化输出 + 部署至 TPU（热路径性能最高优先项）。
- 问题 3：编码 stage 收敛为模型无关薄契约（config 提取 / 输入 spec / 输出字段 / 注册维度），解决非 Qwen omni 模型装载失败。
- 限制/后续：DP>1、batch>1；末附复盘备查（pad_value 仅作 radix key、VL 缺数量校验等 6 条易误判/潜在缺陷）。

**`docs/design/mimo_v25_step2_model_integration.md`** —— MiMo-V2.5 模型级接入方案
- HF 架构梳理（MoE backbone / MiMoVL ViT / 冻结 RVQ 音频理解通路 / token 与 1-D RoPE / 权重前缀路由）。
- 2-stage `embedding → auto_regressive` 总览、接线详解、三模态具体路径（audio 展开）、新增/改动文件清单、里程碑·测试·风险与开放问题。

## 范围
- 本轮 DP=1、batch=1；DP>1 / batch>1 / 音频生成为后续独立任务。
- 关键事实已按真实 config 核定：音频 `audio_channels=20`（非 V1 的 8）、1-D RoPE（非 mrope）、无 deepstack、无 `thinker_config`；合并按 token_id（pad_value 仅 radix key）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)