### PR TITLE
bench(kernels): add grouped topk training wrapper profile

### DIFF
--- a/benchmark/kernels/grouped_topk/profile_compare_training.py
+++ b/benchmark/kernels/grouped_topk/profile_compare_training.py
@@ -1,0 +1,373 @@
+"""Profile grouped_topk v1 against the training-safe ids+gather wrapper.
+
+This benchmark writes one JSON line per (T, variant). Timings are extracted from JAX profiler
+trace events, not host wall time, when running on TPU. CPU/interpret smoke tests may opt into host
+fallback because CPU traces do not always carry device-duration events.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import os
+import pathlib
+import statistics
+import time
+from collections.abc import Iterable
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+
+from sgl_jax.srt.kernels.grouped_topk.grouped_topk import grouped_topk_pallas
+from sgl_jax.srt.kernels.grouped_topk.topk_v1_training import (
+    grouped_topk_pallas_training,
+)
+
+SCOPE_V1_FUSED = "bench_grouped_topk_v1_fused"
+SCOPE_V1_TRAINING_GATHER = "bench_grouped_topk_v1_training_gather"
+
+
+def _parse_csv_ints(value: str) -> list[int]:
+    return [int(part.strip()) for part in value.split(",") if part.strip()]
+
+
+def _logits(tokens: int, experts: int, seed: int) -> jax.Array:
+    key = jax.random.PRNGKey(seed)
+    return jax.nn.sigmoid(jax.random.normal(key, (tokens, experts), dtype=jnp.float32))
+
+
+def _latest_trace_events(trace_root: pathlib.Path) -> list[dict[str, Any]]:
+    profile_root = trace_root / "plugins" / "profile"
+    if not profile_root.exists():
+        return []
+
+    profile_dirs = [path for path in profile_root.iterdir() if path.is_dir()]
+    if not profile_dirs:
+        return []
+    latest = max(profile_dirs, key=os.path.getmtime)
+
+    events: list[dict[str, Any]] = []
+    for trace_file in sorted(latest.glob("*.trace.json.gz")):
+        with gzip.open(trace_file, "rb") as f:
+            trace = json.load(f)
+        shard_events = trace.get("traceEvents", [])
+        if isinstance(shard_events, list):
+            events.extend(shard_events)
+    return events
+
+
+def _metadata_maps(
+    events: Iterable[dict[str, Any]],
+) -> tuple[dict[int, str], dict[tuple[int, int], str]]:
+    process_names: dict[int, str] = {}
+    thread_names: dict[tuple[int, int], str] = {}
+    for event in events:
+        if event.get("ph") != "M":
+            continue
+        args = event.get("args", {})
+        name = event.get("name")
+        if name == "process_name" and isinstance(event.get("pid"), int):
+            process_names[event["pid"]] = args.get("name", "")
+        elif (
+            name == "thread_name"
+            and isinstance(event.get("pid"), int)
+            and isinstance(event.get("tid"), int)
+        ):
+            thread_names[(event["pid"], event["tid"])] = args.get("name", "")
+    return process_names, thread_names
+
+
+def _duration_ms(event: dict[str, Any]) -> float | None:
+    args = event.get("args", {})
+    if args.get("device_duration_ps"):
+        return float(args["device_duration_ps"]) / 1e9
+    if "dur" in event:
+        return float(event["dur"]) / 1e3
+    return None
+
+
+def _xla_module_durations_ms(events: list[dict[str, Any]]) -> list[float]:
+    process_names, thread_names = _metadata_maps(events)
+    durations = []
+    for event in events:
+        if event.get("ph") != "X":
+            continue
+        pid = event.get("pid")
+        tid = event.get("tid")
+        if process_names.get(pid) != "/device:TPU:0":
+            continue
+        if thread_names.get((pid, tid)) != "XLA Modules":
+            continue
+        duration = _duration_ms(event)
+        if duration is not None:
+            durations.append(duration)
+    return durations
+
+
+def _scope_durations_ms(events: list[dict[str, Any]], scope: str) -> list[float]:
+    durations = []
+    for event in events:
+        args = event.get("args", {})
+        searchable = " ".join(
+            str(value)
+            for value in (
+                event.get("name", ""),
+                args.get("tf_op", ""),
+                args.get("hlo_op", ""),
+                args.get("long_name", ""),
+            )
+        )
+        if scope not in searchable:
+            continue
+        duration = _duration_ms(event)
+        if duration is not None:
+            durations.append(duration)
+    return durations
+
+
+def _host_profile_ms(run_fn, scope: str, iters: int) -> list[float]:
+    samples = []
+    for i in range(iters):
+        start = time.perf_counter()
+        with jax.profiler.StepTraceAnnotation(scope, step_num=i), jax.named_scope(scope):
+            jax.block_until_ready(run_fn())
+        samples.append((time.perf_counter() - start) * 1e3)
+    return samples
+
+
+def _trace_profile_ms(
+    run_fn,
+    *,
+    scope: str,
+    trace_root: pathlib.Path,
+    warmup: int,
+    iters: int,
+    allow_host_fallback: bool,
+) -> tuple[list[float], str, pathlib.Path]:
+    for _ in range(warmup):
+        jax.block_until_ready(run_fn())
+
+    run_trace_root = trace_root / f"{scope}_{os.getpid()}_{int(time.time() * 1000)}"
+    run_trace_root.mkdir(parents=True, exist_ok=True)
+    with jax.profiler.trace(str(run_trace_root)):
+        for i in range(iters):
+            with jax.profiler.StepTraceAnnotation(scope, step_num=i), jax.named_scope(scope):
+                jax.block_until_ready(run_fn())
+
+    events = _latest_trace_events(run_trace_root)
+    samples = _xla_module_durations_ms(events) or _scope_durations_ms(events, scope)
+    if samples:
+        return samples, "trace", run_trace_root
+    if allow_host_fallback:
+        return _host_profile_ms(run_fn, scope, iters), "host_fallback", run_trace_root
+    raise RuntimeError(f"No trace durations found for scope={scope} under {run_trace_root}")
+
+
+def _summary_row(
+    *,
+    tokens: int,
+    experts: int,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    variant: str,
+    scope: str,
+    samples_ms: list[float],
+    timing_source: str,
+    trace_path: pathlib.Path,
+) -> dict[str, Any]:
+    sorted_samples = sorted(samples_ms)
+    p90_idx = min(len(sorted_samples) - 1, int(0.9 * (len(sorted_samples) - 1)))
+    return {
+        "T": tokens,
+        "E": experts,
+        "G": n_group,
+        "Gtop": topk_group,
+        "topk": topk,
+        "variant": variant,
+        "scope": scope,
+        "median_ms": statistics.median(samples_ms),
+        "mean_ms": statistics.fmean(samples_ms),
+        "p90_ms": sorted_samples[p90_idx],
+        "num_samples": len(samples_ms),
+        "samples_ms": samples_ms,
+        "timing_source": timing_source,
+        "trace_path": str(trace_path),
+    }
+
+
+def _make_jitted_variants(
+    *,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    block_tokens: int | str,
+    interpret: bool,
+):
+    def v1_fused(logits, bias):
+        with jax.named_scope(SCOPE_V1_FUSED):
+            return grouped_topk_pallas(
+                logits,
+                bias,
+                num_expert_group=n_group,
+                topk_group=topk_group,
+                topk=topk,
+                block_tokens=block_tokens,
+                interpret=interpret,
+            )
+
+    def v1_training_gather(logits, bias):
+        with jax.named_scope(SCOPE_V1_TRAINING_GATHER):
+            return grouped_topk_pallas_training(
+                logits,
+                bias,
+                num_expert_group=n_group,
+                topk_group=topk_group,
+                topk=topk,
+                block_tokens=block_tokens,
+                interpret=interpret,
+            )
+
+    return {
+        "v1_fused": (SCOPE_V1_FUSED, jax.jit(v1_fused)),
+        "v1_training_gather": (SCOPE_V1_TRAINING_GATHER, jax.jit(v1_training_gather)),
+    }
+
+
+def run_comparison(
+    *,
+    token_sizes: list[int],
+    e: int,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    output_path: str | os.PathLike,
+    trace_root: str | os.PathLike,
+    warmup: int,
+    iters: int,
+    block_tokens: int | str = "auto",
+    interpret: bool = False,
+    allow_host_fallback: bool = True,
+) -> list[dict[str, Any]]:
+    output_path = pathlib.Path(output_path)
+    trace_root = pathlib.Path(trace_root)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    trace_root.mkdir(parents=True, exist_ok=True)
+
+    rows: list[dict[str, Any]] = []
+    with output_path.open("w") as out:
+        for tokens in token_sizes:
+            logits = jax.device_put(_logits(tokens, e, seed=tokens + e + topk))
+            bias = jax.device_put(
+                jax.random.normal(jax.random.PRNGKey(e), (e,), dtype=jnp.float32) * 0.1
+            )
+            variants = _make_jitted_variants(
+                n_group=n_group,
+                topk_group=topk_group,
+                topk=topk,
+                block_tokens=block_tokens,
+                interpret=interpret,
+            )
+
+            fused_weights, fused_ids = variants["v1_fused"][1](logits, bias)
+            training_weights, training_ids = variants["v1_training_gather"][1](logits, bias)
+            jax.block_until_ready((fused_weights, fused_ids, training_weights, training_ids))
+            if not bool(jnp.array_equal(fused_ids, training_ids)):
+                raise AssertionError(f"top-k ids differ for T={tokens}")
+            if not bool(jnp.allclose(fused_weights, training_weights, rtol=0, atol=1e-6)):
+                raise AssertionError(f"top-k weights differ for T={tokens}")
+
+            for variant, (scope, fn) in variants.items():
+                samples_ms, timing_source, variant_trace = _trace_profile_ms(
+                    lambda fn=fn: fn(logits, bias),
+                    scope=scope,
+                    trace_root=trace_root,
+                    warmup=warmup,
+                    iters=iters,
+                    allow_host_fallback=allow_host_fallback,
+                )
+                row = _summary_row(
+                    tokens=tokens,
+                    experts=e,
+                    n_group=n_group,
+                    topk_group=topk_group,
+                    topk=topk,
+                    variant=variant,
+                    scope=scope,
+                    samples_ms=samples_ms,
+                    timing_source=timing_source,
+                    trace_path=variant_trace,
+                )
+                rows.append(row)
+                out.write(json.dumps(row, sort_keys=True) + "\n")
+                out.flush()
+                print(
+                    f"T={tokens:>5} variant={variant:<18} "
+                    f"median={row['median_ms'] * 1e3:>9.2f}us "
+                    f"mean={row['mean_ms'] * 1e3:>9.2f}us "
+                    f"samples={row['num_samples']:>2} source={timing_source}"
+                )
+
+    return rows
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--T", default="256,512,1024,2048,4096,8192,16384")
+    parser.add_argument("--E", type=int, default=256)
+    parser.add_argument("--G", type=int, default=8)
+    parser.add_argument("--Gtop", type=int, default=4)
+    parser.add_argument("--topk", type=int, default=8)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--iters", type=int, default=30)
+    parser.add_argument("--block-tokens", default="auto")
+    parser.add_argument("--interpret", action="store_true")
+    parser.add_argument("--allow-host-fallback", action="store_true")
+    parser.add_argument(
+        "--output",
+        default=os.path.join(
+            os.environ.get("OUT", "/tmp/grouped_topk_profile"), "benchmark", "metrics.jsonl"
+        ),
+    )
+    parser.add_argument(
+        "--trace-root",
+        default=os.path.join(
+            os.environ.get("OUT", "/tmp/grouped_topk_profile"), "profiling", "xprof"
+        ),
+    )
+    args = parser.parse_args()
+
+    block_tokens: int | str
+    if args.block_tokens == "auto":
+        block_tokens = "auto"
+    else:
+        block_tokens = int(args.block_tokens)
+
+    print(f"JAX {jax.__version__} | device={jax.devices()[0]} | n_dev={len(jax.devices())}")
+    try:
+        import libtpu
+
+        print(f"libtpu {libtpu.__version__}")
+    except Exception:
+        pass
+
+    run_comparison(
+        token_sizes=_parse_csv_ints(args.T),
+        e=args.E,
+        n_group=args.G,
+        topk_group=args.Gtop,
+        topk=args.topk,
+        output_path=args.output,
+        trace_root=args.trace_root,
+        warmup=args.warmup,
+        iters=args.iters,
+        block_tokens=block_tokens,
+        interpret=args.interpret,
+        allow_host_fallback=args.allow_host_fallback,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sgl_jax/srt/kernels/grouped_topk/topk_v1_training/__init__.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/topk_v1_training/__init__.py
@@ -1,0 +1,8 @@
+"""Training-safe grouped-topk Pallas wrappers."""
+
+from sgl_jax.srt.kernels.grouped_topk.topk_v1_training.kernel import (
+    grouped_topk_ids_pallas,
+    grouped_topk_pallas_training,
+)
+
+__all__ = ["grouped_topk_ids_pallas", "grouped_topk_pallas_training"]

--- a/python/sgl_jax/srt/kernels/grouped_topk/topk_v1_training/kernel.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/topk_v1_training/kernel.py
@@ -1,0 +1,220 @@
+"""Training-safe ids-only Pallas kernel for biased grouped top-k routing.
+
+The Pallas kernel returns only discrete top-k expert ids. The differentiable top-k weights are
+gathered outside the kernel by ``grouped_topk_pallas_training`` so training can use JAX's normal
+``take_along_axis`` VJP instead of requiring a custom transpose for the Pallas call.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+
+import jax
+import jax.experimental.pallas as pl
+import jax.numpy as jnp
+
+try:
+    from sgl_jax.srt.kernels.grouped_topk.tuned_block_sizes import get_tuned_bt
+except Exception:  # noqa: BLE001  (e.g. standalone embedded copies without the package)
+
+    def get_tuned_bt(*_a, **_k):  # noqa: ANN002, ANN003
+        return None
+
+
+logger = logging.getLogger(__name__)
+
+NEG_INF = -jnp.inf
+SAFE_AUTO_BT = 2048
+
+
+def _align_to(x: int, a: int) -> int:
+    return ((x + a - 1) // a) * a
+
+
+def _largest_safe_divisor(bs: int, cap: int = SAFE_AUTO_BT, align: int = 8) -> int | None:
+    hi = (min(cap, bs) // align) * align
+    for d in range(hi, 0, -align):
+        if bs % d == 0:
+            return d
+    return None
+
+
+def get_interpret() -> bool:
+    return os.environ.get("PALLAS_INTERPRET", "").strip().lower() in ("1", "true")
+
+
+def _grouped_topk_ids_kernel(
+    logits_ref,  # [BT, E] f32  (router_logits, post-score-func, PRE-bias)
+    bias_ref,  # [E]     f32  (correction_bias)
+    ids_ref,  # [BT, padded_topk] i32  out: expert ids
+    *,
+    n_group: int,
+    topk_group: int,
+    topk: int,
+    num_experts: int,
+    padded_topk: int,
+):
+    experts_per_group = num_experts // n_group
+    logits = logits_ref[...].astype(jnp.float32)
+    scores = logits + bias_ref[...][None, :]
+    bt = scores.shape[0]
+
+    with jax.named_scope("group_top2"):
+        group_score_cols = []
+        for g in range(n_group):
+            group_scores = scores[:, g * experts_per_group : (g + 1) * experts_per_group]
+            v1 = jnp.max(group_scores, axis=1, keepdims=True)
+            i1 = jnp.argmax(group_scores, axis=1, keepdims=True)
+            group_iota = jax.lax.broadcasted_iota(jnp.int32, group_scores.shape, 1)
+            group_scores_without_top1 = jnp.where(group_iota == i1, NEG_INF, group_scores)
+            v2 = jnp.max(group_scores_without_top1, axis=1, keepdims=True)
+            group_score_cols.append(v1 + v2)
+        group_scores = jnp.concatenate(group_score_cols, axis=1)
+
+    with jax.named_scope("group_select"):
+        group_mask = jnp.zeros((bt, n_group), dtype=jnp.bool_)
+        group_iota = jax.lax.broadcasted_iota(jnp.int32, (bt, n_group), 1)
+        tmp_group_scores = group_scores
+        for _ in range(topk_group):
+            group_idx = jnp.argmax(tmp_group_scores, axis=1, keepdims=True)
+            selected_group = group_iota == group_idx
+            group_mask = jnp.logical_or(group_mask, selected_group)
+            tmp_group_scores = jnp.where(selected_group, NEG_INF, tmp_group_scores)
+
+    with jax.named_scope("expert_mask"):
+        masked_slices = []
+        for g in range(n_group):
+            group_selected = group_mask[:, g : g + 1]
+            masked_slices.append(
+                jnp.where(
+                    group_selected,
+                    scores[:, g * experts_per_group : (g + 1) * experts_per_group],
+                    NEG_INF,
+                )
+            )
+        masked_scores = jnp.concatenate(masked_slices, axis=1)
+
+    with jax.named_scope("final_select_ids"):
+        expert_iota = jax.lax.broadcasted_iota(jnp.int32, (bt, num_experts), 1)
+        cur = masked_scores
+        id_cols = []
+        for k_idx in range(topk):
+            expert_idx = jnp.argmax(cur, axis=1, keepdims=True)
+            selected_expert = expert_iota == expert_idx
+            id_cols.append(expert_idx.astype(jnp.int32))
+            if k_idx != topk - 1:
+                cur = jnp.where(selected_expert, NEG_INF, cur)
+
+    n_pad = padded_topk - topk
+    if n_pad > 0:
+        id_cols.append(jnp.full((bt, n_pad), -1, dtype=jnp.int32))
+
+    ids_ref[...] = jnp.concatenate(id_cols, axis=1)
+
+
+def _resolve_block_tokens(
+    bs: int,
+    e: int,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    block_tokens: int | str,
+) -> int:
+    if block_tokens == "auto":
+        tuned = get_tuned_bt(bs, e, num_expert_group, topk_group, topk)
+        if tuned is not None and bs % tuned == 0:
+            bt = tuned
+        elif bs % 512 == 0:
+            bt = min(512, bs)
+        else:
+            bt = _largest_safe_divisor(bs) or bs
+        if bt > SAFE_AUTO_BT:
+            logger.warning(
+                "grouped_topk_ids: auto block_tokens fell back to whole-batch BT=%d "
+                "(BS=%d has no VMEM-safe divisor); a single [%d,%d] tile may exceed VMEM.",
+                bt,
+                bs,
+                bs,
+                e,
+            )
+        return bt
+
+    bt = min(block_tokens, bs)
+    if bs % bt != 0:
+        raise ValueError(f"BS={bs} must be divisible by block_tokens={bt}")
+    return bt
+
+
+def grouped_topk_ids_pallas(
+    router_logits: jax.Array,
+    correction_bias: jax.Array,
+    *,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    block_tokens: int | str = "auto",
+    interpret: bool | None = None,
+):
+    """Return biased grouped top-k expert ids only."""
+    bs, e = router_logits.shape
+    if e % num_expert_group != 0:
+        raise ValueError(f"E={e} must be divisible by num_expert_group={num_expert_group}")
+    if not (1 <= topk_group <= num_expert_group):
+        raise ValueError(
+            f"topk_group={topk_group} must be in [1, num_expert_group={num_expert_group}]"
+        )
+
+    router_logits = router_logits.astype(jnp.float32)
+    bias = correction_bias.astype(jnp.float32)
+    bt = _resolve_block_tokens(bs, e, num_expert_group, topk_group, topk, block_tokens)
+    if interpret is None:
+        interpret = get_interpret()
+
+    padded_topk = _align_to(topk, 128)
+    kernel = functools.partial(
+        _grouped_topk_ids_kernel,
+        n_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        num_experts=e,
+        padded_topk=padded_topk,
+    )
+    ids = pl.pallas_call(
+        kernel,
+        grid=(bs // bt,),
+        in_specs=[
+            pl.BlockSpec((bt, e), lambda i: (i, 0)),
+            pl.BlockSpec((e,), lambda i: (0,)),
+        ],
+        out_specs=pl.BlockSpec((bt, padded_topk), lambda i: (i, 0)),
+        out_shape=jax.ShapeDtypeStruct((bs, padded_topk), jnp.int32),
+        interpret=interpret,
+        name="grouped-topk-ids",
+    )(router_logits, bias)
+    return ids[:, :topk]
+
+
+def grouped_topk_pallas_training(
+    router_logits: jax.Array,
+    correction_bias: jax.Array,
+    *,
+    num_expert_group: int,
+    topk_group: int,
+    topk: int,
+    block_tokens: int | str = "auto",
+    interpret: bool | None = None,
+):
+    """Training-friendly grouped top-k: ids from Pallas, weights from JAX gather."""
+    topk_ids = grouped_topk_ids_pallas(
+        jax.lax.stop_gradient(router_logits),
+        jax.lax.stop_gradient(correction_bias),
+        num_expert_group=num_expert_group,
+        topk_group=topk_group,
+        topk=topk,
+        block_tokens=block_tokens,
+        interpret=interpret,
+    )
+    topk_weights = jnp.take_along_axis(router_logits.astype(jnp.float32), topk_ids, axis=1)
+    return topk_weights, topk_ids

--- a/python/sgl_jax/srt/kernels/grouped_topk/tuned_block_sizes.py
+++ b/python/sgl_jax/srt/kernels/grouped_topk/tuned_block_sizes.py
@@ -47,7 +47,7 @@ TUNED_BT: dict[str, dict[tuple, int]] = {
         (512, 256, 8, 4, 8): 512,
         (1024, 256, 8, 4, 8): 1024,
         (2048, 256, 8, 4, 8): 2048,
-        (4096, 256, 8, 4, 8): 4096,  # fits as a single block (grid=1, no double-buffer)
+        (4096, 256, 8, 4, 8): 2048,  # BT=4096 exceeds v7x scoped VMEM with padded outputs
         (8192, 256, 8, 4, 8): 2048,  # multi-block double-buffer caps BT at 2048
         (16384, 256, 8, 4, 8): 2048,
         (32768, 256, 8, 4, 8): 2048,

--- a/python/sgl_jax/test/kernels/grouped_topk_profile_compare_test.py
+++ b/python/sgl_jax/test/kernels/grouped_topk_profile_compare_test.py
@@ -1,0 +1,33 @@
+"""Smoke tests for the grouped-topk profile comparison benchmark."""
+
+import json
+
+from benchmark.kernels.grouped_topk.profile_compare_training import run_comparison
+
+
+def test_profile_compare_training_writes_metrics(tmp_path):
+    output_path = tmp_path / "metrics.jsonl"
+
+    rows = run_comparison(
+        token_sizes=[16],
+        e=32,
+        n_group=8,
+        topk_group=4,
+        topk=4,
+        output_path=output_path,
+        trace_root=tmp_path / "traces",
+        warmup=1,
+        iters=1,
+        block_tokens=16,
+        interpret=True,
+    )
+
+    assert {row["variant"] for row in rows} == {
+        "v1_fused",
+        "v1_training_gather",
+    }
+    assert all(row["T"] == 16 and row["num_samples"] >= 1 for row in rows)
+    assert all(row["scope"] for row in rows)
+
+    written = [json.loads(line) for line in output_path.read_text().splitlines()]
+    assert written == rows

--- a/python/sgl_jax/test/kernels/grouped_topk_training_test.py
+++ b/python/sgl_jax/test/kernels/grouped_topk_training_test.py
@@ -1,0 +1,89 @@
+"""Training-safe grouped-topk Pallas kernel tests.
+
+The Pallas kernel in this variant returns only top-k ids. The differentiable weights are gathered
+outside the kernel so reverse-mode autodiff follows JAX's gather rule instead of transposing Pallas.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from sgl_jax.srt.kernels.grouped_topk.topk_v1_training import (
+    grouped_topk_ids_pallas,
+    grouped_topk_pallas_training,
+)
+from sgl_jax.test.kernels.grouped_topk_test import ref_biased_grouped_topk
+
+
+def _logits(bs, e, seed):
+    return jax.nn.sigmoid(jax.random.normal(jax.random.PRNGKey(seed), (bs, e), dtype=jnp.float32))
+
+
+def test_grouped_topk_training_eq_ref():
+    bs, e, n_group, topk_group, topk = 256, 256, 8, 4, 8
+    logits = _logits(bs, e, seed=17)
+    bias = jax.random.normal(jax.random.PRNGKey(19), (e,), dtype=jnp.float32) * 0.1
+
+    w_ref, ids_ref = ref_biased_grouped_topk(
+        logits, bias, num_expert_group=n_group, topk_group=topk_group, topk=topk
+    )
+    w_pal, ids_pal = grouped_topk_pallas_training(
+        logits,
+        bias,
+        num_expert_group=n_group,
+        topk_group=topk_group,
+        topk=topk,
+        block_tokens=256,
+        interpret=True,
+    )
+
+    np.testing.assert_array_equal(np.array(ids_pal), np.array(ids_ref))
+    np.testing.assert_allclose(np.array(w_pal), np.array(w_ref), rtol=0, atol=1e-6)
+
+
+def test_grouped_topk_ids_kernel_returns_ids_only():
+    logits = _logits(32, 64, seed=23)
+    bias = jnp.zeros((64,), dtype=jnp.float32)
+
+    ids = grouped_topk_ids_pallas(
+        logits,
+        bias,
+        num_expert_group=8,
+        topk_group=4,
+        topk=8,
+        block_tokens=32,
+        interpret=True,
+    )
+
+    assert ids.shape == (32, 8)
+    assert ids.dtype == jnp.int32
+
+
+def test_grouped_topk_training_weights_are_differentiable():
+    bs, e, n_group, topk_group, topk = 32, 64, 8, 4, 8
+    logits = _logits(bs, e, seed=29)
+    bias = jax.random.normal(jax.random.PRNGKey(31), (e,), dtype=jnp.float32) * 0.1
+
+    _, ids_ref = ref_biased_grouped_topk(
+        logits, bias, num_expert_group=n_group, topk_group=topk_group, topk=topk
+    )
+    expected_grad = (
+        jnp.zeros_like(logits)
+        .at[jnp.arange(bs)[:, None], ids_ref]
+        .add(jnp.ones((bs, topk), dtype=jnp.float32))
+    )
+
+    def loss_fn(x):
+        weights, _ = grouped_topk_pallas_training(
+            x,
+            bias,
+            num_expert_group=n_group,
+            topk_group=topk_group,
+            topk=topk,
+            block_tokens=32,
+            interpret=True,
+        )
+        return jnp.sum(weights)
+
+    grad = jax.grad(loss_fn)(logits)
+    np.testing.assert_allclose(np.array(grad), np.array(expected_grad), rtol=0, atol=1e-6)


### PR DESCRIPTION
## Summary

Stacked on PR #319 (`feat/fused-group-topk`).

- add a training-safe grouped top-k wrapper where the Pallas kernel returns only top-k ids and weights are gathered outside the kernel with JAX
- add a profile benchmark comparing current v1 fused `(weights, ids)` against ids-only training + gather
- add equivalence, gradient, and benchmark smoke tests
- cap the v7x tuned `T=4096,E=256,G=8,Gtop=4,topk=8` auto block size at 2048 after Falcon profiling showed `BT=4096` exceeds scoped VMEM

## Validation

- `python -m pytest python/sgl_jax/test/kernels/grouped_topk_test.py python/sgl_jax/test/kernels/grouped_topk_training_test.py python/sgl_jax/test/kernels/grouped_topk_profile_compare_test.py -q`
- `black --check --config python/pyproject.toml ...`
- `python -m ruff check ...`
- CPU interpret smoke for `benchmark.kernels.grouped_topk.profile_compare_training`
- Falcon v7x profile: `exp-abvux77yi9`
