### PR TITLE
fix(disagg): 重排 overlap decode 事件循环以防止多主机 SPMD 竞态

### DIFF
--- a/python/sgl_jax/srt/disaggregation/decode.py
+++ b/python/sgl_jax/srt/disaggregation/decode.py
@@ -283,6 +283,15 @@ class SchedulerDisaggregationDecodeMixin:
             if self._engine_paused:
                 continue
 
+            # Drain the forward thread BEFORE any SPMD collective so that
+            # process_allgather in process_decode_queue never races with
+            # jit_jitted_sampler on the forward thread.
+            if self.last_batch:
+                wd.beat("process_batch_result")
+                tmp_batch, tmp_result = self.result_queue.popleft()
+                tmp_batch.next_batch_sampling_info = None
+                self.process_batch_result(tmp_batch, tmp_result, None)
+
             wd.beat("process_decode_queue")
             self.process_decode_queue()
 
@@ -313,26 +322,21 @@ class SchedulerDisaggregationDecodeMixin:
                         self._current_sampling_info_owner().cur_sampling_info
                     )
                     self.process_batch_result(tmp_batch, None, batch.launch_done)
-
-                wd.beat("process_decode_queue_after_launch")
-                self.process_decode_queue()
+                else:
+                    # Signal sampling_info_done for the just-launched batch.
+                    # Originally this was done by set_next_batch_sampling_info_done
+                    # during the previous batch's process_batch_result, but we now
+                    # drain the previous batch before launching.
+                    cur_si = self._current_sampling_info_owner().cur_sampling_info
+                    if cur_si is not None and cur_si.sampling_info_done is not None:
+                        if cur_si.grammars is not None:
+                            cur_si.update_grammar_vocab_mask()
+                        cur_si.sampling_info_done.set()
             else:
                 wd.beat("idle")
                 self.new_token_ratio = self.init_new_token_ratio
                 if self._comm_backend is not None:
                     self._comm_backend.wait_for_new_requests(0.001)
-
-            if self.last_batch:
-                wd.beat("process_batch_result")
-                tmp_batch, tmp_result = self.result_queue.popleft()
-                tmp_batch.next_batch_sampling_info = (
-                    self._current_sampling_info_owner().cur_sampling_info if batch else None
-                )
-                self.process_batch_result(
-                    tmp_batch,
-                    tmp_result,
-                    batch.launch_done if batch else None,
-                )
 
             self.last_batch = batch
 

--- a/python/sgl_jax/test/disaggregation/test_pd_overlap_schedule.py
+++ b/python/sgl_jax/test/disaggregation/test_pd_overlap_schedule.py
@@ -160,12 +160,41 @@ def test_decode_overlap_drains_forward_thread_before_decode_queue():
 
     batch = FakeBatch()
 
+    iteration = [0]
+
+    class PreloadedDeque:
+        """A deque that ignores the first assignment (the loop's __init__
+        reset) and starts pre-populated so we can test the second iteration."""
+
+        def __init__(self):
+            from collections import deque
+
+            self._inner = deque(
+                [(SimpleNamespace(next_batch_sampling_info=None), SimpleNamespace())]
+            )
+            self._assigned = False
+
+        def popleft(self):
+            return self._inner.popleft()
+
+        def append(self, item):
+            self._inner.append(item)
+
     class FakeScheduler:
         disagg_decode_watchdog = FakeWatchdog()
         _comm_backend = None
         _engine_paused = False
         last_batch = object()
-        result_queue = None
+        init_new_token_ratio = 1.0
+        new_token_ratio = 1.0
+
+        def __init__(self):
+            self.result_queue = PreloadedDeque()
+
+        def __setattr__(self, name, value):
+            if name == "result_queue" and hasattr(self, "result_queue"):
+                return
+            super().__setattr__(name, value)
 
         def recv_requests(self):
             calls.append("recv")
@@ -183,7 +212,7 @@ def test_decode_overlap_drains_forward_thread_before_decode_queue():
 
         def get_next_batch_to_run(self):
             calls.append("get_next_batch")
-            return batch
+            return None
 
         def run_batch(self, batch):
             calls.append("run_batch")
@@ -194,12 +223,6 @@ def test_decode_overlap_drains_forward_thread_before_decode_queue():
 
         def process_batch_result(self, batch, result, launch_done=None):
             calls.append("batch_result")
