### PR TITLE
fix(disagg): 支持 SWAKVPool 的 JaxTransfer KV 迁移路径

### DIFF
--- a/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
+++ b/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
@@ -22,12 +22,16 @@ def synced_terminal_rooms(
     entries: Iterable,
     poll_fn: Callable[[object], KVPoll],
     room_fn: Callable[[object], int | None],
+    dp_size: int = 1,
 ) -> tuple[set[int], set[int]]:
     """Return ``(success_rooms, failed_rooms)`` agreed across all processes.
 
     ``poll_fn`` is wrapped in a try/except so a per-NP receiver exception
     becomes FAILED instead of skipping the allgather (which would desync
     the SPMD program counter).
+
+    With ``dp_size > 1`` each request is handled by only ``nproc // dp_size``
+    processes (one DP rank).  The success threshold is lowered accordingly.
     """
 
     from jax.experimental import multihost_utils
@@ -47,6 +51,7 @@ def synced_terminal_rooms(
         local[i, 1] = 1 if st == KVPoll.SUCCESS else (-2 if st == KVPoll.FAILED else 0)
     gathered = multihost_utils.process_allgather(local)
     nproc = int(gathered.shape[0])
+    nproc_per_dp = nproc // max(dp_size, 1)
     per_room: dict[int, list[int]] = {}
     for p in range(nproc):
         for i in range(_SYNC_MAX_INFLIGHT):
@@ -59,6 +64,6 @@ def synced_terminal_rooms(
     for room, sts in per_room.items():
         if -2 in sts:
             failed.add(room)
-        elif len(sts) >= nproc and all(s == 1 for s in sts):
+        elif len(sts) >= nproc_per_dp and all(s == 1 for s in sts):
             success.add(room)
     return success, failed

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -982,7 +982,7 @@ class SchedulerDisaggregationDecodeMixin:
             from sgl_jax.srt.disaggregation.prefill import local_kv_spec_for_pool
 
             return local_kv_spec_for_pool(kv_pool, kv_pool.layer_num, padded_pages)
-        per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
+        per_layer_tail = kv_pool.get_kv_buffer(kv_pool.start_layer).shape[1:]
         shape = (padded_pages, *per_layer_tail)
         sharding = kv_pool.kv_sharding
         return [
@@ -1000,14 +1000,11 @@ class SchedulerDisaggregationDecodeMixin:
             )
 
         kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
+        per_layer_tail = kv_pool.get_kv_buffer(kv_pool.start_layer).shape[1:]
         if jax.process_count() > 1 and kv.is_fully_addressable:
-            # Pulled KV is this host's local shard on a 1-D local mesh.
-            # Assemble it into the global pool sharding (zero-copy: each NP
-            # contributes its own addressable_shards).
             pool_pspec = kv_pool.kv_sharding.spec
             stacked_spec = PartitionSpec(None, None, *pool_pspec[1:])
             gsh = NamedSharding(kv_pool.mesh, stacked_spec)
-            per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
             gshape = (kv.shape[0], kv.shape[1]) + per_layer_tail
             kv = jax.make_array_from_single_device_arrays(
                 gshape, gsh, [s.data for s in kv.addressable_shards]
@@ -1019,9 +1016,6 @@ class SchedulerDisaggregationDecodeMixin:
             np.asarray(kv_indices) if not isinstance(kv_indices, np.ndarray) else kv_indices
         )
         padded_pages = kv[0].shape[0]
-        # page_ids_padded is only consumed by the debug verifier below, which is
-        # a no-op unless SGL_JAX_PD_DEBUG_KV is set. The write itself is
-        # token-level via ``loc``, so skip this numpy work on the production path.
         from sgl_jax.srt.disaggregation.debug_utils import kv_debug_enabled
 
         if kv_debug_enabled(req.rid):
@@ -1035,32 +1029,67 @@ class SchedulerDisaggregationDecodeMixin:
         else:
             page_ids_padded = None
 
-        # Write via the in-place Pallas kernel (``update_fused_kv_cache_vectorized``
-        # with ``input_output_aliases``), so the footprint scales with the tokens
-        # written. ``loc`` is per-token absolute pool slots; -1 marks padding
-        # tokens that are skipped.
         total_tokens = padded_pages * page_size
         loc_np = np.full(total_tokens, -1, dtype=np.int32)
         loc_np[:seqlen] = kv_indices_np[:seqlen]
-        loc = jax.device_put(
-            jnp.asarray(loc_np),
-            NamedSharding(kv_pool.mesh, PartitionSpec(kv_pool.attention_data_partition_axis)),
+        loc_sharding = NamedSharding(
+            kv_pool.mesh, PartitionSpec(kv_pool.attention_data_partition_axis)
         )
+        loc = jax.device_put(jnp.asarray(loc_np), loc_sharding)
+
+        from sgl_jax.srt.mem_cache.memory_pool import SWAKVPool
+
+        is_swa_pool = isinstance(kv_pool, SWAKVPool)
+        swa_loc = None
+        if is_swa_pool:
+            mapping = kv_pool.full_to_swa_index_mapping
+            if mapping is not None:
+                swa_loc_np = np.full_like(loc_np, -1)
+                valid = loc_np >= 0
+                if isinstance(mapping, list):
+                    tokens_per_rank = len(loc_np) // kv_pool.dp_size
+                    for rank in range(kv_pool.dp_size):
+                        s = rank * tokens_per_rank
+                        e = s + tokens_per_rank
+                        rank_valid = valid[s:e]
+                        swa_loc_np[s:e][rank_valid] = np.asarray(
+                            mapping[rank]
+                        )[loc_np[s:e][rank_valid]]
+                else:
+                    swa_loc_np[valid] = np.asarray(mapping)[loc_np[valid]]
+                swa_loc = jax.device_put(jnp.asarray(swa_loc_np), loc_sharding)
 
         for i, layer_id in enumerate(
             range(kv_pool.start_layer, kv_pool.start_layer + kv_pool.layer_num)
         ):
-            layer_idx = layer_id - kv_pool.start_layer
-            kv_pool.kv_buffer[layer_idx] = write_kv_layer(
-                kv[i],
-                loc,
-                kv_pool.kv_buffer[layer_idx],
-                page_size,
-                kv_pool.kv_partition_axis,
-                kv_pool.attention_data_partition_axis,
-                kv_pool.mesh,
-            )
-        # Set prefix_indices to all-but-last so extend_input_len=1.
+            if is_swa_pool:
+                layer_id_pool, is_swa_layer = kv_pool.layers_mapping[layer_id]
+                if is_swa_layer:
+                    sub_pool = kv_pool.swa_kv_pool
+                    layer_loc = swa_loc if swa_loc is not None else loc
+                else:
+                    sub_pool = kv_pool.full_kv_pool
+                    layer_loc = loc
+                sub_pool.kv_buffer[layer_id_pool] = write_kv_layer(
+                    kv[i],
+                    layer_loc,
+                    sub_pool.kv_buffer[layer_id_pool],
+                    page_size,
+                    sub_pool.kv_partition_axis,
+                    sub_pool.attention_data_partition_axis,
+                    sub_pool.mesh,
+                )
+            else:
+                layer_idx = layer_id - kv_pool.start_layer
+                kv_pool.kv_buffer[layer_idx] = write_kv_layer(
+                    kv[i],
+                    loc,
+                    kv_pool.kv_buffer[layer_idx],
+                    page_size,
+                    kv_pool.kv_partition_axis,
+                    kv_pool.attention_data_partition_axis,
+                    kv_pool.mesh,
+                )
         valid_slots = kv_indices_np[:seqlen]
         if len(valid_slots) >= 1:
             req.prefix_indices = valid_slots[:-1]
@@ -1069,8 +1098,6 @@ class SchedulerDisaggregationDecodeMixin:
         req.last_matched_prefix_len = len(req.prefix_indices)
         req._pd_skip_prefix_match = True
         req._pd_prealloc_kv_indices = kv_indices_np
-        # Make sure fill_ids is set so the scheduler doesn't re-derive
-        # an empty prefill chunk.
         req.fill_ids = list(req.origin_input_ids) + list(req.output_ids)
         self._maybe_verify_decode_writeback_debug(req, kv_pool, page_ids_padded, kv)
 

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -1002,6 +1002,9 @@ class SchedulerDisaggregationDecodeMixin:
         kv_pool = self.token_to_kv_pool_allocator.get_kvcache()
         per_layer_tail = kv_pool.get_kv_buffer(kv_pool.start_layer).shape[1:]
         if jax.process_count() > 1 and kv.is_fully_addressable:
+            # Pulled KV is this host's local shard on a 1-D local mesh.
+            # Assemble it into the global pool sharding (zero-copy: each NP
+            # contributes its own addressable_shards).
             pool_pspec = kv_pool.kv_sharding.spec
             stacked_spec = PartitionSpec(None, None, *pool_pspec[1:])
             gsh = NamedSharding(kv_pool.mesh, stacked_spec)
@@ -1016,6 +1019,9 @@ class SchedulerDisaggregationDecodeMixin:
             np.asarray(kv_indices) if not isinstance(kv_indices, np.ndarray) else kv_indices
         )
         padded_pages = kv[0].shape[0]
+        # page_ids_padded is only consumed by the debug verifier below, which is
+        # a no-op unless SGL_JAX_PD_DEBUG_KV is set. The write itself is
+        # token-level via ``loc``, so skip this numpy work on the production path.
         from sgl_jax.srt.disaggregation.debug_utils import kv_debug_enabled
 
         if kv_debug_enabled(req.rid):
@@ -1029,6 +1035,10 @@ class SchedulerDisaggregationDecodeMixin:
         else:
             page_ids_padded = None
 
+        # Write via the in-place Pallas kernel (``update_fused_kv_cache_vectorized``
+        # with ``input_output_aliases``), so the footprint scales with the tokens
+        # written. ``loc`` is per-token absolute pool slots; -1 marks padding
+        # tokens that are skipped.
         total_tokens = padded_pages * page_size
         loc_np = np.full(total_tokens, -1, dtype=np.int32)
         loc_np[:seqlen] = kv_indices_np[:seqlen]
@@ -1090,6 +1100,7 @@ class SchedulerDisaggregationDecodeMixin:
                     kv_pool.attention_data_partition_axis,
                     kv_pool.mesh,
                 )
+        # Set prefix_indices to all-but-last so extend_input_len=1.
         valid_slots = kv_indices_np[:seqlen]
         if len(valid_slots) >= 1:
             req.prefix_indices = valid_slots[:-1]
@@ -1098,6 +1109,8 @@ class SchedulerDisaggregationDecodeMixin:
         req.last_matched_prefix_len = len(req.prefix_indices)
         req._pd_skip_prefix_match = True
         req._pd_prealloc_kv_indices = kv_indices_np
+        # Make sure fill_ids is set so the scheduler doesn't re-derive
+        # an empty prefill chunk.
         req.fill_ids = list(req.origin_input_ids) + list(req.output_ids)
         self._maybe_verify_decode_writeback_debug(req, kv_pool, page_ids_padded, kv)
 

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -1055,19 +1055,12 @@ class SchedulerDisaggregationDecodeMixin:
         if is_swa_pool:
             mapping = kv_pool.full_to_swa_index_mapping
             if mapping is not None:
+                if isinstance(mapping, list):
+                    dp_rank = int(getattr(req, "dp_rank", 0) or 0)
+                    mapping = mapping[dp_rank]
                 swa_loc_np = np.full_like(loc_np, -1)
                 valid = loc_np >= 0
-                if isinstance(mapping, list):
-                    tokens_per_rank = len(loc_np) // kv_pool.dp_size
-                    for rank in range(kv_pool.dp_size):
-                        s = rank * tokens_per_rank
-                        e = s + tokens_per_rank
-                        rank_valid = valid[s:e]
-                        swa_loc_np[s:e][rank_valid] = np.asarray(
-                            mapping[rank]
-                        )[loc_np[s:e][rank_valid]]
-                else:
-                    swa_loc_np[valid] = np.asarray(mapping)[loc_np[valid]]
+                swa_loc_np[valid] = np.asarray(mapping)[loc_np[valid]]
                 swa_loc = jax.device_put(jnp.asarray(swa_loc_np), loc_sharding)
 
         for i, layer_id in enumerate(

--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -624,6 +624,7 @@ class SchedulerDisaggregationDecodeMixin:
             entries,
             poll_fn=lambda e: e.receiver.poll(),
             room_fn=lambda e: getattr(e.req, "bootstrap_room", None),
+            dp_size=self.dp_size,
         )
         if not success and not failed:
             return []

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -97,7 +97,7 @@ def _global_to_local_shard(arr: jax.Array) -> jax.Array:
 
 def local_kv_spec_for_pool(kv_pool, layer_num: int, padded_pages: int) -> jax.ShapeDtypeStruct:
     """Build the ShapeDtypeStruct that D should pull on a multi-host process:
-    this host's 1/nproc slice of the stacked KV, on a 1-D local mesh.
+    this host's local slice of the stacked KV, on a 1-D local mesh.
     """
     import numpy as _np
     from jax.sharding import Mesh as _Mesh
@@ -113,8 +113,9 @@ def local_kv_spec_for_pool(kv_pool, layer_num: int, padded_pages: int) -> jax.Sh
         raise ValueError(f"expected one sharded dim in KV spec, got {gspec}")
     sd = sharded_dims[0]
     ldev = jax.local_devices()
-    nproc = jax.process_count()
-    lshape = tuple(gshape[i] // nproc if i == sd else gshape[i] for i in range(len(gshape)))
+    ndev_on_axis = kv_pool.mesh.devices.shape[kv_pool.mesh.axis_names.index(gspec[sd])]
+    nproc_on_axis = ndev_on_axis // len(ldev)
+    lshape = tuple(gshape[i] // nproc_on_axis if i == sd else gshape[i] for i in range(len(gshape)))
     lmesh = _Mesh(_np.asarray(ldev), ("_local",))
     lspec = _P(*("_local" if i == sd else None for i in range(len(gshape))))
     return jax.ShapeDtypeStruct(lshape, kv_pool.dtype, sharding=_NamedSharding(lmesh, lspec))

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -713,24 +713,48 @@ class SchedulerDisaggregationPrefillMixin:
         from jax.sharding import PartitionSpec as _P
 
         page_ids = _np.asarray(page_id_source) // page_size
-        if padded_pages > num_pages:
+        pad_len = padded_pages - num_pages
+        if pad_len > 0:
             page_ids = _np.concatenate(
-                [page_ids, _np.zeros(padded_pages - num_pages, dtype=page_ids.dtype)]
+                [page_ids, _np.zeros(pad_len, dtype=page_ids.dtype)]
             )
         idx_sharding = _NamedSharding(kv_pool.mesh, _P(None))
         page_indices = jax.device_put(page_ids, idx_sharding)
+
+        # For SWAKVPool, remap full-pool page IDs to SWA-pool page IDs.
+        from sgl_jax.srt.mem_cache.memory_pool import SWAKVPool
+
+        swa_page_indices = None
+        is_swa_pool = isinstance(kv_pool, SWAKVPool)
+        if is_swa_pool:
+            mapping = kv_pool.full_to_swa_index_mapping
+            if isinstance(mapping, list):
+                mapping = mapping[int(getattr(req, "dp_rank", 0) or 0)]
+            if mapping is not None:
+                full_token_ids = _np.asarray(page_id_source)
+                swa_page_ids = _np.asarray(mapping)[full_token_ids] // page_size
+                if pad_len > 0:
+                    swa_page_ids = _np.concatenate(
+                        [swa_page_ids, _np.zeros(pad_len, dtype=swa_page_ids.dtype)]
+                    )
+                swa_page_indices = jax.device_put(swa_page_ids, idx_sharding)
+
         # out_sharding describes the gather output, not the pool.
         pool_pspec = kv_pool.kv_sharding.spec
         gather_pspec = _P(None, *pool_pspec[1:])
         gather_out_sharding = _NamedSharding(kv_pool.mesh, gather_pspec)
-        layer_buffers = [
-            kv_pool.get_kv_buffer(layer_id)
-            for layer_id in range(
-                kv_pool.start_layer,
-                kv_pool.start_layer + kv_pool.layer_num,
-            )
-        ]
-        layer_kvs = _jit_gather_all_layers(layer_buffers, page_indices, gather_out_sharding)
+        layer_kvs = []
+        for layer_id in range(
+            kv_pool.start_layer,
+            kv_pool.start_layer + kv_pool.layer_num,
+        ):
+            buf = kv_pool.get_kv_buffer(layer_id)
+            if swa_page_indices is not None and kv_pool.layers_mapping[layer_id][1]:
+                idx = swa_page_indices
+            else:
+                idx = page_indices
+            layer_kvs.append(_jit_gather_one_layer(buf, idx, gather_out_sharding))
+
         if jax.process_count() > 1:
             # Multi-host: expose only this host's TP shard as a fully-addressable
             # local-mesh array; each P host registers its 1/nproc slice and the

--- a/python/sgl_jax/srt/disaggregation/prefill.py
+++ b/python/sgl_jax/srt/disaggregation/prefill.py
@@ -105,7 +105,7 @@ def local_kv_spec_for_pool(kv_pool, layer_num: int, padded_pages: int) -> jax.Sh
     from jax.sharding import PartitionSpec as _P
 
     pool_pspec = kv_pool.kv_sharding.spec
-    per_layer_tail = kv_pool.kv_buffer[0].shape[1:]
+    per_layer_tail = kv_pool.get_kv_buffer(kv_pool.start_layer).shape[1:]
     gshape = (layer_num, padded_pages) + per_layer_tail
     gspec = (None, None) + tuple(pool_pspec[1:])
     sharded_dims = [i for i, s in enumerate(gspec) if s is not None]

--- a/python/sgl_jax/srt/mem_cache/memory_pool.py
+++ b/python/sgl_jax/srt/mem_cache/memory_pool.py
@@ -816,6 +816,26 @@ class SWAKVPool(KVCache):
         self.swa_kv_pool.replace_buffer(swa_kv_buffer)
         self.full_kv_pool.replace_buffer(full_kv_buffer)
 
+    @property
+    def layer_num(self):
+        return self.swa_layer_nums + self.full_layer_nums
+
+    @property
+    def start_layer(self):
+        return min(self.layers_mapping.keys())
+
+    @property
+    def kv_sharding(self):
+        return self.full_kv_pool.kv_sharding
+
+    @property
+    def dtype(self):
+        return self.full_kv_pool.dtype
+
+    @property
+    def attention_data_partition_axis(self):
+        return self.full_kv_pool.attention_data_partition_axis
+
     def remap_cache_loc(self, loc: jax.Array, layer_id: int) -> jax.Array:
         """
         Remap cache locations from the full-attention token space to the SWA


### PR DESCRIPTION
修复 #334 

## 修复

- `memory_pool.py`：为 `SWAKVPool` 新增属性访问器（`layer_num`、`start_layer`、`kv_sharding`、`dtype`、`attention_data_partition_axis`）
- `decode.py`（`_write_kv_to_pool`）：检测 `SWAKVPool` 后按层分发写入到正确的子池（`full_kv_pool` 或 `swa_kv_pool`），并通过 `full_to_swa_index_mapping` 处理 SWA 索引重映射
- `decode.py`（`_build_kv_spec_for_req`）：`kv_pool.kv_buffer[0]` 改为 `kv_pool.get_kv_buffer(kv_pool.start_layer)`
- `prefill.py`（`local_kv_spec_for_pool`）：同上

## 改动文件

- `python/sgl_jax/srt/mem_cache/memory_pool.py`
- `python/sgl_jax/srt/disaggregation/decode.py`
- `python/sgl_jax/srt/disaggregation/prefill.py`

## 测试

已在 v6e-16 1P1D (MiMo-V2-Flash) 上端到端验证。