### PR TITLE
fix(disagg): 使用 int32 room ID 避免 process_allgather 截断

### DIFF
--- a/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
+++ b/python/sgl_jax/srt/disaggregation/common/multihost_sync.py
@@ -32,7 +32,7 @@ def synced_terminal_rooms(
 
     from jax.experimental import multihost_utils
 
-    local = np.full((_SYNC_MAX_INFLIGHT, 2), -1, dtype=np.int64)
+    local = np.full((_SYNC_MAX_INFLIGHT, 2), -1, dtype=np.int32)
     for i, e in enumerate(entries):
         if i >= _SYNC_MAX_INFLIGHT:
             break
@@ -51,7 +51,7 @@ def synced_terminal_rooms(
     for p in range(nproc):
         for i in range(_SYNC_MAX_INFLIGHT):
             room = int(gathered[p, i, 0])
-            if room < 0:
+            if room == -1:
                 continue
             per_room.setdefault(room, []).append(int(gathered[p, i, 1]))
     success: set[int] = set()

--- a/python/sgl_jax/srt/disaggregation/mini_lb_helpers.py
+++ b/python/sgl_jax/srt/disaggregation/mini_lb_helpers.py
@@ -16,7 +16,7 @@ def maybe_wrap_ipv6_address(address: str) -> str:
 
 
 def generate_bootstrap_room() -> int:
-    return random.randint(0, 2**63 - 1)
+    return random.randint(0, 2**31 - 1)
 
 
 def align_bootstrap_room_to_prefill(

--- a/python/sgl_jax/srt/managers/tokenizer_manager.py
+++ b/python/sgl_jax/srt/managers/tokenizer_manager.py
@@ -399,7 +399,7 @@ class TokenizerManager:
                     if obj.bootstrap_port is None:
                         obj.bootstrap_port = parsed.port
             if obj.bootstrap_room is None and obj.rid is not None:
-                obj.bootstrap_room = zlib.crc32(str(obj.rid).encode("utf-8"))
+                obj.bootstrap_room = zlib.crc32(str(obj.rid).encode("utf-8")) & 0x7FFFFFFF
             missing = [
                 name
                 for name in ("bootstrap_host", "bootstrap_port", "bootstrap_room")

--- a/test/srt/disaggregation/test_pd_router.py
+++ b/test/srt/disaggregation/test_pd_router.py
@@ -42,7 +42,7 @@ class TestGenerateBootstrapRoom:
     def test_room_in_range(self):
         for _ in range(100):
             room = generate_bootstrap_room()
-            assert 0 <= room < 2**63
+            assert 0 <= room <= 2**31 - 1
 
 
 class TestGetRequestBatchSize:


### PR DESCRIPTION
修复 #336 

## 修复

- `mini_lb_helpers.py`：`generate_bootstrap_room()` 范围从 `[0, 2^63-1]` 改为 `[0, 2^31-1]`
- `multihost_sync.py`：allgather 数组 dtype 从 `np.int64` 改为 `np.int32`；sentinel 检查从 `room < 0` 改为 `room == -1`
- `tokenizer_manager.py`：CRC32 fallback 加 `& 0x7FFFFFFF` 掩码

## 改动文件

- `python/sgl_jax/srt/disaggregation/common/multihost_sync.py`
- `python/sgl_jax/srt/disaggregation/mini_lb_helpers.py`
- `python/sgl_jax/srt/managers/tokenizer_manager.py`
- `test/srt/disaggregation/test_pd_router.py`

## 测试

- 已更新 `test_pd_router.py` 中范围断言
- 已在 v6e-16 1P1D (MiMo-V2-Flash) 上端到端验证