-
-    from collections import deque
-
-    FakeScheduler.result_queue = deque(
-        [(SimpleNamespace(next_batch_sampling_info=None), SimpleNamespace())]
-    )
 
     try:
         SchedulerDisaggregationDecodeMixin.event_loop_overlap_disagg_decode(

--- a/python/sgl_jax/test/disaggregation/test_pd_overlap_schedule.py
+++ b/python/sgl_jax/test/disaggregation/test_pd_overlap_schedule.py
@@ -134,7 +134,12 @@ def test_prefill_chunk_snapshot_keeps_mid_chunk_when_global_state_advances():
     assert calls == [False]
 
 
-def test_decode_overlap_polls_transfer_queue_after_launch_before_result_processing():
+def test_decode_overlap_drains_forward_thread_before_decode_queue():
+    """The overlap decode loop must drain the previous batch result (forward
+    thread) BEFORE calling process_decode_queue (SPMD collective).  This
+    prevents process_allgather in process_decode_queue from racing with
+    jit_jitted_sampler on the forward thread, which causes E0200 on
+    multi-host TPU.  See commit 3c301255."""
     from sgl_jax.srt.disaggregation.decode import SchedulerDisaggregationDecodeMixin
 
     class StopLoop(Exception):
@@ -160,6 +165,7 @@ def test_decode_overlap_polls_transfer_queue_after_launch_before_result_processi
         _comm_backend = None
         _engine_paused = False
         last_batch = object()
+        result_queue = None
 
         def recv_requests(self):
             calls.append("recv")
@@ -172,10 +178,8 @@ def test_decode_overlap_polls_transfer_queue_after_launch_before_result_processi
             calls.append("process_input")
 
         def process_decode_queue(self):
-            if "run_batch" in calls:
-                calls.append("after_launch_poll")
-                raise StopLoop
-            calls.append("pre_launch_poll")
+            calls.append("decode_queue")
+            raise StopLoop
 
         def get_next_batch_to_run(self):
             calls.append("get_next_batch")
@@ -189,10 +193,13 @@ def test_decode_overlap_polls_transfer_queue_after_launch_before_result_processi
             return SimpleNamespace(cur_sampling_info=None)
 
         def process_batch_result(self, batch, result, launch_done=None):
-            raise AssertionError(
-                "decode overlap loop processed a batch result before polling "
-                "the transfer queue after launch"
-            )
+            calls.append("batch_result")
+
+    from collections import deque
+
+    FakeScheduler.result_queue = deque(
+        [(SimpleNamespace(next_batch_sampling_info=None), SimpleNamespace())]
+    )
 
     try:
         SchedulerDisaggregationDecodeMixin.event_loop_overlap_disagg_decode(
@@ -201,4 +208,9 @@ def test_decode_overlap_polls_transfer_queue_after_launch_before_result_processi
     except StopLoop:
         pass
 
-    assert calls.index("after_launch_poll") > calls.index("run_batch")
+    assert "batch_result" in calls, "process_batch_result was never called"
+    assert "decode_queue" in calls, "process_decode_queue was never called"
+    assert calls.index("batch_result") < calls.index("decode_queue"), (
+        "process_batch_result must run BEFORE process_decode_queue to prevent "
+        "SPMD race between forward thread and decode queue collective"
+    )


### PR DESCRIPTION
修复 #338 

## 修复

重新排列 `event_loop_overlap_disagg_decode` 执行顺序：
1. 在调用 `process_decode_queue()` 之前先 drain forward thread（`process_batch_result` → `result_queue.popleft()`）
2. 移除 `run_batch` 之后的第二个 `process_decode_queue` 调用
3. `run_batch` 后直接 signal `sampling_info_done` 以保持 grammar/guided-decoding pipeline

修复后 `--disable-overlap-schedule` 不再需要。

## 改动文件

- `python/sgl_jax/srt/disaggregation/decode.py`

## 性能

A/B 测试：修复后与 `--disable-overlap-schedule` 同步方案对比，单请求负载下解码吞吐量一致（~71-73 token/s），保留 CPU/TPU 流水线重叠。

## 测试

已在 v6e-16 1P1D (MiMo-V2-Flash) 上端到端验证。